### PR TITLE
Expose Endpoint Name as a read-only property on EndpointConfiguration

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1047,9 +1047,12 @@ namespace NServiceBus
     }
     public static class SettingsExtensions
     {
-        public static string EndpointName(this NServiceBus.Settings.IReadOnlySettings settings) { }
-        public static string EndpointQueueName(this NServiceBus.Settings.IReadOnlySettings settings) { }
-        public static System.Collections.Generic.IList<System.Type> GetAvailableTypes(this NServiceBus.Settings.IReadOnlySettings settings) { }
+        extension(NServiceBus.Settings.IReadOnlySettings settings)
+        {
+            public System.Collections.Generic.IList<System.Type> GetAvailableTypes() { }
+            public string EndpointName() { }
+            public string EndpointQueueName() { }
+        }
     }
     public class StartupDiagnosticEntries
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -275,6 +275,7 @@ namespace NServiceBus
     public class EndpointConfiguration : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public EndpointConfiguration(string endpointName) { }
+        public string EndpointName { get; }
         public NServiceBus.Pipeline.PipelineSettings Pipeline { get; }
         public NServiceBus.ConventionsBuilder Conventions() { }
         [System.Obsolete(@"RegisterComponents should only be used when self-hosting endpoints, which is no longer recommended. When using a Microsoft IHostApplicationBuilder-based host, register services directly on the host builder's IServiceCollection. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -26,6 +26,8 @@ public class EndpointConfiguration : ExposeSettings
     {
         ValidateEndpointName(endpointName);
 
+        EndpointName = endpointName;
+
         Settings.Set(new SystemEnvironment());
         Settings.Set("NServiceBus.Routing.EndpointName", endpointName);
 
@@ -72,6 +74,11 @@ public class EndpointConfiguration : ExposeSettings
 
         conventionsBuilder = new ConventionsBuilder(Settings);
     }
+
+    /// <summary>
+    /// The name of the endpoint.
+    /// </summary>
+    public string EndpointName { get; }
 
     /// <summary>
     /// Access to the pipeline configuration.

--- a/src/NServiceBus.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/src/NServiceBus.Core/Hosting/ServiceCollectionExtensions.cs
@@ -66,7 +66,7 @@ public static class ServiceCollectionExtensions
         // the old hosting is still supported.
         settings.AssertNotReused();
 
-        var endpointName = settings.EndpointName();
+        var endpointName = endpointConfiguration.EndpointName;
         var transport = settings.Get<TransportSeam.Settings>().TransportDefinition;
         var endpointRegistrations = GetExistingRegistrations<EndpointRegistration>(services);
         var installerRegistrations = GetExistingRegistrations<EndpointInstallerRegistration>(services);
@@ -154,7 +154,7 @@ public static class ServiceCollectionExtensions
         // the old hosting is still supported.
         settings.AssertNotReused();
 
-        var endpointName = settings.EndpointName();
+        var endpointName = endpointConfiguration.EndpointName;
         var transport = settings.Get<TransportSeam.Settings>().TransportDefinition;
         var endpointRegistrations = GetExistingRegistrations<EndpointRegistration>(services);
         var installerRegistrations = GetExistingRegistrations<EndpointInstallerRegistration>(services);

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -7,43 +7,46 @@ using Settings;
 /// <summary>
 /// Provides extensions to the settings holder.
 /// </summary>
-public static partial class SettingsExtensions
+public static class SettingsExtensions
 {
-    /// <summary>
-    /// Gets the list of types available to this endpoint.
-    /// </summary>
-    public static IList<Type> GetAvailableTypes(this IReadOnlySettings settings)
+    extension(IReadOnlySettings settings)
     {
-        ArgumentNullException.ThrowIfNull(settings);
-        return settings.Get<AssemblyScanningComponent.Configuration>().AvailableTypes;
-    }
-
-    /// <summary>
-    /// Returns the name of this endpoint.
-    /// </summary>
-    public static string EndpointName(this IReadOnlySettings settings)
-    {
-        ArgumentNullException.ThrowIfNull(settings);
-        return settings.Get<string>("NServiceBus.Routing.EndpointName");
-    }
-
-    /// <summary>
-    /// Returns the shared queue name of this endpoint.
-    /// </summary>
-    public static string EndpointQueueName(this IReadOnlySettings settings)
-    {
-        ArgumentNullException.ThrowIfNull(settings);
-
-        if (!settings.TryGet<ReceiveComponent.Configuration>(out var receiveConfiguration))
+        /// <summary>
+        /// Gets the list of types available to this endpoint.
+        /// </summary>
+        public IList<Type> GetAvailableTypes()
         {
-            throw new InvalidOperationException("EndpointQueueName isn't available until the endpoint configuration is complete.");
+            ArgumentNullException.ThrowIfNull(settings);
+            return settings.Get<AssemblyScanningComponent.Configuration>().AvailableTypes;
         }
 
-        if (receiveConfiguration.IsSendOnlyEndpoint)
+        /// <summary>
+        /// Returns the name of this endpoint.
+        /// </summary>
+        public string EndpointName()
         {
-            throw new InvalidOperationException("EndpointQueueName isn't available for send only endpoints.");
+            ArgumentNullException.ThrowIfNull(settings);
+            return settings.Get<string>("NServiceBus.Routing.EndpointName");
         }
 
-        return receiveConfiguration.LocalQueueAddress.BaseAddress;
+        /// <summary>
+        /// Returns the shared queue name of this endpoint.
+        /// </summary>
+        public string EndpointQueueName()
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+
+            if (!settings.TryGet<ReceiveComponent.Configuration>(out var receiveConfiguration))
+            {
+                throw new InvalidOperationException("EndpointQueueName isn't available until the endpoint configuration is complete.");
+            }
+
+            if (receiveConfiguration.IsSendOnlyEndpoint)
+            {
+                throw new InvalidOperationException("EndpointQueueName isn't available for send only endpoints.");
+            }
+
+            return receiveConfiguration.LocalQueueAddress.BaseAddress;
+        }
     }
 }


### PR DESCRIPTION
This pull request exposes the endpoint name as a get-only property on the `EndpointConfiguration`.

While the endpoint name can already be retrieved using:

```csharp
endpointConfiguration.GetSettings().EndpointName()
```

providing direct access through the configuration offers additional value and improves usability.

### Motivation
1. Improved support for multi-hosting scenarios
Exposing the endpoint name as a property allows the EndpointConfiguration to serve as the sole information carrier. This is particularly useful when the endpoint name is used as an identifier for keyed services.

2. Enhanced developer experience
Accessing the endpoint name directly is more intuitive, discoverable, and expressive than retrieving it through settings.

3. Simplified integrations
This change streamlines registrations and bindings for the new Functions integration, reducing complexity and boilerplate.