### PR TITLE
Expose `RollingLoggerProviderOptions` and deprecate legacy logging APIs

### DIFF
--- a/.mnemonic/.gitignore
+++ b/.mnemonic/.gitignore
@@ -1,0 +1,1 @@
+embeddings/

--- a/.mnemonic/.gitignore
+++ b/.mnemonic/.gitignore
@@ -1,1 +1,0 @@
-embeddings/

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/CollectingLoggerProvider.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/CollectingLoggerProvider.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+class CollectingLoggerProvider : ILoggerProvider
+{
+    public readonly List<(string Category, LogLevel Level, string Message)> LogEntries = [];
+
+    public ILogger CreateLogger(string categoryName) => new CollectingLogger(this, categoryName);
+
+    public void Dispose() { }
+
+    class CollectingLogger(CollectingLoggerProvider provider, string category) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => null!;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            lock (provider.LogEntries)
+            {
+                provider.LogEntries.Add((category, logLevel, formatter(state, exception)));
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_external_logging_provider_configured.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_external_logging_provider_configured.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 
+[NonParallelizable]
 public class When_external_logging_provider_configured : NServiceBusAcceptanceTest
 {
     [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_external_logging_provider_configured.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_external_logging_provider_configured.cs
@@ -1,0 +1,62 @@
+#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+
+public class When_external_logging_provider_configured : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_use_external_provider_instead_of_default()
+    {
+        var customProvider = new CollectingLoggerProvider();
+
+        await Scenario.Define<Context>()
+            .WithServices(services => services.AddSingleton<ILoggerProvider>(customProvider))
+            .WithEndpoint<EndpointWithExternalLogging>()
+            .Done(c => c.EndpointsStarted)
+            .Run();
+
+        // The custom provider should have received logs
+        Assert.That(customProvider.LogEntries, Is.Not.Empty, "External provider should receive logs");
+    }
+
+    class Context : ScenarioContext;
+
+    class EndpointWithExternalLogging : EndpointConfigurationBuilder
+    {
+        public EndpointWithExternalLogging() =>
+            EndpointSetup<DefaultServer>();
+    }
+
+    class CollectingLoggerProvider : ILoggerProvider
+    {
+        public readonly List<(string Category, LogLevel Level, string Message)> LogEntries = [];
+
+        public ILogger CreateLogger(string categoryName) => new CollectingLogger(this, categoryName);
+
+        public void Dispose() { }
+
+        class CollectingLogger(CollectingLoggerProvider provider, string category) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => null!;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                lock (provider.LogEntries)
+                {
+                    provider.LogEntries.Add((category, logLevel, formatter(state, exception)));
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_external_logging_provider_configured.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_external_logging_provider_configured.cs
@@ -2,12 +2,11 @@
 
 namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
 
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using AcceptanceTesting;
 using EndpointTemplates;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 
@@ -19,7 +18,11 @@ public class When_external_logging_provider_configured : NServiceBusAcceptanceTe
         var customProvider = new CollectingLoggerProvider();
 
         await Scenario.Define<Context>()
-            .WithServices(services => services.AddSingleton<ILoggerProvider>(customProvider))
+            .WithServices(services =>
+            {
+                services.RemoveAll<ILoggerProvider>();
+                services.AddSingleton<ILoggerProvider>(customProvider);
+            })
             .WithEndpoint<EndpointWithExternalLogging>()
             .Done(c => c.EndpointsStarted)
             .Run();
@@ -32,31 +35,6 @@ public class When_external_logging_provider_configured : NServiceBusAcceptanceTe
 
     class EndpointWithExternalLogging : EndpointConfigurationBuilder
     {
-        public EndpointWithExternalLogging() =>
-            EndpointSetup<DefaultServer>();
-    }
-
-    class CollectingLoggerProvider : ILoggerProvider
-    {
-        public readonly List<(string Category, LogLevel Level, string Message)> LogEntries = [];
-
-        public ILogger CreateLogger(string categoryName) => new CollectingLogger(this, categoryName);
-
-        public void Dispose() { }
-
-        class CollectingLogger(CollectingLoggerProvider provider, string category) : ILogger
-        {
-            public IDisposable BeginScope<TState>(TState state) where TState : notnull => null!;
-
-            public bool IsEnabled(LogLevel logLevel) => true;
-
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-            {
-                lock (provider.LogEntries)
-                {
-                    provider.LogEntries.Add((category, logLevel, formatter(state, exception)));
-                }
-            }
-        }
+        public EndpointWithExternalLogging() => EndpointSetup<DefaultServer>();
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_external_logging_provider_configured.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_external_logging_provider_configured.cs
@@ -28,8 +28,14 @@ public class When_external_logging_provider_configured : NServiceBusAcceptanceTe
             .Done(c => c.EndpointsStarted)
             .Run();
 
-        // The custom provider should have received logs
-        Assert.That(customProvider.LogEntries, Is.Not.Empty, "External provider should receive logs");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(customProvider.LogEntries, Is.Not.Empty, "External provider should receive logs");
+
+            var logContent = string.Join("\n", customProvider.LogEntries);
+            Assert.That(logContent, Does.Contain("EndpointWithExternalLogging"));
+            Assert.That(logContent, Does.Contain("Debug"));
+        }
     }
 
     class Context : ScenarioContext;

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
@@ -15,41 +15,50 @@ using NUnit.Framework;
 [NonParallelizable]
 public class When_using_default_logging : NServiceBusAcceptanceTest
 {
+    string logDirectory;
+
+    [SetUp]
+    public void Setup()
+    {
+        logDirectory = Path.Combine(Path.GetTempPath(), "nsb-acceptance-tests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(logDirectory);
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        // Reset LogManager to the default factory so the disposed externalLoggerFactory
+        // is no longer referenced and subsequent tests start with a clean slate.
+        LogManager.Use<DefaultFactory>();
+
+        if (Directory.Exists(logDirectory))
+        {
+            Directory.Delete(logDirectory, true);
+        }
+    }
+
     [Test]
     public async Task Should_write_to_rolling_file()
     {
-        var logDirectory = Path.Combine(Path.GetTempPath(), "nsb-acceptance-tests", Guid.NewGuid().ToString());
-        Directory.CreateDirectory(logDirectory);
+        var defaultFactory = LogManager.Use<DefaultFactory>();
+        defaultFactory.Directory(logDirectory);
+        defaultFactory.Level(Logging.LogLevel.Debug);
 
-        try
+        await Scenario.Define<Context>()
+            // clearing out the context appender to ensure that only the default logging is used and we can verify the output
+            .WithServices(services => services.AddLogging(l => l.ClearProviders()))
+            .WithEndpoint<EndpointWithDefaultLogging>()
+            .Done(c => c.EndpointsStarted)
+            .Run();
+
+        var logFiles = Directory.GetFiles(logDirectory, "nsb_log_*.txt");
+        Assert.That(logFiles, Is.Not.Empty, "Should have created at least one log file");
+
+        var logContent = await File.ReadAllTextAsync(logFiles[0]);
+        using (Assert.EnterMultipleScope())
         {
-            var defaultFactory = LogManager.Use<DefaultFactory>();
-            defaultFactory.Directory(logDirectory);
-            defaultFactory.Level(Logging.LogLevel.Debug);
-
-            await Scenario.Define<Context>()
-                // clearing out the context appender to ensure that only the default logging is used and we can verify the output
-                .WithServices(services => services.AddLogging(l => l.ClearProviders()))
-                .WithEndpoint<EndpointWithDefaultLogging>()
-                .Done(c => c.EndpointsStarted)
-                .Run();
-
-            var logFiles = Directory.GetFiles(logDirectory, "nsb_log_*.txt");
-            Assert.That(logFiles, Is.Not.Empty, "Should have created at least one log file");
-
-            var logContent = await File.ReadAllTextAsync(logFiles[0]);
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(logContent, Does.Contain("EndpointWithDefaultLogging"));
-                Assert.That(logContent, Does.Contain("INFO"));
-            }
-        }
-        finally
-        {
-            if (Directory.Exists(logDirectory))
-            {
-                Directory.Delete(logDirectory, true);
-            }
+            Assert.That(logContent, Does.Contain("EndpointWithDefaultLogging"));
+            Assert.That(logContent, Does.Contain("DEBUG"));
         }
     }
 

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
@@ -1,0 +1,59 @@
+#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+
+public class When_using_default_logging : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_write_to_rolling_file()
+    {
+        var logDirectory = Path.Combine(Path.GetTempPath(), "nsb-acceptance-tests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(logDirectory);
+
+        try
+        {
+            Logging.LogManager.Use<Logging.DefaultFactory>().Directory(logDirectory);
+
+            await Scenario.Define<Context>()
+                // clearing out the context appender to ensure that only the default logging is used and we can verify the output
+                .WithServices(services => services.AddLogging(l => l.ClearProviders()))
+                .WithEndpoint<EndpointWithDefaultLogging>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            var logFiles = Directory.GetFiles(logDirectory, "nsb_log_*.txt");
+            Assert.That(logFiles, Is.Not.Empty, "Should have created at least one log file");
+
+            var logContent = await File.ReadAllTextAsync(logFiles[0]);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(logContent, Does.Contain("EndpointWithDefaultLogging"));
+                Assert.That(logContent, Does.Contain("INFO"));
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(logDirectory))
+            {
+                Directory.Delete(logDirectory, true);
+            }
+        }
+    }
+
+    class Context : ScenarioContext;
+
+    class EndpointWithDefaultLogging : EndpointConfigurationBuilder
+    {
+        public EndpointWithDefaultLogging() =>
+            EndpointSetup<DefaultServer>();
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
@@ -9,6 +9,7 @@ using AcceptanceTesting;
 using EndpointTemplates;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Logging;
 using NUnit.Framework;
 
 public class When_using_default_logging : NServiceBusAcceptanceTest
@@ -21,7 +22,7 @@ public class When_using_default_logging : NServiceBusAcceptanceTest
 
         try
         {
-            Logging.LogManager.Use<Logging.DefaultFactory>().Directory(logDirectory);
+            LogManager.Use<DefaultFactory>().Directory(logDirectory);
 
             await Scenario.Define<Context>()
                 // clearing out the context appender to ensure that only the default logging is used and we can verify the output

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
@@ -9,7 +9,7 @@ using AcceptanceTesting;
 using EndpointTemplates;
 using Microsoft.Extensions.Logging;
 using Logging;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 
 [NonParallelizable]
@@ -23,14 +23,13 @@ public class When_using_default_logging : NServiceBusAcceptanceTest
 
         try
         {
-            LogManager.Use<DefaultFactory>().Directory(logDirectory);
+            var defaultFactory = LogManager.Use<DefaultFactory>();
+            defaultFactory.Directory(logDirectory);
+            defaultFactory.Level(Logging.LogLevel.Debug);
 
             await Scenario.Define<Context>()
-                .WithServices(services =>
-                {
-                    // clearing out the context appender to ensure that only the default logging is used and we can verify the output
-                    services.RemoveAll<ILoggerProvider>();
-                })
+                // clearing out the context appender to ensure that only the default logging is used and we can verify the output
+                .WithServices(services => services.AddLogging(l => l.ClearProviders()))
                 .WithEndpoint<EndpointWithDefaultLogging>()
                 .Done(c => c.EndpointsStarted)
                 .Run();

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
@@ -7,9 +7,9 @@ using System.IO;
 using System.Threading.Tasks;
 using AcceptanceTesting;
 using EndpointTemplates;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Logging;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using NUnit.Framework;
 
 public class When_using_default_logging : NServiceBusAcceptanceTest
@@ -25,8 +25,11 @@ public class When_using_default_logging : NServiceBusAcceptanceTest
             LogManager.Use<DefaultFactory>().Directory(logDirectory);
 
             await Scenario.Define<Context>()
-                // clearing out the context appender to ensure that only the default logging is used and we can verify the output
-                .WithServices(services => services.AddLogging(l => l.ClearProviders()))
+                .WithServices(services =>
+                {
+                    // clearing out the context appender to ensure that only the default logging is used and we can verify the output
+                    services.RemoveAll<ILoggerProvider>();
+                })
                 .WithEndpoint<EndpointWithDefaultLogging>()
                 .Done(c => c.EndpointsStarted)
                 .Run();
@@ -54,7 +57,6 @@ public class When_using_default_logging : NServiceBusAcceptanceTest
 
     class EndpointWithDefaultLogging : EndpointConfigurationBuilder
     {
-        public EndpointWithDefaultLogging() =>
-            EndpointSetup<DefaultServer>();
+        public EndpointWithDefaultLogging() => EndpointSetup<DefaultServer>();
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
@@ -29,7 +29,9 @@ public class When_using_default_logging : NServiceBusAcceptanceTest
     {
         // Reset LogManager to the default factory so the disposed externalLoggerFactory
         // is no longer referenced and subsequent tests start with a clean slate.
+#pragma warning disable CS0618 // Test exercises deprecated DefaultFactory API intentionally
         LogManager.Use<DefaultFactory>();
+#pragma warning restore CS0618
 
         if (Directory.Exists(logDirectory))
         {
@@ -40,9 +42,11 @@ public class When_using_default_logging : NServiceBusAcceptanceTest
     [Test]
     public async Task Should_write_to_rolling_file()
     {
+#pragma warning disable CS0618 // Test exercises deprecated DefaultFactory API intentionally
         var defaultFactory = LogManager.Use<DefaultFactory>();
         defaultFactory.Directory(logDirectory);
         defaultFactory.Level(Logging.LogLevel.Debug);
+#pragma warning restore CS0618
 
         await Scenario.Define<Context>()
             // clearing out the context appender to ensure that only the default logging is used and we can verify the output

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
@@ -12,6 +12,7 @@ using Logging;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using NUnit.Framework;
 
+[NonParallelizable]
 public class When_using_default_logging : NServiceBusAcceptanceTest
 {
     [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
@@ -6,13 +6,13 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using AcceptanceTesting;
-using Configuration.AdvancedExtensibility;
 using EndpointTemplates;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NServiceBus.Logging;
 using NUnit.Framework;
 
+[NonParallelizable]
 public class When_using_default_logging_internally_managed : NServiceBusAcceptanceTest
 {
     [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
@@ -1,0 +1,83 @@
+#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using Configuration.AdvancedExtensibility;
+using EndpointTemplates;
+using Microsoft.Extensions.DependencyInjection;
+using NServiceBus.Logging;
+using NUnit.Framework;
+
+public class When_using_default_logging_internally_managed : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_write_to_rolling_file()
+    {
+        var logDirectory = Path.Combine(Path.GetTempPath(), "nsb-acceptance-tests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(logDirectory);
+
+        try
+        {
+            LogManager.Use<DefaultFactory>().Directory(logDirectory);
+
+            await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithDefaultLogging>(b =>
+                {
+                    b.ToCreateInstance(
+                        (_, configuration) => Endpoint.Create(configuration),
+                        (startableEndpoint, _, ct) => startableEndpoint.Start(ct));
+                    b.When(e => e.SendLocal(new SomeMessage()));
+                })
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            var logFiles = Directory.GetFiles(logDirectory, "nsb_log_*.txt");
+            Assert.That(logFiles.Length, Is.Not.Empty, "Should have created at least one log file");
+
+            var logContent = await File.ReadAllTextAsync(logFiles[0]);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(logContent, Does.Contain("EndpointWithDefaultLogging"));
+                Assert.That(logContent, Does.Contain("INFO"));
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(logDirectory))
+            {
+                Directory.Delete(logDirectory, true);
+            }
+        }
+    }
+
+    public class Context : ScenarioContext
+    {
+        public bool MessageReceived { get; set; }
+    }
+
+    public class EndpointWithDefaultLogging : EndpointConfigurationBuilder
+    {
+        public EndpointWithDefaultLogging() =>
+            EndpointSetup<DefaultServer>(c =>
+            {
+                c.RegisterComponents(s => s.AddSingleton(c.GetSettings().Get<Context>()));
+            });
+
+        [Handler]
+        public class Handler(Context testContext) : IHandleMessages<SomeMessage>
+        {
+            public Task Handle(SomeMessage message, IMessageHandlerContext context)
+            {
+                testContext.MessageReceived = true;
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class SomeMessage : IMessage;
+}

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
@@ -29,7 +29,9 @@ public class When_using_default_logging_internally_managed : NServiceBusAcceptan
     {
         // Reset LogManager to the default factory so the disposed externalLoggerFactory
         // is no longer referenced and subsequent tests start with a clean slate.
+#pragma warning disable CS0618 // Test exercises deprecated DefaultFactory API intentionally
         LogManager.Use<DefaultFactory>();
+#pragma warning restore CS0618
 
         if (Directory.Exists(logDirectory))
         {
@@ -40,9 +42,11 @@ public class When_using_default_logging_internally_managed : NServiceBusAcceptan
     [Test]
     public async Task Should_write_to_rolling_file()
     {
+#pragma warning disable CS0618 // Test exercises deprecated DefaultFactory API intentionally
         var defaultFactory = LogManager.Use<DefaultFactory>();
         defaultFactory.Directory(logDirectory);
         defaultFactory.Level(Logging.LogLevel.Debug);
+#pragma warning restore CS0618
 
         await Scenario.Define<Context>()
             // clearing out the context appender to ensure that only the default logging is used and we can verify the output

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
@@ -9,6 +9,7 @@ using AcceptanceTesting;
 using Configuration.AdvancedExtensibility;
 using EndpointTemplates;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NServiceBus.Logging;
 using NUnit.Framework;
 
@@ -25,18 +26,19 @@ public class When_using_default_logging_internally_managed : NServiceBusAcceptan
             LogManager.Use<DefaultFactory>().Directory(logDirectory);
 
             await Scenario.Define<Context>()
+                // clearing out the context appender to ensure that only the default logging is used and we can verify the output
+                .WithServices(services => services.AddLogging(l => l.ClearProviders()))
                 .WithEndpoint<EndpointWithDefaultLogging>(b =>
                 {
                     b.ToCreateInstance(
                         (_, configuration) => Endpoint.Create(configuration),
                         (startableEndpoint, _, ct) => startableEndpoint.Start(ct));
-                    b.When(e => e.SendLocal(new SomeMessage()));
                 })
-                .Done(c => c.MessageReceived)
+                .Done(c => c.EndpointsStarted)
                 .Run();
 
             var logFiles = Directory.GetFiles(logDirectory, "nsb_log_*.txt");
-            Assert.That(logFiles.Length, Is.Not.Empty, "Should have created at least one log file");
+            Assert.That(logFiles, Is.Not.Empty, "Should have created at least one log file");
 
             var logContent = await File.ReadAllTextAsync(logFiles[0]);
             using (Assert.EnterMultipleScope())
@@ -54,30 +56,10 @@ public class When_using_default_logging_internally_managed : NServiceBusAcceptan
         }
     }
 
-    public class Context : ScenarioContext
-    {
-        public bool MessageReceived { get; set; }
-    }
+    public class Context : ScenarioContext;
 
     public class EndpointWithDefaultLogging : EndpointConfigurationBuilder
     {
-        public EndpointWithDefaultLogging() =>
-            EndpointSetup<DefaultServer>(c =>
-            {
-                c.RegisterComponents(s => s.AddSingleton(c.GetSettings().Get<Context>()));
-            });
-
-        [Handler]
-        public class Handler(Context testContext) : IHandleMessages<SomeMessage>
-        {
-            public Task Handle(SomeMessage message, IMessageHandlerContext context)
-            {
-                testContext.MessageReceived = true;
-                testContext.MarkAsCompleted();
-                return Task.CompletedTask;
-            }
-        }
+        public EndpointWithDefaultLogging() => EndpointSetup<DefaultServer>();
     }
-
-    public class SomeMessage : IMessage;
 }

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
@@ -15,46 +15,55 @@ using NUnit.Framework;
 [NonParallelizable]
 public class When_using_default_logging_internally_managed : NServiceBusAcceptanceTest
 {
+    string logDirectory;
+
+    [SetUp]
+    public void Setup()
+    {
+        logDirectory = Path.Combine(Path.GetTempPath(), "nsb-acceptance-tests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(logDirectory);
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        // Reset LogManager to the default factory so the disposed externalLoggerFactory
+        // is no longer referenced and subsequent tests start with a clean slate.
+        LogManager.Use<DefaultFactory>();
+
+        if (Directory.Exists(logDirectory))
+        {
+            Directory.Delete(logDirectory, true);
+        }
+    }
+
     [Test]
     public async Task Should_write_to_rolling_file()
     {
-        var logDirectory = Path.Combine(Path.GetTempPath(), "nsb-acceptance-tests", Guid.NewGuid().ToString());
-        Directory.CreateDirectory(logDirectory);
+        var defaultFactory = LogManager.Use<DefaultFactory>();
+        defaultFactory.Directory(logDirectory);
+        defaultFactory.Level(Logging.LogLevel.Debug);
 
-        try
-        {
-            var defaultFactory = LogManager.Use<DefaultFactory>();
-            defaultFactory.Directory(logDirectory);
-            defaultFactory.Level(Logging.LogLevel.Debug);
-
-            await Scenario.Define<Context>()
-                // clearing out the context appender to ensure that only the default logging is used and we can verify the output
-                .WithServices(services => services.AddLogging(l => l.ClearProviders()))
-                .WithEndpoint<EndpointWithDefaultLogging>(b =>
-                {
-                    b.ToCreateInstance(
-                        (_, configuration) => Endpoint.Create(configuration),
-                        (startableEndpoint, _, ct) => startableEndpoint.Start(ct));
-                })
-                .Done(c => c.EndpointsStarted)
-                .Run();
-
-            var logFiles = Directory.GetFiles(logDirectory, "nsb_log_*.txt");
-            Assert.That(logFiles, Is.Not.Empty, "Should have created at least one log file");
-
-            var logContent = await File.ReadAllTextAsync(logFiles[0]);
-            using (Assert.EnterMultipleScope())
+        await Scenario.Define<Context>()
+            // clearing out the context appender to ensure that only the default logging is used and we can verify the output
+            .WithServices(services => services.AddLogging(l => l.ClearProviders()))
+            .WithEndpoint<EndpointWithDefaultLogging>(b =>
             {
-                Assert.That(logContent, Does.Contain("EndpointWithDefaultLogging"));
-                Assert.That(logContent, Does.Contain("INFO"));
-            }
-        }
-        finally
+                b.ToCreateInstance(
+                    (_, configuration) => Endpoint.Create(configuration),
+                    (startableEndpoint, _, ct) => startableEndpoint.Start(ct));
+            })
+            .Done(c => c.EndpointsStarted)
+            .Run();
+
+        var logFiles = Directory.GetFiles(logDirectory, "nsb_log_*.txt");
+        Assert.That(logFiles, Is.Not.Empty, "Should have created at least one log file");
+
+        var logContent = await File.ReadAllTextAsync(logFiles[0]);
+        using (Assert.EnterMultipleScope())
         {
-            if (Directory.Exists(logDirectory))
-            {
-                Directory.Delete(logDirectory, true);
-            }
+            Assert.That(logContent, Does.Contain("EndpointWithDefaultLogging"));
+            Assert.That(logContent, Does.Contain("INFO"));
         }
     }
 

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
@@ -23,7 +23,9 @@ public class When_using_default_logging_internally_managed : NServiceBusAcceptan
 
         try
         {
-            LogManager.Use<DefaultFactory>().Directory(logDirectory);
+            var defaultFactory = LogManager.Use<DefaultFactory>();
+            defaultFactory.Directory(logDirectory);
+            defaultFactory.Level(Logging.LogLevel.Debug);
 
             await Scenario.Define<Context>()
                 // clearing out the context appender to ensure that only the default logging is used and we can verify the output

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
@@ -32,7 +32,6 @@ public class When_using_extensions_logging_bridge : NServiceBusAcceptanceTest
             .Run();
 
         Assert.That(customProvider.LogEntries, Is.Not.Empty, "External provider should receive logs via the bridge");
-
     }
 
     public class Context : ScenarioContext;

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
@@ -8,6 +8,7 @@ using AcceptanceTesting;
 using Configuration.AdvancedExtensibility;
 using EndpointTemplates;
 using Logging;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
@@ -27,11 +28,16 @@ public class When_using_extensions_logging_bridge : NServiceBusAcceptanceTest
         LogManager.UseFactory(new BridgeLoggerFactory(externalLoggerFactory));
 
         await Scenario.Define<Context>()
+            // clearing out the context appender to ensure that only the default logging is used and we can verify the output
+            .WithServices(services => services.AddLogging(l => l.ClearProviders()))
             .WithEndpoint<EndpointWithBridge>(b => b.CustomConfig(c => c.GetSettings().Set(c.GetSettings().Get<Context>())))
             .Done(c => c.EndpointsStarted)
             .Run();
 
-        Assert.That(customProvider.LogEntries, Is.Not.Empty, "External provider should receive logs via the bridge");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(customProvider.LogEntries, Is.Not.Empty, "External provider should receive logs");
+        }
     }
 
     [TearDown]

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
@@ -22,7 +22,11 @@ public class When_using_extensions_logging_bridge : NServiceBusAcceptanceTest
     {
         var customProvider = new CollectingLoggerProvider();
 
-        using var externalLoggerFactory = LoggerFactory.Create(builder => builder.AddProvider(customProvider));
+        using var externalLoggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddProvider(customProvider);
+            builder.SetMinimumLevel(LogLevel.Debug);
+        });
 
         // User bridges it to NServiceBus via LogManager.UseFactory (simulating ExtensionsLoggerFactory usage)
         LogManager.UseFactory(new BridgeLoggerFactory(externalLoggerFactory));
@@ -37,6 +41,10 @@ public class When_using_extensions_logging_bridge : NServiceBusAcceptanceTest
         using (Assert.EnterMultipleScope())
         {
             Assert.That(customProvider.LogEntries, Is.Not.Empty, "External provider should receive logs");
+
+            var logContent = string.Join("\n", customProvider.LogEntries);
+            Assert.That(logContent, Does.Contain("EndpointWithBridge"));
+            Assert.That(logContent, Does.Contain("Debug"));
         }
     }
 

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
+[NonParallelizable]
 public class When_using_extensions_logging_bridge : NServiceBusAcceptanceTest
 {
     [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
@@ -1,0 +1,83 @@
+#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
+
+using System;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using Configuration.AdvancedExtensibility;
+using EndpointTemplates;
+using Logging;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+public class When_using_extensions_logging_bridge : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_use_external_factory_and_not_register_default_providers()
+    {
+        var customProvider = new CollectingLoggerProvider();
+
+        using var externalLoggerFactory = LoggerFactory.Create(builder => builder.AddProvider(customProvider));
+
+        // User bridges it to NServiceBus via LogManager.UseFactory (simulating ExtensionsLoggerFactory usage)
+        LogManager.UseFactory(new BridgeLoggerFactory(externalLoggerFactory));
+
+        await Scenario.Define<Context>()
+            .WithEndpoint<EndpointWithBridge>(b => b.CustomConfig(c => c.GetSettings().Set(c.GetSettings().Get<Context>())))
+            .Done(c => c.EndpointsStarted)
+            .Run();
+
+        Assert.That(customProvider.LogEntries, Is.Not.Empty, "External provider should receive logs via the bridge");
+
+    }
+
+    public class Context : ScenarioContext;
+
+    public class EndpointWithBridge : EndpointConfigurationBuilder
+    {
+        public EndpointWithBridge() => EndpointSetup<DefaultServer>();
+    }
+
+    /// <summary>
+    /// Simulates the ExtensionsLoggerFactory from NServiceBus.Extensions.Logging package
+    /// </summary>
+    class BridgeLoggerFactory(ILoggerFactory msFactory) : global::NServiceBus.Logging.ILoggerFactory
+    {
+        public ILog GetLogger(Type type) => new BridgeLogger(msFactory.CreateLogger(type.FullName ?? type.Name));
+
+        public ILog GetLogger(string name) => new BridgeLogger(msFactory.CreateLogger(name));
+
+#pragma warning disable CA2254
+        class BridgeLogger(ILogger logger) : ILog
+        {
+            public bool IsDebugEnabled => logger.IsEnabled(LogLevel.Debug);
+            public bool IsInfoEnabled => logger.IsEnabled(LogLevel.Information);
+            public bool IsWarnEnabled => logger.IsEnabled(LogLevel.Warning);
+            public bool IsErrorEnabled => logger.IsEnabled(LogLevel.Error);
+            public bool IsFatalEnabled => logger.IsEnabled(LogLevel.Critical);
+
+            public void Debug(string? message) => logger.LogDebug(message);
+            public void Debug(string? message, Exception? exception) => logger.LogDebug(exception, message);
+            public void DebugFormat(string format, params object?[] args) => logger.LogDebug(format, args);
+
+            public void Info(string? message) => logger.LogInformation(message);
+            public void Info(string? message, Exception? exception) => logger.LogInformation(exception, message);
+            public void InfoFormat(string format, params object?[] args) => logger.LogInformation(format, args);
+
+            public void Warn(string? message) => logger.LogWarning(message);
+            public void Warn(string? message, Exception? exception) => logger.LogWarning(exception, message);
+            public void WarnFormat(string format, params object?[] args) => logger.LogWarning(format, args);
+
+            public void Error(string? message) => logger.LogError(message);
+            public void Error(string? message, Exception? exception) => logger.LogError(exception, message);
+            public void ErrorFormat(string format, params object?[] args) => logger.LogError(format, args);
+            public void Fatal(string? message) => logger.LogCritical(message);
+            public void Fatal(string? message, Exception? exception) => logger.LogCritical(exception, message);
+            public void FatalFormat(string format, params object?[] args) => logger.LogCritical(format, args);
+#pragma warning restore CA2254
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
@@ -34,6 +34,12 @@ public class When_using_extensions_logging_bridge : NServiceBusAcceptanceTest
         Assert.That(customProvider.LogEntries, Is.Not.Empty, "External provider should receive logs via the bridge");
     }
 
+    [TearDown]
+    public void Teardown() =>
+        // Reset LogManager to the default factory so the disposed externalLoggerFactory
+        // is no longer referenced and subsequent tests start with a clean slate.
+        LogManager.Use<DefaultFactory>();
+
     public class Context : ScenarioContext;
 
     public class EndpointWithBridge : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_extensions_logging_bridge.cs
@@ -29,7 +29,9 @@ public class When_using_extensions_logging_bridge : NServiceBusAcceptanceTest
         });
 
         // User bridges it to NServiceBus via LogManager.UseFactory (simulating ExtensionsLoggerFactory usage)
+#pragma warning disable CS0618 // UseFactory is deprecated; test exercises legacy behavior intentionally
         LogManager.UseFactory(new BridgeLoggerFactory(externalLoggerFactory));
+#pragma warning restore CS0618
 
         await Scenario.Define<Context>()
             // clearing out the context appender to ensure that only the default logging is used and we can verify the output
@@ -49,10 +51,14 @@ public class When_using_extensions_logging_bridge : NServiceBusAcceptanceTest
     }
 
     [TearDown]
-    public void Teardown() =>
+    public void Teardown()
+    {
         // Reset LogManager to the default factory so the disposed externalLoggerFactory
         // is no longer referenced and subsequent tests start with a clean slate.
+#pragma warning disable CS0618 // Test exercises deprecated DefaultFactory API intentionally
         LogManager.Use<DefaultFactory>();
+#pragma warning restore CS0618
+    }
 
     public class Context : ScenarioContext;
 

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_rolling_logger_provider_options.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_rolling_logger_provider_options.cs
@@ -1,0 +1,73 @@
+#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+
+[NonParallelizable]
+public class When_using_rolling_logger_provider_options : NServiceBusAcceptanceTest
+{
+    string logDirectory;
+
+    [SetUp]
+    public void Setup()
+    {
+        logDirectory = Path.Combine(Path.GetTempPath(), "nsb-acceptance-tests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(logDirectory);
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        if (Directory.Exists(logDirectory))
+        {
+            Directory.Delete(logDirectory, true);
+        }
+    }
+
+    [Test]
+    public async Task Should_write_to_rolling_file_using_options()
+    {
+        var capturedDirectory = logDirectory;
+
+        await Scenario.Define<Context>()
+            .WithServices(services =>
+            {
+                services.AddLogging(l => l.ClearProviders());
+                // Use PostConfigure to ensure our settings are applied after EndpointCreator's
+                // legacy-config seeding, which also calls Configure<RollingLoggerProviderOptions>.
+                services.PostConfigure<RollingLoggerProviderOptions>(o =>
+                {
+                    o.Directory = capturedDirectory;
+                    o.LogLevel = LogLevel.Debug;
+                });
+            })
+            .WithEndpoint<EndpointWithOptionsLogging>()
+            .Done(c => c.EndpointsStarted)
+            .Run();
+
+        var logFiles = Directory.GetFiles(logDirectory, "nsb_log_*.txt");
+        Assert.That(logFiles, Is.Not.Empty, "Should have created at least one log file");
+
+        var logContent = await File.ReadAllTextAsync(logFiles[0]);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(logContent, Does.Contain("EndpointWithOptionsLogging"));
+            Assert.That(logContent, Does.Contain("DEBUG"));
+        }
+    }
+
+    class Context : ScenarioContext;
+
+    class EndpointWithOptionsLogging : EndpointConfigurationBuilder
+    {
+        public EndpointWithOptionsLogging() => EndpointSetup<DefaultServer>();
+    }
+}

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1567,11 +1567,17 @@ namespace NServiceBus.Installation
 }
 namespace NServiceBus.Logging
 {
+    [System.Obsolete("Use services.Configure<RollingLoggerProviderOptions>() to configure the built-in " +
+        "rolling file logging provider. Will be treated as an error from version 11.0.0. " +
+        "Will be removed in version 12.0.0.", false)]
     public class DefaultFactory : NServiceBus.Logging.LoggingFactoryDefinition
     {
         public DefaultFactory() { }
+        [System.Obsolete("Set RollingLoggerProviderOptions.Directory instead. Will be treated as an error f" +
+            "rom version 11.0.0. Will be removed in version 12.0.0.", false)]
         public void Directory(string directory) { }
         protected override NServiceBus.Logging.ILoggerFactory GetLoggingFactory() { }
+        [System.Obsolete(@"Set RollingLoggerProviderOptions.LogLevel instead. Note: NServiceBus.Logging.LogLevel.Info maps to Microsoft.Extensions.Logging.LogLevel.Information, Warn to Warning, Fatal to Critical. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
         public void Level(NServiceBus.Logging.LogLevel level) { }
     }
     public interface ILog
@@ -1615,10 +1621,18 @@ namespace NServiceBus.Logging
         public static NServiceBus.Logging.ILog GetLogger(System.Type type) { }
         public static NServiceBus.Logging.ILog GetLogger(string name) { }
         public static NServiceBus.Logging.ILog GetLogger<T>() { }
+        [System.Obsolete("Use services.Configure<RollingLoggerProviderOptions>() to configure the built-in " +
+            "rolling file logging provider. Will be treated as an error from version 11.0.0. " +
+            "Will be removed in version 12.0.0.", false)]
         public static T Use<T>()
             where T : NServiceBus.Logging.LoggingFactoryDefinition, new () { }
+        [System.Obsolete("Configure logging through Microsoft.Extensions.Logging directly. Will be treated " +
+            "as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
         public static void UseFactory(NServiceBus.Logging.ILoggerFactory loggerFactory) { }
     }
+    [System.Obsolete("Implement Microsoft.Extensions.Logging.ILoggerProvider directly and register via " +
+        "services.AddSingleton<ILoggerProvider, YourProvider>(). Will be treated as an er" +
+        "ror from version 11.0.0. Will be removed in version 12.0.0.", false)]
     public abstract class LoggingFactoryDefinition
     {
         protected LoggingFactoryDefinition() { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -890,6 +890,14 @@ namespace NServiceBus
         public NServiceBus.RetryFailedSettings HeaderCustomization(System.Action<System.Collections.Generic.Dictionary<string, string>> customization) { }
         public NServiceBus.RetryFailedSettings OnMessageSentToErrorQueue(System.Func<NServiceBus.Faults.FailedMessage, System.Threading.CancellationToken, System.Threading.Tasks.Task> notificationCallback) { }
     }
+    public class RollingLoggerProviderOptions
+    {
+        public RollingLoggerProviderOptions() { }
+        public string? Directory { get; set; }
+        public Microsoft.Extensions.Logging.LogLevel LogLevel { get; set; }
+        public long MaxFileSizeInBytes { get; set; }
+        public int NumberOfArchiveFilesToKeep { get; set; }
+    }
     public static class RoutingFeatureSettingsExtensions
     {
         public static void OverridePublicReturnAddress(this NServiceBus.EndpointConfiguration configuration, string address) { }

--- a/src/NServiceBus.Core.Tests/Helpers/NonLockingFileReader.cs
+++ b/src/NServiceBus.Core.Tests/Helpers/NonLockingFileReader.cs
@@ -1,0 +1,13 @@
+namespace NServiceBus.Core.Tests.Helpers;
+
+using System.IO;
+
+static class NonLockingFileReader
+{
+    internal static string ReadAllTextWithoutLocking(string path)
+    {
+        using var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var textReader = new StreamReader(fileStream);
+        return textReader.ReadToEnd();
+    }
+}

--- a/src/NServiceBus.Core.Tests/Helpers/TempPath.cs
+++ b/src/NServiceBus.Core.Tests/Helpers/TempPath.cs
@@ -1,0 +1,25 @@
+#nullable enable
+
+namespace NServiceBus.Core.Tests.Helpers;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+class TempPath : IDisposable
+{
+    public TempPath(string category)
+    {
+        TempDirectory = Path.Combine(Path.GetTempPath(), category, Guid.NewGuid().ToString());
+        _ = Directory.CreateDirectory(TempDirectory);
+    }
+
+    public readonly string TempDirectory;
+
+    public IReadOnlyList<string> GetFiles() => [.. Directory.GetFiles(TempDirectory).OrderBy(x => x)];
+
+    public string GetSingle() => GetFiles().Single();
+
+    public void Dispose() => Directory.Delete(TempDirectory, true);
+}

--- a/src/NServiceBus.Core.Tests/Logging/DefaultFactoryTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/DefaultFactoryTests.cs
@@ -1,10 +1,11 @@
-﻿namespace NServiceBus.Core.Tests.Logging;
+namespace NServiceBus.Core.Tests.Logging;
 
 using System;
 using System.IO;
 using NServiceBus.Logging;
 using NUnit.Framework;
 
+#pragma warning disable CS0618 // Tests intentionally exercise deprecated DefaultFactory APIs
 [TestFixture]
 public class DefaultFactoryTests
 {
@@ -19,3 +20,4 @@ public class DefaultFactoryTests
         Assert.Throws<ArgumentException>(() => defaultFactory.Directory(" "));
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
@@ -146,7 +146,9 @@ public class EndpointLoggingScopeTests
     public void Should_flush_pending_deferred_logs_to_default_logger_when_slot_is_unregistered()
     {
         var defaultLoggerFactory = new CollectingNServiceBusLoggerFactory();
+#pragma warning disable CS0618 // UseFactory is deprecated; test exercises legacy behavior intentionally
         LogManager.UseFactory(defaultLoggerFactory);
+#pragma warning restore CS0618
 
         // Slot is created but its factory is never resolved (simulates a failed endpoint startup).
         var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
@@ -167,7 +169,9 @@ public class EndpointLoggingScopeTests
     public void Should_not_duplicate_pending_deferred_logs_when_slot_is_unregistered_multiple_times()
     {
         var defaultLoggerFactory = new CollectingNServiceBusLoggerFactory();
+#pragma warning disable CS0618 // UseFactory is deprecated; test exercises legacy behavior intentionally
         LogManager.UseFactory(defaultLoggerFactory);
+#pragma warning restore CS0618
 
         var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
         var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
@@ -189,7 +193,9 @@ public class EndpointLoggingScopeTests
     {
         var slotLoggerFactory = new CollectingMicrosoftLoggerFactory();
         var defaultLoggerFactory = new CollectingNServiceBusLoggerFactory();
+#pragma warning disable CS0618 // UseFactory is deprecated; test exercises legacy behavior intentionally
         LogManager.UseFactory(defaultLoggerFactory);
+#pragma warning restore CS0618
 
         var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
         var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";

--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerProviderTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerProviderTests.cs
@@ -26,7 +26,8 @@ public class RollingLoggerProviderTests
     public void When_line_is_written_line_appears_in_file()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
+        using var serviceProvider = CreateServiceProvider();
+        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogInformation("Foo");
@@ -44,7 +45,8 @@ public class RollingLoggerProviderTests
     public void When_multiple_lines_are_written_lines_appear_in_file()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
+        using var serviceProvider = CreateServiceProvider();
+        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogInformation("Foo");
@@ -65,7 +67,8 @@ public class RollingLoggerProviderTests
     public void When_exception_is_logged_exception_appears_in_file()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
+        using var serviceProvider = CreateServiceProvider();
+        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         var exception = new InvalidOperationException("Test exception");
@@ -85,7 +88,8 @@ public class RollingLoggerProviderTests
     public void When_exception_with_data_is_logged_data_appears_in_file()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
+        using var serviceProvider = CreateServiceProvider();
+        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         var exception = new InvalidOperationException("Test exception");
@@ -106,7 +110,8 @@ public class RollingLoggerProviderTests
     public void When_log_level_is_filtered_lower_levels_are_not_written()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
+        using var serviceProvider = CreateServiceProvider();
+        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogDebug("Debug message");
@@ -127,7 +132,8 @@ public class RollingLoggerProviderTests
     public void When_critical_level_is_used_fatal_is_written()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
+        using var serviceProvider = CreateServiceProvider();
+        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogCritical("Critical message");
@@ -141,7 +147,8 @@ public class RollingLoggerProviderTests
     public void When_multiple_loggers_write_they_use_same_file()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
+        using var serviceProvider = CreateServiceProvider();
+        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger1 = provider.CreateLogger("Category1");
         var logger2 = provider.CreateLogger("Category2");
 
@@ -181,7 +188,8 @@ public class RollingLoggerProviderTests
     public void When_file_name_is_created_it_follows_nservicebus_convention()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
+        using var serviceProvider = CreateServiceProvider();
+        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogInformation("Test");

--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerProviderTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerProviderTests.cs
@@ -21,12 +21,23 @@ public class RollingLoggerProviderTests
         return services.BuildServiceProvider();
     }
 
+    static RollingLoggerProvider CreateProvider(IServiceProvider serviceProvider, string directory, int numberOfArchiveFilesToKeep = 10, long maxFileSize = 10L * 1024 * 1024)
+    {
+        var options = Microsoft.Extensions.Options.Options.Create(new RollingLoggerProviderOptions
+        {
+            Directory = directory,
+            NumberOfArchiveFilesToKeep = numberOfArchiveFilesToKeep,
+            MaxFileSizeInBytes = maxFileSize
+        });
+        return new RollingLoggerProvider(serviceProvider, options);
+    }
+
     [Test]
     public void When_line_is_written_line_appears_in_file()
     {
         using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
-        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
+        using var provider = CreateProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogInformation("Foo");
@@ -45,7 +56,7 @@ public class RollingLoggerProviderTests
     {
         using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
-        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
+        using var provider = CreateProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogInformation("Foo");
@@ -67,7 +78,7 @@ public class RollingLoggerProviderTests
     {
         using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
-        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
+        using var provider = CreateProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         var exception = new InvalidOperationException("Test exception");
@@ -88,7 +99,7 @@ public class RollingLoggerProviderTests
     {
         using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
-        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
+        using var provider = CreateProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         var exception = new InvalidOperationException("Test exception");
@@ -110,7 +121,7 @@ public class RollingLoggerProviderTests
     {
         using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
-        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
+        using var provider = CreateProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogDebug("Debug message");
@@ -132,7 +143,7 @@ public class RollingLoggerProviderTests
     {
         using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
-        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
+        using var provider = CreateProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogCritical("Critical message");
@@ -147,7 +158,7 @@ public class RollingLoggerProviderTests
     {
         using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
-        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
+        using var provider = CreateProvider(serviceProvider, tempPath.TempDirectory);
         var logger1 = provider.CreateLogger("Category1");
         var logger2 = provider.CreateLogger("Category2");
 
@@ -169,7 +180,7 @@ public class RollingLoggerProviderTests
     public void When_file_is_too_large_new_sequence_file_is_created()
     {
         using var tempPath = new TempPath("RollingLoggerTests");
-        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory, maxFileSize: 50);
+        using var provider = CreateProvider(CreateServiceProvider(), tempPath.TempDirectory, maxFileSize: 50);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogInformation("Some long text that exceeds the limit");
@@ -188,7 +199,7 @@ public class RollingLoggerProviderTests
     {
         using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
-        using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
+        using var provider = CreateProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogInformation("Test");
@@ -208,7 +219,7 @@ public class RollingLoggerProviderTests
     {
         using var tempPath = new TempPath("RollingLoggerTests");
         var externalProvider = new CustomTestProvider();
-        using var provider = new RollingLoggerProvider(CreateServiceProvider(externalProvider), tempPath.TempDirectory);
+        using var provider = CreateProvider(CreateServiceProvider(externalProvider), tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogInformation("This should not be logged");

--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerProviderTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerProviderTests.cs
@@ -4,17 +4,29 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 
 [TestFixture]
 public class RollingLoggerProviderTests
 {
+    static ServiceProvider CreateServiceProvider(params ILoggerProvider[] providers)
+    {
+        var services = new ServiceCollection();
+        foreach (var provider in providers)
+        {
+            services.AddSingleton(provider);
+        }
+        return services.BuildServiceProvider();
+    }
+
     [Test]
     public void When_line_is_written_line_appears_in_file()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogInformation("Foo");
@@ -32,7 +44,7 @@ public class RollingLoggerProviderTests
     public void When_multiple_lines_are_written_lines_appear_in_file()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogInformation("Foo");
@@ -53,7 +65,7 @@ public class RollingLoggerProviderTests
     public void When_exception_is_logged_exception_appears_in_file()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         var exception = new InvalidOperationException("Test exception");
@@ -73,7 +85,7 @@ public class RollingLoggerProviderTests
     public void When_exception_with_data_is_logged_data_appears_in_file()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         var exception = new InvalidOperationException("Test exception");
@@ -94,7 +106,7 @@ public class RollingLoggerProviderTests
     public void When_log_level_is_filtered_lower_levels_are_not_written()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogDebug("Debug message");
@@ -115,7 +127,7 @@ public class RollingLoggerProviderTests
     public void When_critical_level_is_used_fatal_is_written()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogCritical("Critical message");
@@ -129,7 +141,7 @@ public class RollingLoggerProviderTests
     public void When_multiple_loggers_write_they_use_same_file()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
         var logger1 = provider.CreateLogger("Category1");
         var logger2 = provider.CreateLogger("Category2");
 
@@ -151,7 +163,7 @@ public class RollingLoggerProviderTests
     public void When_file_is_too_large_new_sequence_file_is_created()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(tempPath.TempDirectory, maxFileSize: 50);
+        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory, maxFileSize: 50);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogInformation("Some long text that exceeds the limit");
@@ -169,7 +181,7 @@ public class RollingLoggerProviderTests
     public void When_file_name_is_created_it_follows_nservicebus_convention()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
         logger.LogInformation("Test");
@@ -185,21 +197,23 @@ public class RollingLoggerProviderTests
     }
 
     [Test]
-    public void When_scope_is_used_provider_supports_external_scope()
+    public void When_external_provider_is_present_provider_returns_null_logger()
     {
         using var tempPath = new TempPath();
-        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
-        var scopeProvider = new LoggerExternalScopeProvider();
-        provider.SetScopeProvider(scopeProvider);
-
+        var externalProvider = new CustomTestProvider();
+        using var provider = new RollingLoggerProvider(CreateServiceProvider(externalProvider), tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
 
-        using var scope = logger.BeginScope("TestScope");
-        logger.LogInformation("Message in scope");
+        logger.LogInformation("This should not be logged");
 
-        var singleFile = tempPath.GetSingle();
-        var contents = NonLockingFileReader.ReadAllTextWithoutLocking(singleFile);
-        Assert.That(contents, Does.Contain("Message in scope"));
+        var files = tempPath.GetFiles();
+        Assert.That(files, Has.Count.EqualTo(0));
+    }
+
+    sealed class CustomTestProvider : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => NullLogger.Instance;
+        public void Dispose() { }
     }
 
     class TempPath : IDisposable

--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerProviderTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerProviderTests.cs
@@ -1,0 +1,231 @@
+namespace NServiceBus.Core.Tests.Logging;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+
+[TestFixture]
+public class RollingLoggerProviderTests
+{
+    [Test]
+    public void When_line_is_written_line_appears_in_file()
+    {
+        using var tempPath = new TempPath();
+        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        var logger = provider.CreateLogger("TestCategory");
+
+        logger.LogInformation("Foo");
+
+        var singleFile = tempPath.GetSingle();
+        var contents = NonLockingFileReader.ReadAllTextWithoutLocking(singleFile);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(contents, Does.Contain("INFO "));
+            Assert.That(contents, Does.Contain("Foo"));
+        }
+    }
+
+    [Test]
+    public void When_multiple_lines_are_written_lines_appear_in_file()
+    {
+        using var tempPath = new TempPath();
+        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        var logger = provider.CreateLogger("TestCategory");
+
+        logger.LogInformation("Foo");
+        logger.LogWarning("Bar");
+
+        var singleFile = tempPath.GetSingle();
+        var contents = NonLockingFileReader.ReadAllTextWithoutLocking(singleFile);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(contents, Does.Contain("INFO "));
+            Assert.That(contents, Does.Contain("Foo"));
+            Assert.That(contents, Does.Contain("WARN "));
+            Assert.That(contents, Does.Contain("Bar"));
+        }
+    }
+
+    [Test]
+    public void When_exception_is_logged_exception_appears_in_file()
+    {
+        using var tempPath = new TempPath();
+        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        var logger = provider.CreateLogger("TestCategory");
+
+        var exception = new InvalidOperationException("Test exception");
+        logger.LogError(exception, "Error occurred");
+
+        var singleFile = tempPath.GetSingle();
+        var contents = NonLockingFileReader.ReadAllTextWithoutLocking(singleFile);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(contents, Does.Contain("ERROR"));
+            Assert.That(contents, Does.Contain("Error occurred"));
+            Assert.That(contents, Does.Contain("System.InvalidOperationException: Test exception"));
+        }
+    }
+
+    [Test]
+    public void When_exception_with_data_is_logged_data_appears_in_file()
+    {
+        using var tempPath = new TempPath();
+        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        var logger = provider.CreateLogger("TestCategory");
+
+        var exception = new InvalidOperationException("Test exception");
+        exception.Data["Key1"] = "Value1";
+        logger.LogError(exception, "Error occurred");
+
+        var singleFile = tempPath.GetSingle();
+        var contents = NonLockingFileReader.ReadAllTextWithoutLocking(singleFile);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(contents, Does.Contain("Exception details:"));
+            Assert.That(contents, Does.Contain("Key1"));
+            Assert.That(contents, Does.Contain("Value1"));
+        }
+    }
+
+    [Test]
+    public void When_log_level_is_filtered_lower_levels_are_not_written()
+    {
+        using var tempPath = new TempPath();
+        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        var logger = provider.CreateLogger("TestCategory");
+
+        logger.LogDebug("Debug message");
+        logger.LogInformation("Info message");
+        logger.LogWarning("Warn message");
+
+        var singleFile = tempPath.GetSingle();
+        var contents = NonLockingFileReader.ReadAllTextWithoutLocking(singleFile);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(contents, Does.Contain("DEBUG"));
+            Assert.That(contents, Does.Contain("INFO"));
+            Assert.That(contents, Does.Contain("WARN"));
+        }
+    }
+
+    [Test]
+    public void When_critical_level_is_used_fatal_is_written()
+    {
+        using var tempPath = new TempPath();
+        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        var logger = provider.CreateLogger("TestCategory");
+
+        logger.LogCritical("Critical message");
+
+        var singleFile = tempPath.GetSingle();
+        var contents = NonLockingFileReader.ReadAllTextWithoutLocking(singleFile);
+        Assert.That(contents, Does.Contain("FATAL"));
+    }
+
+    [Test]
+    public void When_multiple_loggers_write_they_use_same_file()
+    {
+        using var tempPath = new TempPath();
+        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        var logger1 = provider.CreateLogger("Category1");
+        var logger2 = provider.CreateLogger("Category2");
+
+        logger1.LogInformation("From logger1");
+        logger2.LogInformation("From logger2");
+
+        var files = tempPath.GetFiles();
+        Assert.That(files, Has.Count.EqualTo(1));
+
+        var contents = NonLockingFileReader.ReadAllTextWithoutLocking(files.First());
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(contents, Does.Contain("From logger1"));
+            Assert.That(contents, Does.Contain("From logger2"));
+        }
+    }
+
+    [Test]
+    public void When_file_is_too_large_new_sequence_file_is_created()
+    {
+        using var tempPath = new TempPath();
+        using var provider = new RollingLoggerProvider(tempPath.TempDirectory, maxFileSize: 50);
+        var logger = provider.CreateLogger("TestCategory");
+
+        logger.LogInformation("Some long text that exceeds the limit");
+
+        var files = tempPath.GetFiles();
+        Assert.That(files, Has.Count.EqualTo(1));
+
+        logger.LogInformation("Another message");
+        files = tempPath.GetFiles();
+
+        Assert.That(files.Count, Is.GreaterThanOrEqualTo(1));
+    }
+
+    [Test]
+    public void When_file_name_is_created_it_follows_nservicebus_convention()
+    {
+        using var tempPath = new TempPath();
+        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        var logger = provider.CreateLogger("TestCategory");
+
+        logger.LogInformation("Test");
+
+        var singleFile = tempPath.GetSingle();
+        var fileName = Path.GetFileName(singleFile);
+        Assert.Multiple(() =>
+        {
+            Assert.That(fileName, Does.StartWith("nsb_log_"));
+            Assert.That(fileName, Does.EndWith(".txt"));
+            Assert.That(fileName, Does.Match(@"nsb_log_\d{4}-\d{2}-\d{2}_\d+\.txt"));
+        });
+    }
+
+    [Test]
+    public void When_scope_is_used_provider_supports_external_scope()
+    {
+        using var tempPath = new TempPath();
+        using var provider = new RollingLoggerProvider(tempPath.TempDirectory);
+        var scopeProvider = new LoggerExternalScopeProvider();
+        provider.SetScopeProvider(scopeProvider);
+
+        var logger = provider.CreateLogger("TestCategory");
+
+        using var scope = logger.BeginScope("TestScope");
+        logger.LogInformation("Message in scope");
+
+        var singleFile = tempPath.GetSingle();
+        var contents = NonLockingFileReader.ReadAllTextWithoutLocking(singleFile);
+        Assert.That(contents, Does.Contain("Message in scope"));
+    }
+
+    class TempPath : IDisposable
+    {
+        public TempPath()
+        {
+            TempDirectory = Path.Combine(Path.GetTempPath(), "nsbLoggingProvider", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(TempDirectory);
+        }
+
+        public readonly string TempDirectory;
+
+        public List<string> GetFiles() => [.. Directory.GetFiles(TempDirectory).OrderBy(x => x)];
+
+        public string GetSingle() => GetFiles().Single();
+
+        public void Dispose() => Directory.Delete(TempDirectory, true);
+    }
+
+    static class NonLockingFileReader
+    {
+        internal static string ReadAllTextWithoutLocking(string path)
+        {
+            using var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var textReader = new StreamReader(fileStream);
+            return textReader.ReadToEnd();
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerProviderTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerProviderTests.cs
@@ -1,9 +1,8 @@
 namespace NServiceBus.Core.Tests.Logging;
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -25,7 +24,7 @@ public class RollingLoggerProviderTests
     [Test]
     public void When_line_is_written_line_appears_in_file()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
         using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
@@ -44,7 +43,7 @@ public class RollingLoggerProviderTests
     [Test]
     public void When_multiple_lines_are_written_lines_appear_in_file()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
         using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
@@ -66,7 +65,7 @@ public class RollingLoggerProviderTests
     [Test]
     public void When_exception_is_logged_exception_appears_in_file()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
         using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
@@ -87,7 +86,7 @@ public class RollingLoggerProviderTests
     [Test]
     public void When_exception_with_data_is_logged_data_appears_in_file()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
         using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
@@ -109,7 +108,7 @@ public class RollingLoggerProviderTests
     [Test]
     public void When_log_level_is_filtered_lower_levels_are_not_written()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
         using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
@@ -131,7 +130,7 @@ public class RollingLoggerProviderTests
     [Test]
     public void When_critical_level_is_used_fatal_is_written()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
         using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
@@ -146,7 +145,7 @@ public class RollingLoggerProviderTests
     [Test]
     public void When_multiple_loggers_write_they_use_same_file()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
         using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger1 = provider.CreateLogger("Category1");
@@ -158,7 +157,7 @@ public class RollingLoggerProviderTests
         var files = tempPath.GetFiles();
         Assert.That(files, Has.Count.EqualTo(1));
 
-        var contents = NonLockingFileReader.ReadAllTextWithoutLocking(files.First());
+        var contents = NonLockingFileReader.ReadAllTextWithoutLocking(files[0]);
         using (Assert.EnterMultipleScope())
         {
             Assert.That(contents, Does.Contain("From logger1"));
@@ -169,7 +168,7 @@ public class RollingLoggerProviderTests
     [Test]
     public void When_file_is_too_large_new_sequence_file_is_created()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         using var provider = new RollingLoggerProvider(CreateServiceProvider(), tempPath.TempDirectory, maxFileSize: 50);
         var logger = provider.CreateLogger("TestCategory");
 
@@ -187,7 +186,7 @@ public class RollingLoggerProviderTests
     [Test]
     public void When_file_name_is_created_it_follows_nservicebus_convention()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         using var serviceProvider = CreateServiceProvider();
         using var provider = new RollingLoggerProvider(serviceProvider, tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
@@ -207,7 +206,7 @@ public class RollingLoggerProviderTests
     [Test]
     public void When_external_provider_is_present_provider_returns_null_logger()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var externalProvider = new CustomTestProvider();
         using var provider = new RollingLoggerProvider(CreateServiceProvider(externalProvider), tempPath.TempDirectory);
         var logger = provider.CreateLogger("TestCategory");
@@ -222,32 +221,5 @@ public class RollingLoggerProviderTests
     {
         public ILogger CreateLogger(string categoryName) => NullLogger.Instance;
         public void Dispose() { }
-    }
-
-    class TempPath : IDisposable
-    {
-        public TempPath()
-        {
-            TempDirectory = Path.Combine(Path.GetTempPath(), "nsbLoggingProvider", Guid.NewGuid().ToString());
-            Directory.CreateDirectory(TempDirectory);
-        }
-
-        public readonly string TempDirectory;
-
-        public List<string> GetFiles() => [.. Directory.GetFiles(TempDirectory).OrderBy(x => x)];
-
-        public string GetSingle() => GetFiles().Single();
-
-        public void Dispose() => Directory.Delete(TempDirectory, true);
-    }
-
-    static class NonLockingFileReader
-    {
-        internal static string ReadAllTextWithoutLocking(string path)
-        {
-            using var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using var textReader = new StreamReader(fileStream);
-            return textReader.ReadToEnd();
-        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using Helpers;
 using NUnit.Framework;
 
 [TestFixture]
@@ -12,7 +12,7 @@ public class RollingLoggerTests
     [Test]
     public void When_file_already_exists_that_file_is_written_to()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var dateTime = new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero);
         var logger1 = new RollingLogger(tempPath.TempDirectory)
         {
@@ -23,7 +23,7 @@ public class RollingLoggerTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(files1, Has.Count.EqualTo(1));
-            Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(files1.First()), Is.EqualTo($"Foo{Environment.NewLine}"));
+            Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(files1[0]), Is.EqualTo($"Foo{Environment.NewLine}"));
         }
         var logger2 = new RollingLogger(tempPath.TempDirectory)
         {
@@ -34,14 +34,14 @@ public class RollingLoggerTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(files2, Has.Count.EqualTo(1));
-            Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(files2.First()), Is.EqualTo($"Foo{Environment.NewLine}Bar{Environment.NewLine}"));
+            Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(files2[0]), Is.EqualTo($"Foo{Environment.NewLine}Bar{Environment.NewLine}"));
         }
     }
 
     [Test]
     public void When_file_is_deleted_underneath_continues_to_write_afterwards()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var logger = new RollingLogger(tempPath.TempDirectory)
         {
             GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
@@ -56,7 +56,7 @@ public class RollingLoggerTests
     [Test]
     public void When_file_is_locked_exception_is_swallowed()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var logger = new RollingLogger(tempPath.TempDirectory)
         {
             GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
@@ -75,7 +75,7 @@ public class RollingLoggerTests
     [Test]
     public void When_file_is_deleted_underneath_immediately_before_write()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var logger = new RollingLoggerThatDeletesBeforeWrite(tempPath.TempDirectory)
         {
             GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
@@ -99,7 +99,7 @@ public class RollingLoggerTests
     [Test]
     public void When_file_already_exists_and_is_too_large_a_new_sequence_file_is_written()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var utcOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow);
 
         var dateTime = new DateTimeOffset(2010, 10, 1, 0, 0, 0, utcOffset);
@@ -121,7 +121,7 @@ public class RollingLoggerTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(first), Is.EqualTo("nsb_log_2010-10-01_0.txt"));
-            Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(files.First()), Is.EqualTo($"Some long text{Environment.NewLine}"));
+            Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(first), Is.EqualTo($"Some long text{Environment.NewLine}"));
         }
 
         var second = files[1];
@@ -135,7 +135,7 @@ public class RollingLoggerTests
     [Test]
     public void When_file_already_exists_with_wrong_date_a_file_is_written()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var logger1 = new RollingLogger(tempPath.TempDirectory)
         {
             GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
@@ -154,7 +154,7 @@ public class RollingLoggerTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(first), Is.EqualTo("nsb_log_2010-10-01_0.txt"));
-            Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(files.First()), Is.EqualTo($"Foo{Environment.NewLine}"));
+            Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(first), Is.EqualTo($"Foo{Environment.NewLine}"));
         }
 
         var second = files[1];
@@ -168,7 +168,7 @@ public class RollingLoggerTests
     [Test]
     public void When_line_is_write_line_appears_in_file()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var logger = new RollingLogger(tempPath.TempDirectory);
         logger.WriteLine("Foo");
         var singleFile = tempPath.GetSingle();
@@ -178,7 +178,7 @@ public class RollingLoggerTests
     [Test]
     public void When_multiple_lines_are_written_lines_appears_in_file()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var logger = new RollingLogger(tempPath.TempDirectory);
         logger.WriteLine("Foo");
         logger.WriteLine("Bar");
@@ -189,7 +189,7 @@ public class RollingLoggerTests
     [Test]
     public void When_max_file_size_is_exceeded_sequence_number_is_added()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var utcOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow);
         var logger = new RollingLogger(tempPath.TempDirectory, maxFileSize: 10)
         {
@@ -218,7 +218,7 @@ public class RollingLoggerTests
     [Test]
     public void When_many_sequence_files_are_written_the_max_is_not_exceeded()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var logger = new RollingLogger(tempPath.TempDirectory, maxFileSize: 10)
         {
             GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
@@ -233,7 +233,7 @@ public class RollingLoggerTests
     [Test]
     public void When_new_write_causes_overlap_of_file_size_line_is_written_to_current_file()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var logger = new RollingLogger(tempPath.TempDirectory, maxFileSize: 10);
         logger.WriteLine("Foo");
         logger.WriteLine("Some long text");
@@ -244,7 +244,7 @@ public class RollingLoggerTests
     [Test]
     public void When_date_changes_new_file_is_written()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var logger = new RollingLogger(tempPath.TempDirectory)
         {
             GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
@@ -273,7 +273,7 @@ public class RollingLoggerTests
     [Test]
     public void When_getting_todays_log_file_sequence_number_is_used_in_sorting()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var today = new DateTimeOffset(2010, 10, 2, 0, 0, 0, TimeSpan.Zero);
         var logFiles = new List<RollingLogger.LogFile>
         {
@@ -287,7 +287,7 @@ public class RollingLoggerTests
     [Test]
     public void When_getting_todays_log_file_only_today_is_respected()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var today = new DateTimeOffset(2010, 10, 2, 0, 0, 0, TimeSpan.Zero);
         var yesterday = new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero);
         var tomorrow = new DateTimeOffset(2010, 10, 3, 0, 0, 0, TimeSpan.Zero);
@@ -306,7 +306,7 @@ public class RollingLoggerTests
     [Test]
     public void When_many_files_written_over_size_old_files_are_deleted()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var utcOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow);
         var logger = new RollingLogger(tempPath.TempDirectory, numberOfArchiveFilesToKeep: 2, maxFileSize: 5)
         {
@@ -345,7 +345,7 @@ public class RollingLoggerTests
     [Test]
     public void When_many_files_written_over_dates_old_files_are_deleted()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var logger = new RollingLogger(tempPath.TempDirectory, numberOfArchiveFilesToKeep: 2)
         {
             GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
@@ -387,7 +387,7 @@ public class RollingLoggerTests
     [Test]
     public void When_line_is_write_file_has_correct_name()
     {
-        using var tempPath = new TempPath();
+        using var tempPath = new TempPath("RollingLoggerTests");
         var logger = new RollingLogger(tempPath.TempDirectory)
         {
             GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
@@ -395,31 +395,5 @@ public class RollingLoggerTests
         logger.WriteLine("Foo");
         var singleFile = tempPath.GetSingle();
         Assert.That(Path.GetFileName(singleFile), Is.EqualTo("nsb_log_2010-10-01_0.txt"));
-    }
-    class TempPath : IDisposable
-    {
-        public TempPath()
-        {
-            TempDirectory = Path.Combine(Path.GetTempPath(), "nsbLogging", Guid.NewGuid().ToString());
-            Directory.CreateDirectory(TempDirectory);
-        }
-
-        public readonly string TempDirectory;
-
-        public List<string> GetFiles() => [.. Directory.GetFiles(TempDirectory).OrderBy(x => x)];
-
-        public string GetSingle() => GetFiles().Single();
-
-        public void Dispose() => Directory.Delete(TempDirectory, true);
-    }
-
-    static class NonLockingFileReader
-    {
-        internal static string ReadAllTextWithoutLocking(string path)
-        {
-            using var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using var textReader = new StreamReader(fileStream);
-            return textReader.ReadToEnd();
-        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -125,8 +125,10 @@ public class UnicastPublisherRouterTests
     [OneTimeSetUp]
     public void LoggerSetup()
     {
+#pragma warning disable CS0618 // Use<T> and TestingLoggerFactory (via LoggingFactoryDefinition) are deprecated; test setup uses them intentionally
         LogManager.Use<TestingLoggerFactory>()
             .WriteTo(new StringWriter(logStatements));
+#pragma warning restore CS0618
     }
 
     [SetUp]

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -8,6 +8,7 @@ using Features;
 using MessageInterfaces;
 using MessageInterfaces.MessageMapper.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Pipeline;
 using Settings;
 using Unicast.Messages;
@@ -87,7 +88,21 @@ class EndpointCreator
 
         // Logging is a global service concern
         var globalServices = services.Unwrap();
-        globalServices.AddLogging();
+        var defaultFactory = Logging.LogManager.GetCurrentDefaultFactory();
+        var loggingDirectory = defaultFactory?.LoggingDirectory ?? Host.GetOutputDirectory();
+        var nsbLevel = defaultFactory?.LoggingLevel ?? Logging.LogLevel.Info;
+        var msLevel = ConvertLogLevel(nsbLevel);
+
+        globalServices.AddLogging(builder =>
+        {
+            builder.Services.AddSingleton<ILoggerProvider>(sp => new RollingLoggerProvider(sp, loggingDirectory));
+            builder.Services.AddSingleton<ILoggerProvider, ColoredConsoleLoggerProvider>();
+
+            if (msLevel != LogLevel.Information)
+            {
+                builder.SetMinimumLevel(msLevel);
+            }
+        });
 
         var featureSettings = settings.Get<FeatureComponent.Settings>();
 
@@ -236,6 +251,17 @@ class EndpointCreator
     readonly SettingsHolder settings;
     readonly HostingComponent.Configuration hostingConfiguration;
     readonly Conventions conventions;
+
+    static LogLevel ConvertLogLevel(Logging.LogLevel nsbLevel) =>
+        nsbLevel switch
+        {
+            Logging.LogLevel.Debug => LogLevel.Debug,
+            Logging.LogLevel.Info => LogLevel.Information,
+            Logging.LogLevel.Warn => LogLevel.Warning,
+            Logging.LogLevel.Error => LogLevel.Error,
+            Logging.LogLevel.Fatal => LogLevel.Critical,
+            _ => LogLevel.Information
+        };
 
     internal const string TrimmingSuppressJustification = "The assembly scanning component has a guard that prevents it from being used when dynamic code is not available so we can safely call this.";
 }

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Features;
+using Logging;
 using MessageInterfaces;
 using MessageInterfaces.MessageMapper.Reflection;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Pipeline;
 using Settings;
 using Unicast.Messages;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 class EndpointCreator
 {
@@ -87,20 +89,21 @@ class EndpointCreator
         services.AddSingleton<IReadOnlySettings>(settings);
 
         // Logging is a global service concern
+        var loggingConfig = LogManager.GetLoggingConfiguration();
         var globalServices = services.Unwrap();
-        var defaultFactory = Logging.LogManager.GetCurrentDefaultFactory();
-        var loggingDirectory = defaultFactory?.LoggingDirectory ?? Host.GetOutputDirectory();
-        var nsbLevel = defaultFactory?.LoggingLevel ?? Logging.LogLevel.Info;
-        var msLevel = ConvertLogLevel(nsbLevel);
-
         globalServices.AddLogging(builder =>
         {
-            builder.Services.AddSingleton<ILoggerProvider>(sp => new RollingLoggerProvider(sp, loggingDirectory));
-            builder.Services.AddSingleton<ILoggerProvider, ColoredConsoleLoggerProvider>();
-
-            if (msLevel != LogLevel.Information)
+            // Only register default providers if no external logging factory is configured
+            // (e.g., via LogManager.UseFactory(new ExtensionsLoggerFactory(...)))
+            if (loggingConfig is not null)
             {
-                builder.SetMinimumLevel(msLevel);
+                builder.Services.AddSingleton<ILoggerProvider>(sp => new RollingLoggerProvider(sp, loggingConfig.LoggingDirectory));
+                builder.Services.AddSingleton<ILoggerProvider, ColoredConsoleLoggerProvider>();
+
+                if (loggingConfig.MicrosoftLogLevel != LogLevel.Information)
+                {
+                    builder.SetMinimumLevel(loggingConfig.MicrosoftLogLevel);
+                }
             }
         });
 
@@ -251,17 +254,6 @@ class EndpointCreator
     readonly SettingsHolder settings;
     readonly HostingComponent.Configuration hostingConfiguration;
     readonly Conventions conventions;
-
-    static LogLevel ConvertLogLevel(Logging.LogLevel nsbLevel) =>
-        nsbLevel switch
-        {
-            Logging.LogLevel.Debug => LogLevel.Debug,
-            Logging.LogLevel.Info => LogLevel.Information,
-            Logging.LogLevel.Warn => LogLevel.Warning,
-            Logging.LogLevel.Error => LogLevel.Error,
-            Logging.LogLevel.Fatal => LogLevel.Critical,
-            _ => LogLevel.Information
-        };
 
     internal const string TrimmingSuppressJustification = "The assembly scanning component has a guard that prevents it from being used when dynamic code is not available so we can safely call this.";
 }

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -10,6 +10,7 @@ using MessageInterfaces;
 using MessageInterfaces.MessageMapper.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Pipeline;
 using Settings;
 using Unicast.Messages;
@@ -97,8 +98,30 @@ class EndpointCreator
             // (e.g., via LogManager.UseFactory(new ExtensionsLoggerFactory(...)))
             if (loggingConfig is not null)
             {
-                builder.Services.AddSingleton<ILoggerProvider>(sp => new RollingLoggerProvider(sp, loggingConfig.LoggingDirectory));
+                builder.Services.Configure<RollingLoggerProviderOptions>(o =>
+                {
+                    o.Directory = loggingConfig.LoggingDirectory;
+                    o.LogLevel = loggingConfig.MicrosoftLogLevel;
+                });
+                builder.Services.AddSingleton<ILoggerProvider, RollingLoggerProvider>();
                 builder.Services.AddSingleton<ILoggerProvider, ColoredConsoleLoggerProvider>();
+
+                // Register a per-provider filter rule so RollingLoggerProviderOptions.LogLevel
+                // is honoured by the MEL pipeline. This works for both the legacy path
+                // (where o.LogLevel is seeded above from loggingConfig) and the new path
+                // (where users set o.LogLevel via services.PostConfigure<RollingLoggerProviderOptions>()).
+                builder.Services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(sp =>
+                {
+                    var rollingOptions = sp.GetRequiredService<IOptions<RollingLoggerProviderOptions>>();
+                    return new ConfigureOptions<LoggerFilterOptions>(filterOptions =>
+                    {
+                        filterOptions.Rules.Add(new LoggerFilterRule(
+                            providerName: typeof(RollingLoggerProvider).FullName,
+                            categoryName: null,
+                            logLevel: rollingOptions.Value.LogLevel,
+                            filter: null));
+                    });
+                });
 
                 if (loggingConfig.MicrosoftLogLevel != LogLevel.Information)
                 {

--- a/src/NServiceBus.Core/Hosting/EndpointPreparation.cs
+++ b/src/NServiceBus.Core/Hosting/EndpointPreparation.cs
@@ -19,10 +19,7 @@ static class EndpointPreparation
         ArgumentNullException.ThrowIfNull(creationStrategy);
         ArgumentNullException.ThrowIfNull(serviceProvider);
 
-        var microsoftLoggerFactory = serviceProvider.GetRequiredService<MicrosoftLoggerFactory>();
-        ILoggerFactory slotLoggerFactory = LogManager.TryGetExternalFactory() is { } externalFactory
-            ? new ExternalLoggerFactoryAdapter(externalFactory, microsoftLoggerFactory)
-            : new MicrosoftLoggerFactoryAdapter(microsoftLoggerFactory);
+        var slotLoggerFactory = LogManager.Adapt(serviceProvider.GetRequiredService<MicrosoftLoggerFactory>());
         LogManager.RegisterSlotFactory(creationStrategy.EndpointLogSlot, slotLoggerFactory);
 
         using var _ = LogManager.BeginSlotScope(creationStrategy.EndpointLogSlot);

--- a/src/NServiceBus.Core/Hosting/EndpointPreparation.cs
+++ b/src/NServiceBus.Core/Hosting/EndpointPreparation.cs
@@ -19,8 +19,10 @@ static class EndpointPreparation
         ArgumentNullException.ThrowIfNull(creationStrategy);
         ArgumentNullException.ThrowIfNull(serviceProvider);
 
-        var slotLoggerFactory = LogManager.TryGetExternalFactory()
-            ?? new MicrosoftLoggerFactoryAdapter(serviceProvider.GetRequiredService<MicrosoftLoggerFactory>());
+        var microsoftLoggerFactory = serviceProvider.GetRequiredService<MicrosoftLoggerFactory>();
+        ILoggerFactory slotLoggerFactory = LogManager.TryGetExternalFactory() is { } externalFactory
+            ? new ExternalLoggerFactoryAdapter(externalFactory, microsoftLoggerFactory)
+            : new MicrosoftLoggerFactoryAdapter(microsoftLoggerFactory);
         LogManager.RegisterSlotFactory(creationStrategy.EndpointLogSlot, slotLoggerFactory);
 
         using var _ = LogManager.BeginSlotScope(creationStrategy.EndpointLogSlot);

--- a/src/NServiceBus.Core/Hosting/EndpointPreparation.cs
+++ b/src/NServiceBus.Core/Hosting/EndpointPreparation.cs
@@ -19,8 +19,9 @@ static class EndpointPreparation
         ArgumentNullException.ThrowIfNull(creationStrategy);
         ArgumentNullException.ThrowIfNull(serviceProvider);
 
-        var microsoftLoggerFactory = serviceProvider.GetRequiredService<MicrosoftLoggerFactory>();
-        LogManager.RegisterSlotFactory(creationStrategy.EndpointLogSlot, new MicrosoftLoggerFactoryAdapter(microsoftLoggerFactory));
+        var slotLoggerFactory = LogManager.TryGetExternalFactory()
+            ?? new MicrosoftLoggerFactoryAdapter(serviceProvider.GetRequiredService<MicrosoftLoggerFactory>());
+        LogManager.RegisterSlotFactory(creationStrategy.EndpointLogSlot, slotLoggerFactory);
 
         using var _ = LogManager.BeginSlotScope(creationStrategy.EndpointLogSlot);
         var endpoint = creationStrategy.CreateStartableEndpoint(serviceProvider);

--- a/src/NServiceBus.Core/Logging/ColoredConsoleLoggerProvider.cs
+++ b/src/NServiceBus.Core/Logging/ColoredConsoleLoggerProvider.cs
@@ -1,0 +1,104 @@
+#nullable enable
+
+namespace NServiceBus;
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+[ProviderAlias("NServiceBusConsole")]
+sealed class ColoredConsoleLoggerProvider : ILoggerProvider
+{
+    readonly IServiceProvider serviceProvider;
+    readonly Lazy<bool> isEnabled;
+
+    public ColoredConsoleLoggerProvider(IServiceProvider serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+        isEnabled = new Lazy<bool>(ShouldBeEnabled);
+    }
+
+    public void Dispose() { }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        if (!isEnabled.Value)
+        {
+            return NullLogger.Instance;
+        }
+
+        return ColoredConsoleLogger.Instance;
+    }
+
+    bool ShouldBeEnabled()
+    {
+        var providers = serviceProvider.GetServices<ILoggerProvider>();
+        return providers.All(p => p is RollingLoggerProvider or ColoredConsoleLoggerProvider);
+    }
+
+    sealed class ColoredConsoleLogger : ILogger
+    {
+        public static readonly ColoredConsoleLogger Instance = new();
+
+        static ColoredConsoleLogger()
+        {
+            using var stream = Console.OpenStandardOutput();
+            logToConsole = stream != Stream.Null;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            if (!logToConsole)
+            {
+                return;
+            }
+
+            var message = formatter(state, exception);
+            try
+            {
+                Console.ForegroundColor = GetColor(logLevel);
+                Console.WriteLine(message);
+                Console.ResetColor();
+            }
+            catch (IOException)
+            {
+                logToConsole = false;
+            }
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        static ConsoleColor GetColor(LogLevel logLevel)
+        {
+            if (logLevel >= LogLevel.Error)
+            {
+                return ConsoleColor.Red;
+            }
+
+            if (logLevel == LogLevel.Warning)
+            {
+                return ConsoleColor.DarkYellow;
+            }
+
+            return ConsoleColor.White;
+        }
+
+        static bool logToConsole;
+
+        sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Logging/ColoredConsoleLoggerProvider.cs
+++ b/src/NServiceBus.Core/Logging/ColoredConsoleLoggerProvider.cs
@@ -94,11 +94,5 @@ sealed class ColoredConsoleLoggerProvider : ILoggerProvider
         }
 
         static bool logToConsole;
-
-        sealed class NullScope : IDisposable
-        {
-            public static readonly NullScope Instance = new();
-            public void Dispose() { }
-        }
     }
 }

--- a/src/NServiceBus.Core/Logging/DefaultFactory.cs
+++ b/src/NServiceBus.Core/Logging/DefaultFactory.cs
@@ -30,6 +30,10 @@ public class DefaultFactory : LoggingFactoryDefinition
         level = new Lazy<LogLevel>(() => LogLevel.Info);
     }
 
+    internal string LoggingDirectory => directory.Value;
+
+    internal LogLevel LoggingLevel => level.Value;
+
     /// <summary>
     /// <see cref="LoggingFactoryDefinition.GetLoggingFactory" />.
     /// </summary>

--- a/src/NServiceBus.Core/Logging/DefaultFactory.cs
+++ b/src/NServiceBus.Core/Logging/DefaultFactory.cs
@@ -4,11 +4,17 @@ namespace NServiceBus.Logging;
 
 using System;
 using System.IO;
+using Particular.Obsoletes;
 using IODirectory = System.IO.Directory;
 
 /// <summary>
 /// The default <see cref="LoggingFactoryDefinition" />.
 /// </summary>
+[ObsoleteMetadata(
+    Message = "Use services.Configure<RollingLoggerProviderOptions>() to configure the built-in rolling file logging provider",
+    TreatAsErrorFromVersion = "11",
+    RemoveInVersion = "12")]
+[Obsolete("Use services.Configure<RollingLoggerProviderOptions>() to configure the built-in rolling file logging provider. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
 public class DefaultFactory : LoggingFactoryDefinition
 {
     /// <summary>
@@ -24,7 +30,7 @@ public class DefaultFactory : LoggingFactoryDefinition
             }
             catch (Exception e)
             {
-                throw new Exception("Unable to determine the logging output directory. Check the inner exception for further information, or configure a custom logging directory using 'LogManager.Use<DefaultFactory>().Directory()'.", e);
+                throw new Exception("Unable to determine the logging output directory. Check the inner exception for further information, or configure a custom logging directory using 'services.Configure<RollingLoggerProviderOptions>(o => o.Directory = \"...\")'.", e);
             }
         });
         level = new Lazy<LogLevel>(() => LogLevel.Info);
@@ -49,11 +55,21 @@ public class DefaultFactory : LoggingFactoryDefinition
     /// <summary>
     /// Controls the <see cref="LogLevel" />.
     /// </summary>
+    [ObsoleteMetadata(
+        Message = "Set RollingLoggerProviderOptions.LogLevel instead. Note: NServiceBus.Logging.LogLevel.Info maps to Microsoft.Extensions.Logging.LogLevel.Information, Warn to Warning, Fatal to Critical",
+        TreatAsErrorFromVersion = "11",
+        RemoveInVersion = "12")]
+    [Obsolete("Set RollingLoggerProviderOptions.LogLevel instead. Note: NServiceBus.Logging.LogLevel.Info maps to Microsoft.Extensions.Logging.LogLevel.Information, Warn to Warning, Fatal to Critical. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
     public void Level(LogLevel level) => this.level = new Lazy<LogLevel>(() => level);
 
     /// <summary>
     /// The directory to log files to.
     /// </summary>
+    [ObsoleteMetadata(
+        Message = "Set RollingLoggerProviderOptions.Directory instead",
+        TreatAsErrorFromVersion = "11",
+        RemoveInVersion = "12")]
+    [Obsolete("Set RollingLoggerProviderOptions.Directory instead. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
     public void Directory(string directory)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(directory);

--- a/src/NServiceBus.Core/Logging/ExternalLoggerFactoryAdapter.cs
+++ b/src/NServiceBus.Core/Logging/ExternalLoggerFactoryAdapter.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 using ILoggerFactory = Logging.ILoggerFactory;
 
 sealed class ExternalLoggerFactoryAdapter(ILoggerFactory externalFactory, Microsoft.Extensions.Logging.ILoggerFactory microsoftLoggerFactory)
-    : ILoggerFactory, LogManager.ISlotScopedLoggerFactory
+    : ILoggerFactory, ISlotScopedLoggerFactory
 {
     readonly ILogger scopeLogger = microsoftLoggerFactory.CreateLogger(MicrosoftLoggerFactoryAdapter.ScopeLoggerName);
 

--- a/src/NServiceBus.Core/Logging/ExternalLoggerFactoryAdapter.cs
+++ b/src/NServiceBus.Core/Logging/ExternalLoggerFactoryAdapter.cs
@@ -1,0 +1,17 @@
+#nullable enable
+namespace NServiceBus;
+
+using System;
+using Logging;
+using Microsoft.Extensions.Logging;
+using ILoggerFactory = Logging.ILoggerFactory;
+
+sealed class ExternalLoggerFactoryAdapter(ILoggerFactory externalFactory, Microsoft.Extensions.Logging.ILoggerFactory microsoftLoggerFactory)
+    : ILoggerFactory, LogManager.ISlotScopedLoggerFactory
+{
+    readonly ILogger scopeLogger = microsoftLoggerFactory.CreateLogger(MicrosoftLoggerFactoryAdapter.ScopeLoggerName);
+
+    public ILog GetLogger(Type type) => externalFactory.GetLogger(type);
+    public ILog GetLogger(string name) => externalFactory.GetLogger(name);
+    public IDisposable BeginScope(LogScopeState scopeState) => scopeLogger.BeginScope(scopeState) ?? NullScope.Instance;
+}

--- a/src/NServiceBus.Core/Logging/ISlotScopedLoggerFactory.cs
+++ b/src/NServiceBus.Core/Logging/ISlotScopedLoggerFactory.cs
@@ -1,0 +1,10 @@
+#nullable enable
+
+namespace NServiceBus;
+
+using System;
+
+interface ISlotScopedLoggerFactory
+{
+    IDisposable BeginScope(LogScopeState scopeState);
+}

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -56,8 +56,7 @@ public static class LogManager
     /// </summary>
     internal static DefaultLoggingConfiguration? GetLoggingConfiguration()
     {
-        // If external factory was set via UseFactory, don't use default providers
-        if (defaultLoggerFactoryDefinition is null)
+        if (IsExternalFactoryConfigured)
         {
             return null;
         }
@@ -65,6 +64,16 @@ public static class LogManager
         var factory = defaultLoggerFactoryDefinition as DefaultFactory;
         return new DefaultLoggingConfiguration(factory?.LoggingDirectory ?? Host.GetOutputDirectory(), factory?.LoggingLevel ?? LogLevel.Info);
     }
+
+    /// <summary>
+    /// Returns the externally configured logger factory when <see cref="UseFactory"/> was called,
+    /// or null when using the default factory configured via <see cref="Use{T}"/>.
+    /// </summary>
+    internal static ILoggerFactory? TryGetExternalFactory() =>
+        IsExternalFactoryConfigured ? defaultLoggerFactory.Value : null;
+
+    // True when UseFactory() was called with an external factory; false when Use<T>() set a built-in definition.
+    static bool IsExternalFactoryConfigured => defaultLoggerFactoryDefinition is null;
 
     internal sealed class DefaultLoggingConfiguration(string loggingDirectory, LogLevel nsbLogLevel)
     {

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -155,7 +155,7 @@ public static class LogManager
         }
     }
 
-    internal static IDisposable BeginSlotScope(object slot)
+    internal static SlotScope BeginSlotScope(object slot)
     {
         ArgumentNullException.ThrowIfNull(slot);
 
@@ -519,9 +519,9 @@ public static class LogManager
         }
     }
 
-    sealed class SlotScope : IDisposable
+    internal readonly struct SlotScope : IDisposable
     {
-        public SlotScope(SlotContext slot, bool activateExternalScope)
+        internal SlotScope(SlotContext slot, bool activateExternalScope)
         {
             previousSlot = currentSlot.Value;
             currentSlot.Value = slot;
@@ -542,13 +542,13 @@ public static class LogManager
         readonly IDisposable? activeScope;
     }
 
-    sealed class SlotContext(object identifier, LogScopeState scopeState)
+    internal sealed class SlotContext(object identifier, LogScopeState scopeState)
     {
         public SlotKey Key { get; } = new(identifier);
         public LogScopeState ScopeState { get; } = scopeState;
     }
 
-    readonly struct SlotKey(object value) : IEquatable<SlotKey>
+    internal readonly struct SlotKey(object value) : IEquatable<SlotKey>
     {
         public object Value { get; } = value;
 
@@ -557,7 +557,6 @@ public static class LogManager
         public override bool Equals(object? obj) => obj is SlotKey other && Equals(other);
 
         public override int GetHashCode() => Value.GetHashCode();
-
     }
 
     static Lazy<ILoggerFactory> defaultLoggerFactory = new(new DefaultFactory().GetLoggingFactory);

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -60,7 +60,7 @@ public static class LogManager
         return new DefaultLoggingConfiguration(factory?.LoggingDirectory ?? Host.GetOutputDirectory(), factory?.LoggingLevel ?? LogLevel.Info);
     }
 
-    static ILoggerFactory? TryGetExternalFactory() => IsExternalFactoryConfigured ? defaultLoggerFactory.Value : null;
+    static ILoggerFactory? GetExternalFactoryIfAvailable() => IsExternalFactoryConfigured ? defaultLoggerFactory.Value : null;
 
     static bool IsExternalFactoryConfigured => defaultLoggerFactoryDefinition is null;
 
@@ -105,7 +105,7 @@ public static class LogManager
     }
 
     internal static ILoggerFactory Adapt(Microsoft.Extensions.Logging.ILoggerFactory microsoftLoggerFactory) =>
-        TryGetExternalFactory() is { } externalFactory
+        GetExternalFactoryIfAvailable() is { } externalFactory
             ? new ExternalLoggerFactoryAdapter(externalFactory, microsoftLoggerFactory)
             : new MicrosoftLoggerFactoryAdapter(microsoftLoggerFactory);
 

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -58,10 +58,6 @@ public static class LogManager
         _ = Interlocked.Increment(ref defaultLoggerFactoryVersion);
     }
 
-    /// <summary>
-    /// Gets the logging configuration for default providers.
-    /// Returns null if an external logger factory was configured via <see cref="UseFactory(ILoggerFactory)"/>.
-    /// </summary>
     internal static DefaultLoggingConfiguration? GetLoggingConfiguration()
     {
         if (IsExternalFactoryConfigured)

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -60,14 +60,8 @@ public static class LogManager
         return new DefaultLoggingConfiguration(factory?.LoggingDirectory ?? Host.GetOutputDirectory(), factory?.LoggingLevel ?? LogLevel.Info);
     }
 
-    /// <summary>
-    /// Returns the externally configured logger factory when <see cref="UseFactory"/> was called,
-    /// or null when using the default factory configured via <see cref="Use{T}"/>.
-    /// </summary>
-    internal static ILoggerFactory? TryGetExternalFactory() =>
-        IsExternalFactoryConfigured ? defaultLoggerFactory.Value : null;
+    static ILoggerFactory? TryGetExternalFactory() => IsExternalFactoryConfigured ? defaultLoggerFactory.Value : null;
 
-    // True when UseFactory() was called with an external factory; false when Use<T>() set a built-in definition.
     static bool IsExternalFactoryConfigured => defaultLoggerFactoryDefinition is null;
 
     internal sealed class DefaultLoggingConfiguration(string loggingDirectory, LogLevel nsbLogLevel)
@@ -109,6 +103,11 @@ public static class LogManager
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         return loggers.GetOrAdd(name, static loggerName => new SlotAwareLogger(loggerName));
     }
+
+    internal static ILoggerFactory Adapt(Microsoft.Extensions.Logging.ILoggerFactory microsoftLoggerFactory) =>
+        TryGetExternalFactory() is { } externalFactory
+            ? new ExternalLoggerFactoryAdapter(externalFactory, microsoftLoggerFactory)
+            : new MicrosoftLoggerFactoryAdapter(microsoftLoggerFactory);
 
     internal static void RegisterSlotFactory(object slot, ILoggerFactory loggerFactory)
     {

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -16,11 +16,6 @@ using System.Threading;
 /// </remarks>
 public static class LogManager
 {
-    internal interface ISlotScopedLoggerFactory
-    {
-        IDisposable BeginScope(LogScopeState scopeState);
-    }
-
     /// <summary>
     /// Used to inject an instance of <see cref="ILoggerFactory" /> into <see cref="LogManager" />.
     /// </summary>

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Particular.Obsoletes;
 
 /// <summary>
 /// Responsible for the creation of <see cref="ILog" /> instances and used as an extension point to redirect log events to
@@ -19,6 +20,12 @@ public static class LogManager
     /// <summary>
     /// Used to inject an instance of <see cref="ILoggerFactory" /> into <see cref="LogManager" />.
     /// </summary>
+    [ObsoleteMetadata(
+        Message = "Use services.Configure<RollingLoggerProviderOptions>() to configure the built-in rolling file logging provider",
+        TreatAsErrorFromVersion = "11",
+        RemoveInVersion = "12")]
+    [Obsolete("Use services.Configure<RollingLoggerProviderOptions>() to configure the built-in rolling file logging provider. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+#pragma warning disable CS0618 // DefaultFactory and LoggingFactoryDefinition are deprecated; LogManager must reference them internally during the deprecation window
     public static T Use<T>() where T : LoggingFactoryDefinition, new()
     {
         var loggingDefinition = new T();
@@ -29,6 +36,7 @@ public static class LogManager
 
         return loggingDefinition;
     }
+#pragma warning restore CS0618
 
     /// <summary>
     /// An instance of <see cref="ILoggerFactory" /> that will be used to construct <see cref="ILog" />s for static fields.
@@ -36,6 +44,11 @@ public static class LogManager
     /// <remarks>
     /// Replace this instance at application startup to redirect log events to the custom logging library.
     /// </remarks>
+    [ObsoleteMetadata(
+        Message = "Configure logging through Microsoft.Extensions.Logging directly",
+        TreatAsErrorFromVersion = "11",
+        RemoveInVersion = "12")]
+    [Obsolete("Configure logging through Microsoft.Extensions.Logging directly. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
     public static void UseFactory(ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(loggerFactory);
@@ -56,8 +69,10 @@ public static class LogManager
             return null;
         }
 
+#pragma warning disable CS0618 // DefaultFactory and LoggingFactoryDefinition are deprecated; LogManager must reference them internally during the deprecation window
         var factory = defaultLoggerFactoryDefinition as DefaultFactory;
         return new DefaultLoggingConfiguration(factory?.LoggingDirectory ?? Host.GetOutputDirectory(), factory?.LoggingLevel ?? LogLevel.Info);
+#pragma warning restore CS0618
     }
 
     static ILoggerFactory? GetExternalFactoryIfAvailable() => IsExternalFactoryConfigured ? defaultLoggerFactory.Value : null;
@@ -559,8 +574,10 @@ public static class LogManager
         public override int GetHashCode() => Value.GetHashCode();
     }
 
+#pragma warning disable CS0618 // DefaultFactory and LoggingFactoryDefinition are deprecated; LogManager must reference them internally during the deprecation window
     static Lazy<ILoggerFactory> defaultLoggerFactory = new(new DefaultFactory().GetLoggingFactory);
     static LoggingFactoryDefinition? defaultLoggerFactoryDefinition = new DefaultFactory();
+#pragma warning restore CS0618
     static readonly AsyncLocal<SlotContext?> currentSlot = new();
     static readonly ConcurrentDictionary<string, SlotAwareLogger> loggers = new(StringComparer.Ordinal);
     static readonly ConcurrentDictionary<SlotKey, SlotContext> slotContexts = new();

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -51,9 +51,37 @@ public static class LogManager
     }
 
     /// <summary>
-    /// Gets the current <see cref="DefaultFactory" /> if one was configured via <see cref="Use{T}" />, otherwise null.
+    /// Gets the logging configuration for default providers.
+    /// Returns null if an external logger factory was configured via <see cref="UseFactory(ILoggerFactory)"/>.
     /// </summary>
-    internal static DefaultFactory? GetCurrentDefaultFactory() => defaultLoggerFactoryDefinition as DefaultFactory;
+    internal static DefaultLoggingConfiguration? GetLoggingConfiguration()
+    {
+        // If external factory was set via UseFactory, don't use default providers
+        if (defaultLoggerFactoryDefinition is null)
+        {
+            return null;
+        }
+
+        var factory = defaultLoggerFactoryDefinition as DefaultFactory;
+        return new DefaultLoggingConfiguration(factory?.LoggingDirectory ?? Host.GetOutputDirectory(), factory?.LoggingLevel ?? LogLevel.Info);
+    }
+
+    internal sealed class DefaultLoggingConfiguration(string loggingDirectory, LogLevel nsbLogLevel)
+    {
+        public string LoggingDirectory { get; } = loggingDirectory;
+        public Microsoft.Extensions.Logging.LogLevel MicrosoftLogLevel => ConvertLogLevel(nsbLogLevel);
+
+        static Microsoft.Extensions.Logging.LogLevel ConvertLogLevel(LogLevel level) =>
+            level switch
+            {
+                LogLevel.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
+                LogLevel.Info => Microsoft.Extensions.Logging.LogLevel.Information,
+                LogLevel.Warn => Microsoft.Extensions.Logging.LogLevel.Warning,
+                LogLevel.Error => Microsoft.Extensions.Logging.LogLevel.Error,
+                LogLevel.Fatal => Microsoft.Extensions.Logging.LogLevel.Critical,
+                _ => Microsoft.Extensions.Logging.LogLevel.Information
+            };
+    }
 
     /// <summary>
     /// Construct a <see cref="ILog" /> using <typeparamref name="T" /> as the name.

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -29,6 +29,7 @@ public static class LogManager
         var loggingDefinition = new T();
 
         defaultLoggerFactory = new Lazy<ILoggerFactory>(loggingDefinition.GetLoggingFactory);
+        defaultLoggerFactoryDefinition = loggingDefinition;
         _ = Interlocked.Increment(ref defaultLoggerFactoryVersion);
 
         return loggingDefinition;
@@ -45,8 +46,14 @@ public static class LogManager
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         defaultLoggerFactory = new Lazy<ILoggerFactory>(() => loggerFactory);
+        defaultLoggerFactoryDefinition = null;
         _ = Interlocked.Increment(ref defaultLoggerFactoryVersion);
     }
+
+    /// <summary>
+    /// Gets the current <see cref="DefaultFactory" /> if one was configured via <see cref="Use{T}" />, otherwise null.
+    /// </summary>
+    internal static DefaultFactory? GetCurrentDefaultFactory() => defaultLoggerFactoryDefinition as DefaultFactory;
 
     /// <summary>
     /// Construct a <see cref="ILog" /> using <typeparamref name="T" /> as the name.
@@ -523,6 +530,7 @@ public static class LogManager
     }
 
     static Lazy<ILoggerFactory> defaultLoggerFactory = new(new DefaultFactory().GetLoggingFactory);
+    static LoggingFactoryDefinition? defaultLoggerFactoryDefinition = new DefaultFactory();
     static readonly AsyncLocal<SlotContext?> currentSlot = new();
     static readonly ConcurrentDictionary<string, SlotAwareLogger> loggers = new(StringComparer.Ordinal);
     static readonly ConcurrentDictionary<SlotKey, SlotContext> slotContexts = new();

--- a/src/NServiceBus.Core/Logging/LoggingDefinition.cs
+++ b/src/NServiceBus.Core/Logging/LoggingDefinition.cs
@@ -2,9 +2,17 @@
 
 namespace NServiceBus.Logging;
 
+using System;
+using Particular.Obsoletes;
+
 /// <summary>
 /// Base class for logging definitions.
 /// </summary>
+[ObsoleteMetadata(
+    Message = "Implement Microsoft.Extensions.Logging.ILoggerProvider directly and register via services.AddSingleton<ILoggerProvider, YourProvider>()",
+    TreatAsErrorFromVersion = "11",
+    RemoveInVersion = "12")]
+[Obsolete("Implement Microsoft.Extensions.Logging.ILoggerProvider directly and register via services.AddSingleton<ILoggerProvider, YourProvider>(). Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
 public abstract class LoggingFactoryDefinition
 {
     /// <summary>

--- a/src/NServiceBus.Core/Logging/MicrosoftLoggerAdapter.cs
+++ b/src/NServiceBus.Core/Logging/MicrosoftLoggerAdapter.cs
@@ -1,0 +1,69 @@
+#nullable enable
+namespace NServiceBus;
+
+using System;
+using Logging;
+using Microsoft.Extensions.Logging;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+sealed class MicrosoftLoggerAdapter(ILogger logger) : ILog
+{
+    static readonly Func<string?, Exception?, string> MessageFormatter = static (state, _) => state ?? string.Empty;
+    static readonly Func<(string format, object?[] args), Exception?, string> FormatMessageFormatter = static (state, _) => string.Format(state.format, state.args);
+
+    public bool IsDebugEnabled => logger.IsEnabled(LogLevel.Debug);
+    public bool IsInfoEnabled => logger.IsEnabled(LogLevel.Information);
+    public bool IsWarnEnabled => logger.IsEnabled(LogLevel.Warning);
+    public bool IsErrorEnabled => logger.IsEnabled(LogLevel.Error);
+    public bool IsFatalEnabled => logger.IsEnabled(LogLevel.Critical);
+
+    public void Debug(string? message) => Write(LogLevel.Debug, message);
+
+    public void Debug(string? message, Exception? exception) => Write(LogLevel.Debug, message, exception);
+
+    public void DebugFormat(string format, params object?[] args) => WriteFormat(LogLevel.Debug, format, args);
+
+    public void Info(string? message) => Write(LogLevel.Information, message);
+
+    public void Info(string? message, Exception? exception) => Write(LogLevel.Information, message, exception);
+
+    public void InfoFormat(string format, params object?[] args) => WriteFormat(LogLevel.Information, format, args);
+
+    public void Warn(string? message) => Write(LogLevel.Warning, message);
+
+    public void Warn(string? message, Exception? exception) => Write(LogLevel.Warning, message, exception);
+
+    public void WarnFormat(string format, params object?[] args) => WriteFormat(LogLevel.Warning, format, args);
+
+    public void Error(string? message) => Write(LogLevel.Error, message);
+
+    public void Error(string? message, Exception? exception) => Write(LogLevel.Error, message, exception);
+
+    public void ErrorFormat(string format, params object?[] args) => WriteFormat(LogLevel.Error, format, args);
+
+    public void Fatal(string? message) => Write(LogLevel.Critical, message);
+
+    public void Fatal(string? message, Exception? exception) => Write(LogLevel.Critical, message, exception);
+
+    public void FatalFormat(string format, params object?[] args) => WriteFormat(LogLevel.Critical, format, args);
+
+    void Write(LogLevel level, string? message, Exception? exception = null)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        logger.Log(level, default, message, exception, MessageFormatter);
+    }
+
+    void WriteFormat(LogLevel level, string format, object?[] args)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        logger.Log(level, default, (format, args), null, FormatMessageFormatter);
+    }
+}

--- a/src/NServiceBus.Core/Logging/MicrosoftLoggerFactoryAdapter.cs
+++ b/src/NServiceBus.Core/Logging/MicrosoftLoggerFactoryAdapter.cs
@@ -7,8 +7,7 @@ using Logging;
 using MicrosoftLoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 using MicrosoftLogger = Microsoft.Extensions.Logging.ILogger;
 
-sealed class MicrosoftLoggerFactoryAdapter(MicrosoftLoggerFactory loggerFactory) : ILoggerFactory
-    , LogManager.ISlotScopedLoggerFactory
+sealed class MicrosoftLoggerFactoryAdapter(MicrosoftLoggerFactory loggerFactory) : ILoggerFactory, ISlotScopedLoggerFactory
 {
     public const string ScopeLoggerName = "NServiceBus.Logging.Scope";
 

--- a/src/NServiceBus.Core/Logging/MicrosoftLoggerFactoryAdapter.cs
+++ b/src/NServiceBus.Core/Logging/MicrosoftLoggerFactoryAdapter.cs
@@ -6,12 +6,13 @@ using System;
 using Logging;
 using MicrosoftLoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 using MicrosoftLogger = Microsoft.Extensions.Logging.ILogger;
-using MicrosoftLogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 sealed class MicrosoftLoggerFactoryAdapter(MicrosoftLoggerFactory loggerFactory) : ILoggerFactory
     , LogManager.ISlotScopedLoggerFactory
 {
-    readonly MicrosoftLogger scopeLogger = loggerFactory.CreateLogger("NServiceBus.Logging.Scope");
+    public const string ScopeLoggerName = "NServiceBus.Logging.Scope";
+
+    readonly MicrosoftLogger scopeLogger = loggerFactory.CreateLogger(ScopeLoggerName);
 
     public ILog GetLogger(Type type)
     {
@@ -26,75 +27,4 @@ sealed class MicrosoftLoggerFactoryAdapter(MicrosoftLoggerFactory loggerFactory)
     }
 
     public IDisposable BeginScope(LogScopeState scopeState) => scopeLogger.BeginScope(scopeState) ?? NullScope.Instance;
-
-    sealed class MicrosoftLoggerAdapter(MicrosoftLogger logger) : ILog
-    {
-        static readonly Func<string?, Exception?, string> MessageFormatter = static (state, _) => state ?? string.Empty;
-        static readonly Func<(string format, object?[] args), Exception?, string> FormatMessageFormatter = static (state, _) => string.Format(state.format, state.args);
-
-        public bool IsDebugEnabled => logger.IsEnabled(MicrosoftLogLevel.Debug);
-        public bool IsInfoEnabled => logger.IsEnabled(MicrosoftLogLevel.Information);
-        public bool IsWarnEnabled => logger.IsEnabled(MicrosoftLogLevel.Warning);
-        public bool IsErrorEnabled => logger.IsEnabled(MicrosoftLogLevel.Error);
-        public bool IsFatalEnabled => logger.IsEnabled(MicrosoftLogLevel.Critical);
-
-        public void Debug(string? message) => Write(MicrosoftLogLevel.Debug, message);
-
-        public void Debug(string? message, Exception? exception) => Write(MicrosoftLogLevel.Debug, message, exception);
-
-        public void DebugFormat(string format, params object?[] args) => WriteFormat(MicrosoftLogLevel.Debug, format, args);
-
-        public void Info(string? message) => Write(MicrosoftLogLevel.Information, message);
-
-        public void Info(string? message, Exception? exception) => Write(MicrosoftLogLevel.Information, message, exception);
-
-        public void InfoFormat(string format, params object?[] args) => WriteFormat(MicrosoftLogLevel.Information, format, args);
-
-        public void Warn(string? message) => Write(MicrosoftLogLevel.Warning, message);
-
-        public void Warn(string? message, Exception? exception) => Write(MicrosoftLogLevel.Warning, message, exception);
-
-        public void WarnFormat(string format, params object?[] args) => WriteFormat(MicrosoftLogLevel.Warning, format, args);
-
-        public void Error(string? message) => Write(MicrosoftLogLevel.Error, message);
-
-        public void Error(string? message, Exception? exception) => Write(MicrosoftLogLevel.Error, message, exception);
-
-        public void ErrorFormat(string format, params object?[] args) => WriteFormat(MicrosoftLogLevel.Error, format, args);
-
-        public void Fatal(string? message) => Write(MicrosoftLogLevel.Critical, message);
-
-        public void Fatal(string? message, Exception? exception) => Write(MicrosoftLogLevel.Critical, message, exception);
-
-        public void FatalFormat(string format, params object?[] args) => WriteFormat(MicrosoftLogLevel.Critical, format, args);
-
-        void Write(MicrosoftLogLevel level, string? message, Exception? exception = null)
-        {
-            if (!logger.IsEnabled(level))
-            {
-                return;
-            }
-
-            logger.Log(level, default, message, exception, MessageFormatter);
-        }
-
-        void WriteFormat(MicrosoftLogLevel level, string format, object?[] args)
-        {
-            if (!logger.IsEnabled(level))
-            {
-                return;
-            }
-
-            logger.Log(level, default, (format, args), null, FormatMessageFormatter);
-        }
-    }
-
-    sealed class NullScope : IDisposable
-    {
-        public static readonly NullScope Instance = new();
-
-        public void Dispose()
-        {
-        }
-    }
 }

--- a/src/NServiceBus.Core/Logging/NullScope.cs
+++ b/src/NServiceBus.Core/Logging/NullScope.cs
@@ -1,6 +1,6 @@
 #nullable enable
 
-namespace NServiceBus.Logging;
+namespace NServiceBus;
 
 using System;
 

--- a/src/NServiceBus.Core/Logging/NullScope.cs
+++ b/src/NServiceBus.Core/Logging/NullScope.cs
@@ -1,0 +1,11 @@
+#nullable enable
+
+namespace NServiceBus.Logging;
+
+using System;
+
+sealed class NullScope : IDisposable
+{
+    public static readonly NullScope Instance = new();
+    public void Dispose() { }
+}

--- a/src/NServiceBus.Core/Logging/RollingLoggerProvider.cs
+++ b/src/NServiceBus.Core/Logging/RollingLoggerProvider.cs
@@ -1,0 +1,95 @@
+#nullable enable
+
+namespace NServiceBus;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections;
+using System.Text;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+[ProviderAlias("NServiceBusRollingFile")]
+sealed class RollingLoggerProvider(
+    string loggingDirectory,
+    int numberOfArchiveFilesToKeep = 10,
+    long maxFileSize = 10L * 1024 * 1024) : ILoggerProvider, ISupportExternalScope
+{
+    readonly ConcurrentDictionary<string, RollingMicrosoftLogger> loggers = new();
+    readonly RollingLogger rollingLogger = new(loggingDirectory, numberOfArchiveFilesToKeep, maxFileSize);
+    readonly Lock locker = new();
+    IExternalScopeProvider scopeProvider = new LoggerExternalScopeProvider();
+
+    public void Dispose() => loggers.Clear();
+
+    public ILogger CreateLogger(string categoryName) =>
+        loggers.GetOrAdd(categoryName, static (_, provider) => new RollingMicrosoftLogger(provider), this);
+
+    public void SetScopeProvider(IExternalScopeProvider externalScopeProvider) => scopeProvider = externalScopeProvider;
+
+    void Write(LogLevel logLevel, string? message, Exception? exception)
+    {
+        var stringBuilder = new StringBuilder();
+#pragma warning disable PS0023 // Logging should use local time because logging with UTC can cause confusion and the assumption is the server runs in a timezone that makes sense (most likely UTC)
+        var datePart = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+#pragma warning restore PS0023
+        var paddedLevel = LogLevelName(logLevel);
+
+        stringBuilder.Append(datePart).Append(' ').Append(paddedLevel).Append(' ').Append(message);
+
+        if (exception != null)
+        {
+            stringBuilder.AppendLine();
+            stringBuilder.Append(exception);
+            if (exception.Data.Count > 0)
+            {
+                stringBuilder.AppendLine();
+                stringBuilder.Append("Exception details:");
+
+                foreach (DictionaryEntry exceptionData in exception.Data)
+                {
+                    stringBuilder.AppendLine();
+                    stringBuilder.Append('\t').Append(exceptionData.Key).Append(": ").Append(exceptionData.Value);
+                }
+            }
+        }
+
+        var fullMessage = stringBuilder.ToString();
+        lock (locker)
+        {
+            rollingLogger.WriteLine(fullMessage);
+        }
+    }
+
+    static string LogLevelName(LogLevel level) =>
+        level switch
+        {
+            LogLevel.Debug => "DEBUG",
+            LogLevel.Information => "INFO ",
+            LogLevel.Warning => "WARN ",
+            LogLevel.Error => "ERROR",
+            LogLevel.Critical => "FATAL",
+            LogLevel.Trace => "TRACE",
+            LogLevel.None => "NONE ",
+            _ => level.ToString().ToUpper().PadRight(5)
+        };
+
+    sealed class RollingMicrosoftLogger(RollingLoggerProvider provider) : ILogger
+    {
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            var message = formatter(state, exception);
+            provider.Write(logLevel, message, exception);
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull =>
+            provider.scopeProvider.Push(state);
+    }
+}

--- a/src/NServiceBus.Core/Logging/RollingLoggerProvider.cs
+++ b/src/NServiceBus.Core/Logging/RollingLoggerProvider.cs
@@ -125,11 +125,5 @@ sealed class RollingLoggerProvider : ILoggerProvider
         public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None && provider.isEnabled.Value;
 
         public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
-
-        sealed class NullScope : IDisposable
-        {
-            public static readonly NullScope Instance = new();
-            public void Dispose() { }
-        }
     }
 }

--- a/src/NServiceBus.Core/Logging/RollingLoggerProvider.cs
+++ b/src/NServiceBus.Core/Logging/RollingLoggerProvider.cs
@@ -10,12 +10,13 @@ using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 [ProviderAlias("NServiceBusRollingFile")]
 sealed class RollingLoggerProvider : ILoggerProvider
 {
     readonly IServiceProvider serviceProvider;
-    readonly string loggingDirectory;
+    readonly string? loggingDirectory;
     readonly int numberOfArchiveFilesToKeep;
     readonly long maxFileSize;
     readonly ConcurrentDictionary<string, ILogger> loggers = new();
@@ -23,16 +24,13 @@ sealed class RollingLoggerProvider : ILoggerProvider
     RollingLogger? rollingLogger;
     readonly Lock locker = new();
 
-    public RollingLoggerProvider(
-        IServiceProvider serviceProvider,
-        string loggingDirectory,
-        int numberOfArchiveFilesToKeep = 10,
-        long maxFileSize = 10L * 1024 * 1024)
+    public RollingLoggerProvider(IServiceProvider serviceProvider, IOptions<RollingLoggerProviderOptions> options)
     {
         this.serviceProvider = serviceProvider;
-        this.loggingDirectory = loggingDirectory;
-        this.numberOfArchiveFilesToKeep = numberOfArchiveFilesToKeep;
-        this.maxFileSize = maxFileSize;
+        var o = options.Value;
+        loggingDirectory = o.Directory;
+        numberOfArchiveFilesToKeep = o.NumberOfArchiveFilesToKeep;
+        maxFileSize = o.MaxFileSizeInBytes;
         isEnabled = new Lazy<bool>(ShouldBeEnabled);
     }
 
@@ -47,7 +45,7 @@ sealed class RollingLoggerProvider : ILoggerProvider
 
         lock (locker)
         {
-            rollingLogger ??= new RollingLogger(loggingDirectory, numberOfArchiveFilesToKeep, maxFileSize);
+            rollingLogger ??= new RollingLogger(loggingDirectory ?? Host.GetOutputDirectory(), numberOfArchiveFilesToKeep, maxFileSize);
         }
         return loggers.GetOrAdd(categoryName, static (_, provider) => new RollingMicrosoftLogger(provider), this);
     }

--- a/src/NServiceBus.Core/Logging/RollingLoggerProvider.cs
+++ b/src/NServiceBus.Core/Logging/RollingLoggerProvider.cs
@@ -4,33 +4,69 @@ namespace NServiceBus;
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections;
+using System.Linq;
 using System.Text;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 [ProviderAlias("NServiceBusRollingFile")]
-sealed class RollingLoggerProvider(
-    string loggingDirectory,
-    int numberOfArchiveFilesToKeep = 10,
-    long maxFileSize = 10L * 1024 * 1024) : ILoggerProvider, ISupportExternalScope
+sealed class RollingLoggerProvider : ILoggerProvider
 {
-    readonly ConcurrentDictionary<string, RollingMicrosoftLogger> loggers = new();
-    readonly RollingLogger rollingLogger = new(loggingDirectory, numberOfArchiveFilesToKeep, maxFileSize);
+    readonly IServiceProvider serviceProvider;
+    readonly string loggingDirectory;
+    readonly int numberOfArchiveFilesToKeep;
+    readonly long maxFileSize;
+    readonly ConcurrentDictionary<string, ILogger> loggers = new();
+    readonly Lazy<bool> isEnabled;
+    RollingLogger? rollingLogger;
     readonly Lock locker = new();
-    IExternalScopeProvider scopeProvider = new LoggerExternalScopeProvider();
+
+    public RollingLoggerProvider(
+        IServiceProvider serviceProvider,
+        string loggingDirectory,
+        int numberOfArchiveFilesToKeep = 10,
+        long maxFileSize = 10L * 1024 * 1024)
+    {
+        this.serviceProvider = serviceProvider;
+        this.loggingDirectory = loggingDirectory;
+        this.numberOfArchiveFilesToKeep = numberOfArchiveFilesToKeep;
+        this.maxFileSize = maxFileSize;
+        isEnabled = new Lazy<bool>(ShouldBeEnabled);
+    }
 
     public void Dispose() => loggers.Clear();
 
-    public ILogger CreateLogger(string categoryName) =>
-        loggers.GetOrAdd(categoryName, static (_, provider) => new RollingMicrosoftLogger(provider), this);
+    public ILogger CreateLogger(string categoryName)
+    {
+        if (!isEnabled.Value)
+        {
+            return NullLogger.Instance;
+        }
 
-    public void SetScopeProvider(IExternalScopeProvider externalScopeProvider) => scopeProvider = externalScopeProvider;
+        lock (locker)
+        {
+            rollingLogger ??= new RollingLogger(loggingDirectory, numberOfArchiveFilesToKeep, maxFileSize);
+        }
+        return loggers.GetOrAdd(categoryName, static (_, provider) => new RollingMicrosoftLogger(provider), this);
+    }
+
+    bool ShouldBeEnabled()
+    {
+        var providers = serviceProvider.GetServices<ILoggerProvider>();
+        return providers.All(p => p is RollingLoggerProvider or ColoredConsoleLoggerProvider);
+    }
 
     void Write(LogLevel logLevel, string? message, Exception? exception)
     {
+        if (!isEnabled.Value || rollingLogger == null)
+        {
+            return;
+        }
+
         var stringBuilder = new StringBuilder();
-#pragma warning disable PS0023 // Logging should use local time because logging with UTC can cause confusion and the assumption is the server runs in a timezone that makes sense (most likely UTC)
+#pragma warning disable PS0023
         var datePart = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
 #pragma warning restore PS0023
         var paddedLevel = LogLevelName(logLevel);
@@ -46,7 +82,7 @@ sealed class RollingLoggerProvider(
                 stringBuilder.AppendLine();
                 stringBuilder.Append("Exception details:");
 
-                foreach (DictionaryEntry exceptionData in exception.Data)
+                foreach (System.Collections.DictionaryEntry exceptionData in exception.Data)
                 {
                     stringBuilder.AppendLine();
                     stringBuilder.Append('\t').Append(exceptionData.Key).Append(": ").Append(exceptionData.Value);
@@ -54,10 +90,9 @@ sealed class RollingLoggerProvider(
             }
         }
 
-        var fullMessage = stringBuilder.ToString();
         lock (locker)
         {
-            rollingLogger.WriteLine(fullMessage);
+            rollingLogger.WriteLine(stringBuilder.ToString());
         }
     }
 
@@ -87,9 +122,14 @@ sealed class RollingLoggerProvider(
             provider.Write(logLevel, message, exception);
         }
 
-        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None && provider.isEnabled.Value;
 
-        public IDisposable BeginScope<TState>(TState state) where TState : notnull =>
-            provider.scopeProvider.Push(state);
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }

--- a/src/NServiceBus.Core/Logging/RollingLoggerProviderOptions.cs
+++ b/src/NServiceBus.Core/Logging/RollingLoggerProviderOptions.cs
@@ -1,0 +1,38 @@
+#nullable enable
+
+namespace NServiceBus;
+
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Options for the NServiceBus rolling file logger provider.
+/// </summary>
+public class RollingLoggerProviderOptions
+{
+    /// <summary>
+    /// Directory to write log files to. Defaults to null, which resolves to
+    /// <c>Host.GetOutputDirectory()</c> lazily on first write inside the provider.
+    /// </summary>
+    public string? Directory { get; set; }
+
+    /// <summary>
+    /// Minimum log level for the rolling file. Defaults to <see cref="LogLevel.Information"/>.
+    /// </summary>
+    /// <remarks>
+    /// Member names differ from the legacy <c>NServiceBus.Logging.LogLevel</c>:
+    /// <c>Info</c> → <c>Information</c>, <c>Warn</c> → <c>Warning</c>, <c>Fatal</c> → <c>Critical</c>.
+    /// Level filtering is applied by the MEL pipeline via <c>SetMinimumLevel</c>;
+    /// the provider itself only filters out <see cref="LogLevel.None"/>.
+    /// </remarks>
+    public LogLevel LogLevel { get; set; } = LogLevel.Information;
+
+    /// <summary>
+    /// Number of archive log files to keep. Defaults to 10.
+    /// </summary>
+    public int NumberOfArchiveFilesToKeep { get; set; } = 10;
+
+    /// <summary>
+    /// Maximum size of a single log file in bytes. Defaults to 10 MB.
+    /// </summary>
+    public long MaxFileSizeInBytes { get; set; } = 10L * 1024 * 1024;
+}

--- a/src/NServiceBus.Testing.Fakes/TestingLoggerFactory.cs
+++ b/src/NServiceBus.Testing.Fakes/TestingLoggerFactory.cs
@@ -4,6 +4,8 @@ using System;
 using System.IO;
 using Logging;
 
+#pragma warning disable CS0618 // TestingLoggerFactory intentionally extends the deprecated LoggingFactoryDefinition during the deprecation window
+
 /// <summary>
 /// Logger factory which allows to log to a text writer.
 /// </summary>
@@ -49,3 +51,4 @@ public class TestingLoggerFactory : LoggingFactoryDefinition
     Lazy<LogLevel> level;
     Lazy<TextWriter> writer;
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -17,7 +17,9 @@ public abstract class NServiceBusTransportTest
     static NServiceBusTransportTest()
     {
         LogFactory = new TransportTestLoggerFactory();
+#pragma warning disable CS0618 // UseFactory is deprecated; transport tests use it for test setup
         LogManager.UseFactory(LogFactory);
+#pragma warning restore CS0618
     }
 
     [SetUp]


### PR DESCRIPTION
NServiceBus recently [replaced its internal logging stack with a Microsoft.Extensions.Logging](https://github.com/Particular/NServiceBus/pull/7659) (MEL) based implementation. The new stack includes:

- `RollingLoggerProvider` — writes to a rolling file
- `ColoredConsoleLoggerProvider` — writes to the console with colours
- Slot-based isolation (`SlotAwareLogger`, `BeginSlotScope`, `RegisterSlotFactory`) — routes log output per-endpoint in multi-endpoint host scenarios
- `MicrosoftLoggerFactoryAdapter` / `ExternalLoggerFactoryAdapter` — bridge the NServiceBus `ILog`/`ILoggerFactory` surface to MEL

Both providers self-disable via `ShouldBeEnabled()` when external MEL providers are registered. However, there was no user-facing API to configure the new providers. This PR adds that surface and begins deprecating the pre-MEL configuration API.

## Changes

**New: `RollingLoggerProviderOptions`**

A new public `IOptions<T>`-based configuration class:

```csharp
services.Configure<RollingLoggerProviderOptions>(o =>
{
    o.Directory = "C:/logs";
    o.LogLevel = LogLevel.Debug;              // Info → Information, Warn → Warning, Fatal → Critical
    o.NumberOfArchiveFilesToKeep = 10;        // previously hardcoded
    o.MaxFileSizeInBytes = 10L * 1024 * 1024; // previously hardcoded
});
```

`RollingLoggerProvider` now takes `IOptions<RollingLoggerProviderOptions>` instead of raw constructor arguments and resolves the log directory lazily via `Host.GetOutputDirectory()` when `Directory` is null.

**Log level filtering — idiomatic MEL approach**

An `IConfigureOptions<LoggerFilterOptions>` singleton registers a `LoggerFilterRule` scoped to `RollingLoggerProvider`, the same pattern used by `AddConsole` and `AddDebug` internally. This keeps level filtering composable with the rest of the MEL pipeline rather than buried in the provider.

**Legacy path preserved**

`EndpointCreator` continues to read `LogManager.GetLoggingConfiguration()` during the deprecation window and seeds `RollingLoggerProviderOptions` from legacy `DefaultFactory` directory/level settings — all existing code continues to work without changes.

**Deprecated (warnings now, errors in v11, removed in v12):**

| API | Migration |
|-----|-----------|
| `LogManager.Use<T>()` | `services.Configure<RollingLoggerProviderOptions>()` |
| `LogManager.UseFactory(ILoggerFactory)` | Configure MEL directly |
| `DefaultFactory` | `services.Configure<RollingLoggerProviderOptions>()` |
| `DefaultFactory.Directory(string)` | `RollingLoggerProviderOptions.Directory` |
| `DefaultFactory.Level(LogLevel)` | `RollingLoggerProviderOptions.LogLevel` |
| `LoggingFactoryDefinition` | Implement `ILoggerProvider`, register via `services.AddSingleton<ILoggerProvider, YourProvider>()` |

All internal call sites of the deprecated APIs are suppressed with tight `#pragma warning disable CS0618`.

## Trade-offs

**`PostConfigure` in acceptance tests**

`EndpointCreator.Configure` runs after `WithServices`, so the acceptance test uses `PostConfigure<RollingLoggerProviderOptions>` to win the ordering race — the idiomatic MEL pattern for late-binding overrides.

**`LogLevel` on options is advisory for the new path**

On the legacy path, `EndpointCreator` seeds `o.LogLevel` and registers the filter rule consistently. On the new path (no legacy config), `SetMinimumLevel` is the user's responsibility; the `LogLevel` property on options remains readable.

**`LoggingFactoryDefinition` subclasses will warn**

Downstream packages (`NServiceBus.Extensions.Logging`, community adapters) will see deprecation warnings. Those packages are deprecated because Core now integrates MEL natively.

**`RollingLoggerProviderOptions` as a stable migration surface**

Exposing `RollingLoggerProviderOptions` as a first-class public API means that if `RollingLoggerProvider` itself is ever deprecated in favor of a fully standard MEL setup (e.g., just `AddConsole` / community providers), users who configured logging via `services.Configure<RollingLoggerProviderOptions>()` will receive `[Obsolete]` warnings pointing them to the next migration step. Without this options class, there would be no first-class API to hang a deprecation on—users would silently lose their configuration when the provider is removed.

## Intentionally deferred

**Slot infrastructure simplification**

The current per-slot deferred log queues (`SlotFactoryState` enum, `DeferredLogs`, `deferredLogsBySlot`) exist to handle the window between `BeginSlotScope` (called in `EndpointCreator.Create()` before DI is built) and `RegisterSlotFactory` (called in `EndpointPreparation.Prepare()` once the MEL factory is available).

Now that MEL is always present after this PR, pre-startup is the only real edge case. Proposed simplification:

- Remove `SlotFactoryState` and `slotFactoryStates` dictionary
- Remove per-slot `DeferredLogs` and `deferredLogsBySlot`
- Add a single global `ConcurrentQueue` pre-startup buffer
- `SlotAwareLogger.Write()`: resolved slot logger → global buffer (no per-slot deferral, no fall-through to default)
- `RegisterSlotFactory`: drain global buffer into the new slot (duplicate logs across slots are rare and acceptable for pre-startup output)
- Remove `BeginSlotScope` call in `EndpointCreator.Create()` — no benefit without deferred state
- `FlushToDefault` in `UnregisterSlot` goes away — no per-slot pending state to flush

## Future changes after this PR

**1. Deprecate `TestingLoggerFactory`**

`TestingLoggerFactory` in `NServiceBus.Testing.Fakes` extends the now-deprecated `LoggingFactoryDefinition`. It should be deprecated in the same v10-warn / v11-error / v12-remove cycle and replaced with a standard MEL `ILoggerProvider` registration that test authors can compose normally.

**2. Slot infrastructure simplification**

As described in the deferred section above, simplify `SlotAwareLogger` / `LogManager` to use a single global pre-startup buffer now that MEL is always available.