### PR TITLE
Expose SendOnly as a read-only property on EndpointConfiguration

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -276,6 +276,7 @@ namespace NServiceBus
     {
         public EndpointConfiguration(string endpointName) { }
         public string EndpointName { get; }
+        public bool IsSendOnly { get; }
         public NServiceBus.Pipeline.PipelineSettings Pipeline { get; }
         public NServiceBus.ConventionsBuilder Conventions() { }
         [System.Obsolete(@"RegisterComponents should only be used when self-hosting endpoints, which is no longer recommended. When using a Microsoft IHostApplicationBuilder-based host, register services directly on the host builder's IServiceCollection. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -26,8 +26,6 @@ public class EndpointConfiguration : ExposeSettings
     {
         ValidateEndpointName(endpointName);
 
-        EndpointName = endpointName;
-
         Settings.Set(new SystemEnvironment());
         Settings.Set("NServiceBus.Routing.EndpointName", endpointName);
 
@@ -78,7 +76,8 @@ public class EndpointConfiguration : ExposeSettings
     /// <summary>
     /// The name of the endpoint.
     /// </summary>
-    public string EndpointName { get; }
+    public string EndpointName => Settings.Get<string>("NServiceBus.Routing.EndpointName");
+
     /// <summary>
     /// Returns true if the endpoint is configured as send-only.
     /// </summary>

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -79,6 +79,10 @@ public class EndpointConfiguration : ExposeSettings
     /// The name of the endpoint.
     /// </summary>
     public string EndpointName { get; }
+    /// <summary>
+    /// Returns true if the endpoint is configured as send-only.
+    /// </summary>
+    public bool IsSendOnly => Settings.Get<bool>("Endpoint.SendOnly");
 
     /// <summary>
     /// Access to the pipeline configuration.


### PR DESCRIPTION
This pull request exposes the 'IsSendOnly' as a get-only property on the `EndpointConfiguration`.

While the send-only state can already be retrieved using:

```csharp
endpointConfiguration.GetSettings().Get<bool>("Endpoint.SendOnly")
```

providing direct access through the configuration offers additional value and improves usability.

### Motivation

This change streamlines registrations and bindings for the new Functions integration to discover whether an endpoint is send-only, reducing complexity and boilerplate.