### PR TITLE
[Backport to 10.1] Split `When_sending_within_an_ambient_transaction` into two distinct tests and improve done condition (#7695)

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Tx/When_ambient_transaction_is_not_completed.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_ambient_transaction_is_not_completed.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus.AcceptanceTests.Tx;
+
+using System;
+using System.Threading.Tasks;
+using System.Transactions;
+using AcceptanceTesting;
+using AcceptanceTesting.Customization;
+using EndpointTemplates;
+using NUnit.Framework;
+
+public class When_ambient_transaction_is_not_completed : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_not_deliver_enlisted_message()
+    {
+        Requires.DtcSupport();
+
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<TransactionalEndpoint>(b => b.When(async session =>
+            {
+                using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    await session.Send(new MessageThatIsEnlisted());
+
+                    // scope is not completed 
+                }
+
+                await session.Send(new MessageThatIsNotEnlisted());
+            }))
+            .Run();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(context.MessageThatIsEnlistedHandlerWasCalled, Is.False, "The transactional handler should not be called");
+            Assert.That(context.MessageThatIsNotEnlistedHandlerWasCalled, Is.True, "The non-transactional handler should be called");
+        }
+    }
+
+    public class Context : ScenarioContext
+    {
+        public bool MessageThatIsEnlistedHandlerWasCalled { get; set; }
+        public bool MessageThatIsNotEnlistedHandlerWasCalled { get; set; }
+    }
+
+    public class TransactionalEndpoint : EndpointConfigurationBuilder
+    {
+        public TransactionalEndpoint() =>
+            EndpointSetup<DefaultServer>(c =>
+            {
+                c.LimitMessageProcessingConcurrencyTo(1);
+                var routing = c.ConfigureRouting();
+                routing.RouteToEndpoint(typeof(MessageThatIsEnlisted), typeof(TransactionalEndpoint));
+                routing.RouteToEndpoint(typeof(MessageThatIsNotEnlisted), typeof(TransactionalEndpoint));
+            });
+
+        public class MessageThatIsEnlistedHandler(Context testContext) : IHandleMessages<MessageThatIsEnlisted>
+        {
+            public Task Handle(MessageThatIsEnlisted messageThatIsEnlisted, IMessageHandlerContext context)
+            {
+                testContext.MessageThatIsEnlistedHandlerWasCalled = true;
+                testContext.MarkAsFailed(new InvalidOperationException($"'{nameof(MessageThatIsEnlistedHandler)}' should not be called because the surrounding transaction was rolled back."));
+                return Task.CompletedTask;
+            }
+        }
+
+        public class MessageThatIsNotEnlistedHandler(Context testContext) : IHandleMessages<MessageThatIsNotEnlisted>
+        {
+            public Task Handle(MessageThatIsNotEnlisted messageThatIsNotEnlisted, IMessageHandlerContext context)
+            {
+                testContext.MessageThatIsNotEnlistedHandlerWasCalled = true;
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class MessageThatIsEnlisted : ICommand;
+
+    public class MessageThatIsNotEnlisted : ICommand;
+}

--- a/src/NServiceBus.AcceptanceTests/Tx/When_sends_are_enlisted_in_ambient_transaction.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_sends_are_enlisted_in_ambient_transaction.cs
@@ -7,60 +7,31 @@ using AcceptanceTesting.Customization;
 using EndpointTemplates;
 using NUnit.Framework;
 
-public class When_sending_within_an_ambient_transaction : NServiceBusAcceptanceTest
+public class When_sends_are_enlisted_in_ambient_transaction : NServiceBusAcceptanceTest
 {
     [Test]
-    public async Task Should_not_deliver_them_until_the_commit_phase()
+    public async Task Should_not_dispatch_messages_until_the_commit_phase()
     {
         Requires.DtcSupport();
 
         var context = await Scenario.Define<Context>()
             .WithEndpoint<TransactionalEndpoint>(b => b.When(async (session, ctx) =>
             {
-                using (var tx = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+                using var tx = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+                await session.Send(new MessageThatIsEnlisted { SequenceNumber = 1 });
+                await session.Send(new MessageThatIsEnlisted { SequenceNumber = 2 });
+
+                //send another message that is not enlisted so that we can check the order in the receiver
+                using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
                 {
-                    await session.Send(new MessageThatIsEnlisted
-                    {
-                        SequenceNumber = 1
-                    });
-                    await session.Send(new MessageThatIsEnlisted
-                    {
-                        SequenceNumber = 2
-                    });
-
-                    //send another message as well so that we can check the order in the receiver
-                    using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
-                    {
-                        await session.Send(new MessageThatIsNotEnlisted());
-                    }
-
-                    tx.Complete();
+                    await session.Send(new MessageThatIsNotEnlisted());
                 }
+
+                tx.Complete();
             }))
             .Run();
 
         Assert.That(context.SequenceNumberOfFirstMessage, Is.EqualTo(1), "The transport should preserve the order in which the transactional messages are delivered to the queuing system");
-    }
-
-    [Test]
-    public async Task Should_not_deliver_them_on_rollback()
-    {
-        Requires.DtcSupport();
-
-        var context = await Scenario.Define<Context>()
-            .WithEndpoint<TransactionalEndpoint>(b => b.When(async session =>
-            {
-                using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
-                {
-                    await session.Send(new MessageThatIsEnlisted());
-                    //rollback
-                }
-
-                await session.Send(new MessageThatIsNotEnlisted());
-            }))
-            .Run();
-
-        Assert.That(context.MessageThatIsEnlistedHandlerWasCalled, Is.False, "The transactional handler should not be called");
     }
 
     public class Context : ScenarioContext


### PR DESCRIPTION
Backport of:

- #7695

to `release-10.1`