### PR TITLE
AddNServiceBusEndpoint throws a meaningful exception when the transport is not specified

### DIFF
--- a/src/NServiceBus.Core.Tests/Hosting/ServiceCollectionExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Hosting/ServiceCollectionExtensionsTests.cs
@@ -72,6 +72,22 @@ public class ServiceCollectionExtensionsTests
         Assert.That(ex!.Message, Does.Contain("An endpoint with the identifier 'shared-key' has already been registered"));
     }
 
+    [Test]
+    public void Should_throw_when_transport_not_specified()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Assert.Throws<Exception>(() =>
+        {
+            var endpointConfiguration = new EndpointConfiguration("Billing");
+            endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+
+            services.AddNServiceBusEndpoint(endpointConfiguration);
+        });
+
+        Assert.That(ex!.Message, Does.Contain("A transport has not been configured. Use 'EndpointConfiguration.UseTransport()' to specify a transport"));
+    }
+
     static EndpointConfiguration CreateConfig(string endpointName)
     {
         var config = new EndpointConfiguration(endpointName);

--- a/src/NServiceBus.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/src/NServiceBus.Core/Hosting/ServiceCollectionExtensions.cs
@@ -67,7 +67,7 @@ public static class ServiceCollectionExtensions
         var settings = endpointConfiguration.GetSettings();
         var endpointName = settings.EndpointName();
         var hostingSettings = settings.Get<HostingComponent.Settings>();
-        var transport = settings.Get<TransportDefinition>();
+        var transport = settings.Get<TransportSeam.Settings>().TransportDefinition;
         var registrations = GetExistingRegistrations(services);
 
         ValidateEndpointIdentifier(endpointIdentifier, registrations);

--- a/src/NServiceBus.Core/Transports/TransportSeam.cs
+++ b/src/NServiceBus.Core/Transports/TransportSeam.cs
@@ -67,15 +67,7 @@ class TransportSeam(TransportDefinition transportDefinition, HostSettings hostSe
 
         public TransportDefinition TransportDefinition
         {
-            get
-            {
-                if (!settings.HasExplicitValue<TransportDefinition>())
-                {
-                    throw new Exception("A transport has not been configured. Use 'EndpointConfiguration.UseTransport()' to specify a transport.");
-                }
-
-                return settings.Get<TransportDefinition>();
-            }
+            get => !settings.HasExplicitValue<TransportDefinition>() ? throw new Exception("A transport has not been configured. Use 'EndpointConfiguration.UseTransport()' to specify a transport.") : settings.Get<TransportDefinition>();
             set => settings.Set(value);
         }
 


### PR DESCRIPTION
Previously it did throw a `KeyNotFoundException` from the `SettingsHolder` which is not exactly user-friendly. Nice find @bording 