### PR TITLE
Update dependency System.Security.Cryptography.Xml to 10.0.6 (#7700)

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" AutomaticVersionRange="false" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics" Version="10.0.2" AutomaticVersionRange="false" />
     <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.2" AutomaticVersionRange="false" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" AutomaticVersionRange="false" />
   </ItemGroup>
 
   <ItemGroup Label="Private dependencies">


### PR DESCRIPTION

Backport of:
- https://github.com/Particular/NServiceBus/pull/7700

With fixes for the https://github.com/Particular/NServiceBus/tree/release-10.0 release branch:
-  https://github.com/Particular/NServiceBus/issues/7705