### PR TITLE
Revert mutated headers before auditing to match body behavior

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
@@ -74,7 +74,6 @@ NServiceBus.Transport.DispatchProperties
 NServiceBus.Transport.ErrorContext
 NServiceBus.Transport.IMessageDispatcher
 NServiceBus.Transport.IMessageReceiver
-NServiceBus.Transport.IncomingMessage
 NServiceBus.Transport.IncomingMessageExtensions
 NServiceBus.Transport.IOutgoingTransportOperation
 NServiceBus.Transport.ISubscriptionManager

--- a/src/NServiceBus.Core.Tests/Transports/IncomingMessageTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/IncomingMessageTests.cs
@@ -52,4 +52,105 @@ public class IncomingMessageTests
             Assert.That(message.MessageId, Is.EqualTo("nativeId"));
         }
     }
+
+    [Test]
+    public void RevertToOriginalHeadersIfNeeded_should_restore_added_headers()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { Headers.MessageId, "id" },
+            { "OriginalHeader", "original-value" }
+        };
+        var message = new IncomingMessage("id", headers, System.Array.Empty<byte>());
+
+        message.SnapshotHeaders();
+        message.Headers["AddedByMutator"] = "mutator-value";
+
+        message.RevertToOriginal();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(message.Headers.ContainsKey("AddedByMutator"), Is.False);
+            Assert.That(message.Headers["OriginalHeader"], Is.EqualTo("original-value"));
+        }
+    }
+
+    [Test]
+    public void RevertToOriginalHeadersIfNeeded_should_restore_modified_headers()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { Headers.MessageId, "id" },
+            { Headers.ContentType, "text/plain" }
+        };
+        var message = new IncomingMessage("id", headers, System.Array.Empty<byte>());
+
+        message.SnapshotHeaders();
+        message.Headers[Headers.ContentType] = "application/json";
+        message.Headers[Headers.EnclosedMessageTypes] = "MyMessage";
+
+        message.RevertToOriginal();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(message.Headers[Headers.ContentType], Is.EqualTo("text/plain"));
+            Assert.That(message.Headers.ContainsKey(Headers.EnclosedMessageTypes), Is.False);
+        }
+    }
+
+    [Test]
+    public void RevertToOriginalHeadersIfNeeded_should_restore_removed_headers()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { Headers.MessageId, "id" },
+            { "WillBeRemoved", "value" }
+        };
+        var message = new IncomingMessage("id", headers, System.Array.Empty<byte>());
+
+        message.SnapshotHeaders();
+        message.Headers.Remove("WillBeRemoved");
+
+        message.RevertToOriginal();
+
+        Assert.That(message.Headers["WillBeRemoved"], Is.EqualTo("value"));
+    }
+
+    [Test]
+    public void RevertToOriginalHeadersIfNeeded_should_noop_without_snapshot()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { Headers.MessageId, "id" },
+            { "Key", "value" }
+        };
+        var message = new IncomingMessage("id", headers, System.Array.Empty<byte>());
+
+        message.Headers["Key"] = "mutated";
+        message.RevertToOriginal();
+
+        Assert.That(message.Headers["Key"], Is.EqualTo("mutated"));
+    }
+
+    [Test]
+    public void SnapshotHeaders_should_only_capture_first_snapshot()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { Headers.MessageId, "id" },
+            { "Key", "original" }
+        };
+        var message = new IncomingMessage("id", headers, System.Array.Empty<byte>());
+
+        message.SnapshotHeaders();
+        message.Headers["Key"] = "first-mutation";
+
+        // Second snapshot should not overwrite the first
+        message.SnapshotHeaders();
+        message.Headers["Key"] = "second-mutation";
+
+        message.RevertToOriginal();
+
+        Assert.That(message.Headers["Key"], Is.EqualTo("original"));
+    }
 }

--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -20,7 +20,7 @@ class InvokeAuditPipelineBehavior : IForkConnector<IIncomingPhysicalMessageConte
     {
         await next(context).ConfigureAwait(false);
 
-        context.Message.RevertToOriginalBodyIfNeeded();
+        context.Message.RevertToOriginal();
 
         var processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), context.Message.Body);
 

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -19,6 +19,7 @@ class MutateIncomingTransportMessageBehavior(HashSet<IMutateIncomingTransportMes
     {
         var mutatorsRegisteredInDI = context.Builder.GetServices<IMutateIncomingTransportMessages>();
         var transportMessage = context.Message;
+        transportMessage.SnapshotHeaders();
         var mutatorContext = new MutateIncomingTransportMessageContext(transportMessage.Body, transportMessage.Headers, context.CancellationToken);
 
         var hasMutators = false;

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -50,7 +50,7 @@ public class IncomingMessage
     /// <summary>
     /// The message headers.
     /// </summary>
-    public Dictionary<string, string> Headers { get; }
+    public Dictionary<string, string> Headers { get; private set; }
 
     /// <summary>
     /// Gets/sets a byte array to the body content of the message.
@@ -68,15 +68,31 @@ public class IncomingMessage
     }
 
     /// <summary>
-    /// Makes sure that the body is reset to the exact state as it was when the message was created.
+    /// Captures the current headers so they can be reverted later. Only the first call captures; subsequent calls are no-ops.
     /// </summary>
-    internal void RevertToOriginalBodyIfNeeded()
+    internal void SnapshotHeaders()
+    {
+        originalHeaders ??= new Dictionary<string, string>(Headers);
+    }
+
+    /// <summary>
+    /// Resets body and headers to the exact state as they were when the message was created.
+    /// </summary>
+    internal void RevertToOriginal()
     {
         if (originalBody != null)
         {
             Body = originalBody.Value;
         }
+
+        if (originalHeaders != null)
+        {
+            Headers = originalHeaders;
+        }
     }
 
     ReadOnlyMemory<byte>? originalBody;
+#nullable enable
+    Dictionary<string, string>? originalHeaders;
+#nullable restore
 }

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -70,14 +70,6 @@ public class IncomingMessage
     }
 
     /// <summary>
-    /// Captures the current headers so they can be reverted later. Only the first call captures; subsequent calls are no-ops.
-    /// </summary>
-    internal void SnapshotHeaders()
-    {
-        originalHeaders ??= new Dictionary<string, string>(Headers);
-    }
-
-    /// <summary>
     /// Resets body and headers to the exact state as they were when the message was created.
     /// </summary>
     internal void RevertToOriginal()
@@ -92,6 +84,11 @@ public class IncomingMessage
             Headers = originalHeaders;
         }
     }
+
+    /// <summary>
+    /// Captures the current headers so they can be reverted later. Only the first call captures; subsequent calls are no-ops.
+    /// </summary>
+    internal void SnapshotHeaders() => originalHeaders ??= new Dictionary<string, string>(Headers);
 
     ReadOnlyMemory<byte>? originalBody;
     Dictionary<string, string>? originalHeaders;

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace NServiceBus.Transport;
 
 using System;
@@ -92,7 +94,5 @@ public class IncomingMessage
     }
 
     ReadOnlyMemory<byte>? originalBody;
-#nullable enable
     Dictionary<string, string>? originalHeaders;
-#nullable restore
 }


### PR DESCRIPTION
Headers modified by IMutateIncomingTransportMessages leaked into audit messages while body was correctly reverted. This caused mismatches where audit stored e.g. ContentType: application/json with a non-JSON body.

Adds SnapshotHeaders/RevertToOriginalHeadersIfNeeded to IncomingMessage, matching the existing body snapshot pattern.