### PR TITLE
Options for handler style settable via .editorconfig

### DIFF
--- a/src/NServiceBus.Core.Analyzer.Fixes/Handlers/AddConventionBasedHandleMethodFixer.cs
+++ b/src/NServiceBus.Core.Analyzer.Fixes/Handlers/AddConventionBasedHandleMethodFixer.cs
@@ -31,8 +31,7 @@ public class AddConventionBasedHandleMethodFixer : CodeFixProvider
             return;
         }
 
-        var analyzerOptions = context.Document.Project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(root.SyntaxTree);
-        if (analyzerOptions.TryGetValue("nservicebus_handler_style", out var handlerStyle) && string.Equals(handlerStyle, "IHandleMessages", StringComparison.OrdinalIgnoreCase))
+        if (EditorConfigSettings.KeyMatches(context.Document.Project.AnalyzerOptions, root.SyntaxTree, EditorConfigSettings.HandlerStyleKey, EditorConfigSettings.HandlerStyleInterfaces))
         {
             return;
         }
@@ -50,7 +49,7 @@ public class AddConventionBasedHandleMethodFixer : CodeFixProvider
                 CodeAction.Create(
                     "Add convention-based Handle(MyMessage, ...)",
                     token => AddHandleMethod(context.Document, classDecl.SpanStart, token),
-                    EquivalenceKey + handlerStyle),
+                    EquivalenceKey),
                 diagnostic);
         }
     }

--- a/src/NServiceBus.Core.Analyzer.Fixes/Handlers/AddConventionBasedHandleMethodFixer.cs
+++ b/src/NServiceBus.Core.Analyzer.Fixes/Handlers/AddConventionBasedHandleMethodFixer.cs
@@ -1,9 +1,11 @@
 namespace NServiceBus.Core.Analyzer.Fixes;
 
+using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Handlers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -12,7 +14,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
-using NServiceBus.Core.Analyzer.Handlers;
 
 [Shared]
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AddConventionBasedHandleMethodFixer))]
@@ -25,14 +26,20 @@ public class AddConventionBasedHandleMethodFixer : CodeFixProvider
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        var analyzerOptions = context.Document.Project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(root.SyntaxTree);
+        if (analyzerOptions.TryGetValue("nservicebus_handler_style", out var handlerStyle) && string.Equals(handlerStyle, "IHandleMessages", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
 
         foreach (var diagnostic in context.Diagnostics)
         {
-            if (root?.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) is not { } node)
-            {
-                continue;
-            }
-
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
             var classDecl = node.FirstAncestorOrSelf<ClassDeclarationSyntax>();
             if (classDecl is null || !HandlerFixerGuards.IsEmptyHandlerShell(classDecl))
             {
@@ -43,7 +50,7 @@ public class AddConventionBasedHandleMethodFixer : CodeFixProvider
                 CodeAction.Create(
                     "Add convention-based Handle(MyMessage, ...)",
                     token => AddHandleMethod(context.Document, classDecl.SpanStart, token),
-                    EquivalenceKey),
+                    EquivalenceKey + handlerStyle),
                 diagnostic);
         }
     }

--- a/src/NServiceBus.Core.Analyzer.Fixes/Handlers/AddIHandleMessagesInterfaceFixer.cs
+++ b/src/NServiceBus.Core.Analyzer.Fixes/Handlers/AddIHandleMessagesInterfaceFixer.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Core.Analyzer.Fixes;
 
+using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
@@ -25,14 +26,20 @@ public class AddIHandleMessagesInterfaceFixer : CodeFixProvider
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        var analyzerOptions = context.Document.Project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(root.SyntaxTree);
+        if (analyzerOptions.TryGetValue("nservicebus_handler_style", out var handlerStyle) && string.Equals(handlerStyle, "Conventions", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
 
         foreach (var diagnostic in context.Diagnostics)
         {
-            if (root?.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) is not { } node)
-            {
-                continue;
-            }
-
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
             var classDecl = node.FirstAncestorOrSelf<ClassDeclarationSyntax>();
             if (classDecl is null || !HandlerFixerGuards.IsEmptyHandlerShell(classDecl))
             {
@@ -43,7 +50,7 @@ public class AddIHandleMessagesInterfaceFixer : CodeFixProvider
                 CodeAction.Create(
                     "Implement IHandleMessages<MyMessage>",
                     token => AddInterface(context.Document, classDecl.SpanStart, token),
-                    EquivalenceKey),
+                    EquivalenceKey + handlerStyle),
                 diagnostic);
         }
     }

--- a/src/NServiceBus.Core.Analyzer.Fixes/Handlers/AddIHandleMessagesInterfaceFixer.cs
+++ b/src/NServiceBus.Core.Analyzer.Fixes/Handlers/AddIHandleMessagesInterfaceFixer.cs
@@ -31,8 +31,7 @@ public class AddIHandleMessagesInterfaceFixer : CodeFixProvider
             return;
         }
 
-        var analyzerOptions = context.Document.Project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(root.SyntaxTree);
-        if (analyzerOptions.TryGetValue("nservicebus_handler_style", out var handlerStyle) && string.Equals(handlerStyle, "Conventions", StringComparison.OrdinalIgnoreCase))
+        if (EditorConfigSettings.KeyMatches(context.Document.Project.AnalyzerOptions, root.SyntaxTree, EditorConfigSettings.HandlerStyleKey, EditorConfigSettings.HandlerStyleConventions))
         {
             return;
         }
@@ -50,7 +49,7 @@ public class AddIHandleMessagesInterfaceFixer : CodeFixProvider
                 CodeAction.Create(
                     "Implement IHandleMessages<MyMessage>",
                     token => AddInterface(context.Document, classDecl.SpanStart, token),
-                    EquivalenceKey + handlerStyle),
+                    EquivalenceKey),
                 diagnostic);
         }
     }

--- a/src/NServiceBus.Core.Analyzer.Fixes/NServiceBus.Core.Analyzer.Fixes.csproj
+++ b/src/NServiceBus.Core.Analyzer.Fixes/NServiceBus.Core.Analyzer.Fixes.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <Compile Include="..\NServiceBus.Core.Analyzer\DiagnosticIds.cs" />
+    <Compile Include="..\NServiceBus.Core.Analyzer\EditorConfigSettings.cs" />
     <Compile Include="..\NServiceBus.Core.Analyzer\Features\FeatureKnownTypes.cs" LinkBase="Features" />
     <Compile Include="..\NServiceBus.Core.Analyzer\TypeSymbolExtensions.cs" />
     <Compile Include="..\NServiceBus.Core.Analyzer\NamespaceSymbolExtensions.cs" />

--- a/src/NServiceBus.Core.Analyzer/EditorConfigSettings.cs
+++ b/src/NServiceBus.Core.Analyzer/EditorConfigSettings.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+namespace NServiceBus.Core.Analyzer;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+static class EditorConfigSettings
+{
+    /// <summary>
+    /// Get an editorconfig setting in an Analyzer. The AnalyzerOptions should be accessible from an Analyzer through <c>context.Options</c>
+    /// or in a CodeFixProvider from <c>context.Document.Project.AnalyzerOptions</c>.
+    /// </summary>
+    /// <returns></returns>
+    public static bool TryGetValue(AnalyzerOptions analyzerOptions, SyntaxTree? syntaxTree, string settingName, [NotNullWhen(true)] out string? value)
+    {
+        var provider = analyzerOptions.AnalyzerConfigOptionsProvider;
+
+        if (syntaxTree is null)
+        {
+            return provider.GlobalOptions.TryGetValue(settingName, out value);
+        }
+
+        var options = analyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
+        return options.TryGetValue(settingName, out value);
+    }
+
+    public static bool KeyMatches(AnalyzerOptions analyzerOptions, SyntaxTree? syntaxTree, string settingName, string matchValue, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
+        => TryGetValue(analyzerOptions, syntaxTree, settingName, out var value) && string.Equals(value, matchValue, comparison);
+
+    public const string HandlerStyleKey = "nservicebus_handler_style";
+    public const string HandlerStyleInterfaces = "interfaces";
+    public const string HandlerStyleConventions = "conventions";
+}


### PR DESCRIPTION
This pull request introduces a new `nservicebus_handler_style` option with values of either `IHandleMessages` or `Conventions` to the `.editorconfig` file that control which fixers are allowed to scaffold an NServiceBus message handler when the `[Handler]` attribute is applied to a class:

```csharp
[Handler]
public class MyNewHandler
{
}
```

When either of these options is set in .editorconfig, it determines the preferred organization for NServiceBus message handlers within the codebase. This centralized configuration allows project maintainers to suggest a consistent handler structure across the codebase, streamlining code reviews and onboarding for contributors.

Because `.editorconfig` files are hierarchical, project maintainers can control which styles are preferred in different parts of the codebase, if there are differences.

### No setting (default)

When no setting is used, both fixers are available:

1. `Implement IHandleMessages<MyMessage>`
1. `Add convention-based Handle(MyMessage, ...)`

### IHandleMessages only

When the `.editorconfig` file contains:

```ini
nservicebus_handler_style = IHandleMessages
```

Then only the `Implement IHandleMessages<MyMessage>` code fix is available.

### Conventions only

When the `.editorconfig` file contains

```ini
nservicebus_handler_style = Conventions
```

### Details

- Evaluation of the setting value (`IHandleMessages` or `Conventions`) is case insensitive.

Then only the `Add convention-based Handle(MyMessage, ...)` code fix is available.