### PR TITLE
Spike: Auto-disable delayed retries when not explicitly set when transport lacks delayed delivery support

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_delayed_retries_enabled_with_no_support.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_delayed_retries_enabled_with_no_support.cs
@@ -1,6 +1,7 @@
-﻿namespace NServiceBus.AcceptanceTests.Core.Recoverability;
+namespace NServiceBus.AcceptanceTests.Core.Recoverability;
 
 using System;
+using System.Threading.Tasks;
 using AcceptanceTesting;
 using EndpointTemplates;
 using NUnit.Framework;
@@ -8,7 +9,7 @@ using NUnit.Framework;
 public class When_delayed_retries_enabled_with_no_support : NServiceBusAcceptanceTest
 {
     [Test]
-    public void Should_throw_on_startup()
+    public void Should_throw_when_explicitly_configured()
     {
         if (TestSuiteConstraints.Current.SupportsDelayedDelivery)
         {
@@ -16,20 +17,40 @@ public class When_delayed_retries_enabled_with_no_support : NServiceBusAcceptanc
         }
 
         var exception = Assert.ThrowsAsync<Exception>(async () => await Scenario.Define<ScenarioContext>()
-            .WithEndpoint<StartedEndpoint>()
+            .WithEndpoint<EndpointWithExplicitDelayedRetries>()
             .Done(c => c.EndpointsStarted)
             .Run());
 
-        Assert.That(exception.ToString(), Does.Contain("Delayed retries are not supported when the transport does not support delayed delivery. Disable delayed retries using 'endpointConfiguration.Recoverability().Delayed(settings => settings.NumberOfRetries(0))'."));
+        Assert.That(exception.ToString(), Does.Contain("Delayed retries are not supported when the transport does not support delayed delivery."));
     }
 
-    public class StartedEndpoint : EndpointConfigurationBuilder
+    [Test]
+    public async Task Should_start_successfully_with_default_delayed_retries()
     {
-        public StartedEndpoint() =>
+        if (TestSuiteConstraints.Current.SupportsDelayedDelivery)
+        {
+            Assert.Ignore("Ignoring this test because it requires the transport to not support delayed delivery.");
+        }
+
+        await Scenario.Define<ScenarioContext>()
+            .WithEndpoint<EndpointWithDefaultDelayedRetries>()
+            .Done(c => c.EndpointsStarted)
+            .Run();
+    }
+
+    public class EndpointWithExplicitDelayedRetries : EndpointConfigurationBuilder
+    {
+        public EndpointWithExplicitDelayedRetries() =>
             EndpointSetup<DefaultServer>((config, context) =>
             {
                 var recoverability = config.Recoverability();
                 recoverability.Delayed(i => i.NumberOfRetries(1));
             });
+    }
+
+    public class EndpointWithDefaultDelayedRetries : EndpointConfigurationBuilder
+    {
+        public EndpointWithDefaultDelayedRetries() =>
+            EndpointSetup<DefaultServer>();
     }
 }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
@@ -181,7 +181,13 @@ class RecoverabilityComponent
         {
             if (!transportDefinition.SupportsDelayedDelivery)
             {
-                throw new Exception("Delayed retries are not supported when the transport does not support delayed delivery. Disable delayed retries using 'endpointConfiguration.Recoverability().Delayed(settings => settings.NumberOfRetries(0))'.");
+                if (settings.HasExplicitValue(NumberOfDelayedRetries))
+                {
+                    throw new Exception("Delayed retries are not supported when the transport does not support delayed delivery. Disable delayed retries using 'endpointConfiguration.Recoverability().Delayed(settings => settings.NumberOfRetries(0))'.");
+                }
+
+                Logger.Info("Delayed retries have been disabled because the transport does not support delayed delivery.");
+                numberOfRetries = 0;
             }
 
             if (!transactionsOn)


### PR DESCRIPTION
Instead of throwing at startup, log an info message and set delayed retries to 0 unless delayed retries is explicitly configured.



