### PR TITLE
Expose KeyedServiceCollection on SettingsHolder

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -61,9 +61,7 @@ public class EndpointRunner(
 
             behavior.CustomConfig.ForEach(customAction => customAction(endpointConfiguration, scenarioContext));
 
-            services = new KeyedServiceCollectionAdapter(runDescriptor.Services, Name);
-            // This is a little hacky but we wanted to avoid having to change the entire acceptance test infrastructure with the creation and start callbacks
-            endpointConfiguration.Settings.Set(services);
+            services = (KeyedServiceCollectionAdapter)settingsHolder.AddKeyedServiceCollection(runDescriptor.Services, Name);
             endpointConfiguration.Settings.Set("NServiceBus.Hosting.DisableAssemblyScanningValidation", bool.TrueString);
 
             behavior.ServicesBeforeStart.ForEach(customAction => customAction(services, scenarioContext));

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -61,7 +61,7 @@ public class EndpointRunner(
 
             behavior.CustomConfig.ForEach(customAction => customAction(endpointConfiguration, scenarioContext));
 
-            services = (KeyedServiceCollectionAdapter)settingsHolder.AddKeyedServiceCollection(runDescriptor.Services, Name);
+            services = (KeyedServiceCollectionAdapter)settingsHolder.GetOrCreateKeyedServiceCollection(runDescriptor.Services, Name);
             endpointConfiguration.Settings.Set("NServiceBus.Hosting.DisableAssemblyScanningValidation", bool.TrueString);
 
             behavior.ServicesBeforeStart.ForEach(customAction => customAction(services, scenarioContext));

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1266,7 +1266,7 @@ namespace NServiceBus.Configuration.AdvancedExtensibility
     }
     public static class KeyedServicesSettingsExtensions
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddKeyedServiceCollection(this NServiceBus.Settings.SettingsHolder settings, Microsoft.Extensions.DependencyInjection.IServiceCollection services, object serviceKey) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection GetOrCreateKeyedServiceCollection(this NServiceBus.Settings.SettingsHolder settings, Microsoft.Extensions.DependencyInjection.IServiceCollection services, object serviceKey) { }
     }
 }
 namespace NServiceBus.ConsistencyGuarantees

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1264,6 +1264,10 @@ namespace NServiceBus.Configuration.AdvancedExtensibility
     {
         protected ExposeSettings(NServiceBus.Settings.SettingsHolder settings) { }
     }
+    public static class KeyedServicesSettingsExtensions
+    {
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddKeyedServiceCollection(this NServiceBus.Settings.SettingsHolder settings, Microsoft.Extensions.DependencyInjection.IServiceCollection services, object serviceKey) { }
+    }
 }
 namespace NServiceBus.ConsistencyGuarantees
 {

--- a/src/NServiceBus.Core.Tests/Hosting/KeyedServicesSettingsExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Hosting/KeyedServicesSettingsExtensionsTests.cs
@@ -2,7 +2,6 @@
 
 namespace NServiceBus.Core.Tests.Host;
 
-using System;
 using Configuration.AdvancedExtensibility;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -28,7 +27,7 @@ public class KeyedServicesSettingsExtensionsTests
     }
 
     [Test]
-    public void Should_return_existing_adapter_on_repeat_call_with_same_key()
+    public void Should_return_existing_adapter_on_repeat_call()
     {
         var settings = new SettingsHolder();
         var services = new ServiceCollection();
@@ -37,47 +36,5 @@ public class KeyedServicesSettingsExtensionsTests
         var second = settings.GetOrCreateKeyedServiceCollection(services, "endpoint-key");
 
         Assert.That(second, Is.SameAs(first));
-    }
-
-    [Test]
-    public void Should_return_existing_adapter_when_repeat_call_wraps_the_same_key()
-    {
-        var settings = new SettingsHolder();
-        var services = new ServiceCollection();
-
-        var first = settings.GetOrCreateKeyedServiceCollection(services, "endpoint-key");
-        var second = settings.GetOrCreateKeyedServiceCollection(services, new KeyedServiceKey("endpoint-key"));
-
-        Assert.That(second, Is.SameAs(first));
-    }
-
-    [Test]
-    public void Should_throw_when_repeat_call_uses_different_key()
-    {
-        var settings = new SettingsHolder();
-        var services = new ServiceCollection();
-
-        _ = settings.GetOrCreateKeyedServiceCollection(services, "first-key");
-
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-            settings.GetOrCreateKeyedServiceCollection(services, "second-key"));
-
-        Assert.That(ex!.Message, Does.Contain("first-key"));
-        Assert.That(ex.Message, Does.Contain("second-key"));
-    }
-
-    [Test]
-    public void Should_throw_when_repeat_call_uses_different_wrapped_key()
-    {
-        var settings = new SettingsHolder();
-        var services = new ServiceCollection();
-
-        _ = settings.GetOrCreateKeyedServiceCollection(services, "first-key");
-
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-            settings.GetOrCreateKeyedServiceCollection(services, new KeyedServiceKey("second-key")));
-
-        Assert.That(ex!.Message, Does.Contain("first-key"));
-        Assert.That(ex.Message, Does.Contain("second-key"));
     }
 }

--- a/src/NServiceBus.Core.Tests/Hosting/KeyedServicesSettingsExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Hosting/KeyedServicesSettingsExtensionsTests.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+namespace NServiceBus.Core.Tests.Host;
+
+using Configuration.AdvancedExtensibility;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Settings;
+
+[TestFixture]
+public class KeyedServicesSettingsExtensionsTests
+{
+    [Test]
+    public void Should_store_adapter_in_settings_and_return_it()
+    {
+        var settings = new SettingsHolder();
+        var services = new ServiceCollection();
+
+        var returned = settings.AddKeyedServiceCollection(services, "endpoint-key");
+
+        Assert.That(returned, Is.TypeOf<KeyedServiceCollectionAdapter>());
+
+        var adapter = settings.GetOrDefault<KeyedServiceCollectionAdapter>();
+        Assert.That(adapter, Is.SameAs(returned));
+        Assert.That(adapter!.Inner, Is.SameAs(services));
+        Assert.That(adapter.ServiceKey.BaseKey, Is.EqualTo("endpoint-key"));
+    }
+}

--- a/src/NServiceBus.Core.Tests/Hosting/KeyedServicesSettingsExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Hosting/KeyedServicesSettingsExtensionsTests.cs
@@ -2,6 +2,7 @@
 
 namespace NServiceBus.Core.Tests.Host;
 
+using System;
 using Configuration.AdvancedExtensibility;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -16,7 +17,7 @@ public class KeyedServicesSettingsExtensionsTests
         var settings = new SettingsHolder();
         var services = new ServiceCollection();
 
-        var returned = settings.AddKeyedServiceCollection(services, "endpoint-key");
+        var returned = settings.GetOrCreateKeyedServiceCollection(services, "endpoint-key");
 
         Assert.That(returned, Is.TypeOf<KeyedServiceCollectionAdapter>());
 
@@ -24,5 +25,59 @@ public class KeyedServicesSettingsExtensionsTests
         Assert.That(adapter, Is.SameAs(returned));
         Assert.That(adapter!.Inner, Is.SameAs(services));
         Assert.That(adapter.ServiceKey.BaseKey, Is.EqualTo("endpoint-key"));
+    }
+
+    [Test]
+    public void Should_return_existing_adapter_on_repeat_call_with_same_key()
+    {
+        var settings = new SettingsHolder();
+        var services = new ServiceCollection();
+
+        var first = settings.GetOrCreateKeyedServiceCollection(services, "endpoint-key");
+        var second = settings.GetOrCreateKeyedServiceCollection(services, "endpoint-key");
+
+        Assert.That(second, Is.SameAs(first));
+    }
+
+    [Test]
+    public void Should_return_existing_adapter_when_repeat_call_wraps_the_same_key()
+    {
+        var settings = new SettingsHolder();
+        var services = new ServiceCollection();
+
+        var first = settings.GetOrCreateKeyedServiceCollection(services, "endpoint-key");
+        var second = settings.GetOrCreateKeyedServiceCollection(services, new KeyedServiceKey("endpoint-key"));
+
+        Assert.That(second, Is.SameAs(first));
+    }
+
+    [Test]
+    public void Should_throw_when_repeat_call_uses_different_key()
+    {
+        var settings = new SettingsHolder();
+        var services = new ServiceCollection();
+
+        _ = settings.GetOrCreateKeyedServiceCollection(services, "first-key");
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            settings.GetOrCreateKeyedServiceCollection(services, "second-key"));
+
+        Assert.That(ex!.Message, Does.Contain("first-key"));
+        Assert.That(ex.Message, Does.Contain("second-key"));
+    }
+
+    [Test]
+    public void Should_throw_when_repeat_call_uses_different_wrapped_key()
+    {
+        var settings = new SettingsHolder();
+        var services = new ServiceCollection();
+
+        _ = settings.GetOrCreateKeyedServiceCollection(services, "first-key");
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            settings.GetOrCreateKeyedServiceCollection(services, new KeyedServiceKey("second-key")));
+
+        Assert.That(ex!.Message, Does.Contain("first-key"));
+        Assert.That(ex.Message, Does.Contain("second-key"));
     }
 }

--- a/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServicesSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServicesSettingsExtensions.cs
@@ -15,18 +15,29 @@ using Settings;
 public static class KeyedServicesSettingsExtensions
 {
     /// <summary>
-    /// Creates a keyed service collection adapter that wraps <paramref name="services"/> under
-    /// <paramref name="serviceKey"/>, stores it on <paramref name="settings"/>, and returns it.
-    /// <see cref="ServiceCollectionExtensions.AddNServiceBusEndpoint"/> will pick up the preloaded
-    /// adapter instead of creating a new one, allowing the host to share a single adapter with user
-    /// configuration code that runs before the endpoint is registered.
+    /// Returns the keyed service collection adapter stored on <paramref name="settings"/>, creating and
+    /// storing a new one that wraps <paramref name="services"/> under <paramref name="serviceKey"/> on
+    /// the first call. Subsequent calls with the same key return the existing adapter; calls with a
+    /// different key throw <see cref="InvalidOperationException"/>.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static IServiceCollection AddKeyedServiceCollection(this SettingsHolder settings, IServiceCollection services, object serviceKey)
+    public static IServiceCollection GetOrCreateKeyedServiceCollection(this SettingsHolder settings, IServiceCollection services, object serviceKey)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(serviceKey);
+
+        if (settings.GetOrDefault<KeyedServiceCollectionAdapter>() is { } existing)
+        {
+            var requestedBaseKey = serviceKey is KeyedServiceKey key ? key.BaseKey : serviceKey;
+            if (!Equals(existing.ServiceKey.BaseKey, requestedBaseKey))
+            {
+                throw new InvalidOperationException(
+                    $"A keyed service collection has already been registered with key '{existing.ServiceKey.BaseKey}'; cannot register again with key '{requestedBaseKey}'.");
+            }
+
+            return existing;
+        }
 
         var adapter = new KeyedServiceCollectionAdapter(services, serviceKey);
         settings.Set(adapter);

--- a/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServicesSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServicesSettingsExtensions.cs
@@ -1,0 +1,35 @@
+#nullable enable
+
+namespace NServiceBus.Configuration.AdvancedExtensibility;
+
+using System;
+using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
+using Settings;
+
+/// <summary>
+/// Advanced extensibility entry point for adapter-layer hosts that need to pre-create the keyed
+/// service collection adapter used by a keyed NServiceBus endpoint.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class KeyedServicesSettingsExtensions
+{
+    /// <summary>
+    /// Creates a keyed service collection adapter that wraps <paramref name="services"/> under
+    /// <paramref name="serviceKey"/>, stores it on <paramref name="settings"/>, and returns it.
+    /// <see cref="ServiceCollectionExtensions.AddNServiceBusEndpoint"/> will pick up the preloaded
+    /// adapter instead of creating a new one, allowing the host to share a single adapter with user
+    /// configuration code that runs before the endpoint is registered.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static IServiceCollection AddKeyedServiceCollection(this SettingsHolder settings, IServiceCollection services, object serviceKey)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(serviceKey);
+
+        var adapter = new KeyedServiceCollectionAdapter(services, serviceKey);
+        settings.Set(adapter);
+        return adapter;
+    }
+}

--- a/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServicesSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServicesSettingsExtensions.cs
@@ -17,8 +17,7 @@ public static class KeyedServicesSettingsExtensions
     /// <summary>
     /// Returns the keyed service collection adapter stored on <paramref name="settings"/>, creating and
     /// storing a new one that wraps <paramref name="services"/> under <paramref name="serviceKey"/> on
-    /// the first call. Subsequent calls with the same key return the existing adapter; calls with a
-    /// different key throw <see cref="InvalidOperationException"/>.
+    /// the first call. Subsequent calls return the existing adapter.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static IServiceCollection GetOrCreateKeyedServiceCollection(this SettingsHolder settings, IServiceCollection services, object serviceKey)
@@ -29,13 +28,6 @@ public static class KeyedServicesSettingsExtensions
 
         if (settings.GetOrDefault<KeyedServiceCollectionAdapter>() is { } existing)
         {
-            var requestedBaseKey = serviceKey is KeyedServiceKey key ? key.BaseKey : serviceKey;
-            if (!Equals(existing.ServiceKey.BaseKey, requestedBaseKey))
-            {
-                throw new InvalidOperationException(
-                    $"A keyed service collection has already been registered with key '{existing.ServiceKey.BaseKey}'; cannot register again with key '{requestedBaseKey}'.");
-            }
-
             return existing;
         }
 

--- a/src/NServiceBus.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/src/NServiceBus.Core/Hosting/ServiceCollectionExtensions.cs
@@ -89,7 +89,7 @@ public static class ServiceCollectionExtensions
         }
         else
         {
-            // Backdoor for acceptance testing
+            // Use the preloaded adapter from settings.AddKeyedServiceCollection if present; otherwise create one.
             var keyedServices = settings.GetOrDefault<KeyedServiceCollectionAdapter>() ?? new KeyedServiceCollectionAdapter(services, endpointIdentifier);
             var baseKey = keyedServices.ServiceKey.BaseKey;
 

--- a/src/NServiceBus.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/src/NServiceBus.Core/Hosting/ServiceCollectionExtensions.cs
@@ -89,8 +89,7 @@ public static class ServiceCollectionExtensions
         }
         else
         {
-            // Use the preloaded adapter from settings.AddKeyedServiceCollection if present; otherwise create one.
-            var keyedServices = settings.GetOrDefault<KeyedServiceCollectionAdapter>() ?? new KeyedServiceCollectionAdapter(services, endpointIdentifier);
+            var keyedServices = (KeyedServiceCollectionAdapter)settings.GetOrCreateKeyedServiceCollection(services, endpointIdentifier);
             var baseKey = keyedServices.ServiceKey.BaseKey;
 
             // Deliberately creating it here to make sure we are not accidentally doing it too late.


### PR DESCRIPTION
Adds `SettingsHolder.AddKeyedServiceCollection` in `NServiceBus.Configuration.AdvancedExtensibility`. The method creates the keyed service collection adapter used by keyed endpoints and stores it on the settings holder.

### Motivation

`AddNServiceBusEndpoint` and `AddNServiceBusEndpointInstaller` already check the settings holder for a preloaded `KeyedServiceCollectionAdapter` before creating one themselves - originally a backdoor for acceptance tests. Exposing that seam as a public method marked `[EditorBrowsable(Never)]` gives external integrations a compile-time contract without making the internal adapter type public.

### Scope

- New extension in `Hosting/KeyedServices/KeyedServicesSettingsExtensions.cs`
- API approval + unit test