### PR TITLE
Analyzer warnings for static handler classes

### DIFF
--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
@@ -715,7 +715,7 @@ public class HandlerAttributeAnalyzerTests : AnalyzerTestFixture<HandlerAttribut
     }
 
     [Test]
-    public Task DoesNotReportStaticConventionBasedHandlerWithPrivateConstructor()
+    public Task ReportsStaticConventionBasedHandlerEvenWithOnlyStaticHandleMethods()
     {
         var source =
             """
@@ -723,7 +723,7 @@ public class HandlerAttributeAnalyzerTests : AnalyzerTestFixture<HandlerAttribut
             using NServiceBus;
 
             [Handler]
-            static class MyHandler
+            static class [|MyHandler|]
             {
                 public static Task Handle(MyMessage message, IMessageHandlerContext context) => Task.CompletedTask;
             }
@@ -731,7 +731,7 @@ public class HandlerAttributeAnalyzerTests : AnalyzerTestFixture<HandlerAttribut
             class MyMessage : IMessage {}
             """;
 
-        return Assert(source);
+        return Assert(source, DiagnosticIds.HandlerClassCannotBeStatic);
     }
 
     [Test]
@@ -828,5 +828,25 @@ public class HandlerAttributeAnalyzerTests : AnalyzerTestFixture<HandlerAttribut
             """;
 
         return Assert(source);
+    }
+
+    [Test]
+    public Task ReportsStaticConventionBasedHandler()
+    {
+        var source =
+            """
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            [Handler]
+            static class [|MyHandler|]
+            {
+                public static Task Handle(MyMessage message, IMessageHandlerContext context) => Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage {}
+            """;
+
+        return Assert(source, DiagnosticIds.HandlerClassCannotBeStatic);
     }
 }

--- a/src/NServiceBus.Core.Analyzer/DiagnosticIds.cs
+++ b/src/NServiceBus.Core.Analyzer/DiagnosticIds.cs
@@ -50,4 +50,5 @@ public static class DiagnosticIds
     public const string ConventionBasedHandlerMisplacedAttribute = "NSB0035";
     public const string ConventionBasedHandlerNoAccessibleConstructor = "NSB0036";
     public const string ConventionBasedHandlerAmbiguousConstructor = "NSB0037";
+    public const string HandlerClassCannotBeStatic = "NSB0038";
 }

--- a/src/NServiceBus.Core.Analyzer/Handlers/AddHandlerGenerator.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/AddHandlerGenerator.cs
@@ -17,7 +17,7 @@ public sealed partial class AddHandlerGenerator : IIncrementalGenerator
 
         var addHandlers = context.SyntaxProvider
             .ForAttributeWithMetadataName("NServiceBus.HandlerAttribute",
-                predicate: static (node, _) => node is ClassDeclarationSyntax classDeclarationSyntax && !classDeclarationSyntax.Modifiers.Any(SyntaxKind.AbstractKeyword),
+                predicate: static (node, _) => node is ClassDeclarationSyntax classDeclarationSyntax && !classDeclarationSyntax.Modifiers.Any(SyntaxKind.AbstractKeyword) && !classDeclarationSyntax.Modifiers.Any(SyntaxKind.StaticKeyword),
                 transform: static (ctx, _) => (INamedTypeSymbol)ctx.TargetSymbol)
             .Combine(knownTypes)
             .Where(static pair =>

--- a/src/NServiceBus.Core.Analyzer/Handlers/AddHandlerInterceptor.Parser.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/AddHandlerInterceptor.Parser.cs
@@ -41,6 +41,11 @@ public sealed partial class AddHandlerInterceptor
                 return null;
             }
 
+            if (handlerType.IsStatic)
+            {
+                return null;
+            }
+
             if (semanticModel.GetInterceptableLocation(invocation, cancellationToken) is not { } location)
             {
                 return null;

--- a/src/NServiceBus.Core.Analyzer/Handlers/HandlerAttributeAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/HandlerAttributeAnalyzer.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 public class HandlerAttributeAnalyzer : DiagnosticAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        [HandlerAttributeMissing, HandlerAttributeMissingImmediate, HandlerAttributeMisplaced, HandlerAttributeMisplacedImmediate, ConventionBasedHandlerMissingAttribute, ConventionBasedHandlerMissingAttributeImmediate, ConventionBasedHandlerMisplacedAttribute, ConventionBasedHandlerMisplacedAttributeImmediate, HandlerAttributeOnNonHandlerType, ConventionBasedHandlerMixedStyleDescriptor, ConventionBasedHandlerNoAccessibleConstructorDescriptor, ConventionBasedHandlerAmbiguousConstructorDescriptor];
+        [HandlerAttributeMissing, HandlerAttributeMissingImmediate, HandlerAttributeMisplaced, HandlerAttributeMisplacedImmediate, ConventionBasedHandlerMissingAttribute, ConventionBasedHandlerMissingAttributeImmediate, ConventionBasedHandlerMisplacedAttribute, ConventionBasedHandlerMisplacedAttributeImmediate, HandlerAttributeOnNonHandlerType, ConventionBasedHandlerMixedStyleDescriptor, ConventionBasedHandlerNoAccessibleConstructorDescriptor, ConventionBasedHandlerAmbiguousConstructorDescriptor, HandlerClassCannotBeStaticDescriptor];
 
     public override void Initialize(AnalysisContext context)
     {
@@ -89,7 +89,15 @@ public class HandlerAttributeAnalyzer : DiagnosticAnalyzer
                             }
                         }
                     }
-                    else if (!classType.IsAbstract && conventionBasedAttributeLocations.IsDefaultOrEmpty)
+                    else if (classType.IsStatic && !conventionBasedAttributeLocations.IsDefaultOrEmpty)
+                    {
+                        var classLocation = classType.GetClassIdentifierLocation(context.CancellationToken);
+                        if (classLocation is not null)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(HandlerClassCannotBeStaticDescriptor, classLocation, classType.Name));
+                        }
+                    }
+                    else if (!classType.IsAbstract && !classType.IsStatic && conventionBasedAttributeLocations.IsDefaultOrEmpty)
                     {
                         var isUsedAsBase = baseTypes.ContainsKey(classType.OriginalDefinition);
                         var inheritsDirectlyFromObject = classType.BaseType?.SpecialType == SpecialType.System_Object;
@@ -167,6 +175,15 @@ public class HandlerAttributeAnalyzer : DiagnosticAnalyzer
                         {
                             context.ReportDiagnostic(Diagnostic.Create(HandlerAttributeMisplacedImmediate, location, classType.Name));
                         }
+                    }
+                }
+                // Static classes can't be used as generic type arguments for handler registration
+                else if (classType.IsStatic && !attributeLocations.IsDefaultOrEmpty)
+                {
+                    var classLocation = classType.GetClassIdentifierLocation(context.CancellationToken);
+                    if (classLocation is not null)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(HandlerClassCannotBeStaticDescriptor, classLocation, classType.Name));
                     }
                 }
                 // concrete classes that are used as base classes
@@ -332,6 +349,14 @@ public class HandlerAttributeAnalyzer : DiagnosticAnalyzer
         id: DiagnosticIds.ConventionBasedHandlerAmbiguousConstructor,
         title: "Convention-based handler has ambiguous constructor selection",
         messageFormat: "Convention-based handler '{0}' has multiple constructors with {1} parameters. Use [ActivatorUtilitiesConstructor] attribute to specify which constructor to use.",
+        category: "NServiceBus.Handlers",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    static readonly DiagnosticDescriptor HandlerClassCannotBeStaticDescriptor = new(
+        id: DiagnosticIds.HandlerClassCannotBeStatic,
+        title: "Handler class cannot be static",
+        messageFormat: "Handler class '{0}' is static. Static handler classes cannot be used as generic type arguments for handler registration.",
         category: "NServiceBus.Handlers",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);


### PR DESCRIPTION
This pull request introduces a new analyzer diagnostic to prevent static classes from being used as handler classes in NServiceBus, ensuring that only non-static classes are allowed for handler registration via the `[Handler]` attribute or convention-based mechanisms. The changes add enforcement in both the analyzer logic and the code generation pipeline, as well as new tests to verify the behavior.

**Analyzer and Diagnostic Improvements:**

* Added a new diagnostic ID `NSB0038` (`HandlerClassCannotBeStatic`) to identify and report static handler classes. [[1]](diffhunk://#diff-e9ec42fa18c369d9646fb311ce0063631e872e89593a541203769ddf7c1bae17R53) [[2]](diffhunk://#diff-1af1be92d7b042ad5a5759a9f9ff0386d4344b20bbf93e690d1c22a8ceefa75fR355-R362)
* Updated `HandlerAttributeAnalyzer` to report the new diagnostic when a static class is decorated with the `[Handler]` attribute or detected as a convention-based handler. [[1]](diffhunk://#diff-1af1be92d7b042ad5a5759a9f9ff0386d4344b20bbf93e690d1c22a8ceefa75fL92-R100) [[2]](diffhunk://#diff-1af1be92d7b042ad5a5759a9f9ff0386d4344b20bbf93e690d1c22a8ceefa75fR180-R188) [[3]](diffhunk://#diff-1af1be92d7b042ad5a5759a9f9ff0386d4344b20bbf93e690d1c22a8ceefa75fL15-R15)

**Code Generation and Parsing Adjustments:**

* Modified the handler registration generator to exclude static classes from being considered for handler generation.
* Updated the handler parser to skip static classes during interception logic.

**Testing Enhancements:**

* Added and updated tests to assert that static handler classes are correctly reported with the new diagnostic, ensuring coverage for both attribute-based and convention-based handlers. [[1]](diffhunk://#diff-205f4ecc700dd7da9687ef46ec2fd5935621dd3d0e61c9b1249484c92628540dL718-R734) [[2]](diffhunk://#diff-205f4ecc700dd7da9687ef46ec2fd5935621dd3d0e61c9b1249484c92628540dR832-R851)