### PR TITLE
Update Particular.Licensing.Sources to 7.0.1 on release-10.0

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup Label="Private dependencies">
     <PackageReference Include="FastExpressionCompiler.Internal.src" Version="5.3.3" PrivateAssets="All" GeneratePathProperty="true" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="7.0.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="7.0.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Obsoletes" Version="1.0.0" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
Related to https://github.com/Particular/NServiceBus/issues/7705

Particular.Licensing.Sources no longer relies on System.Security.Cryptography.Xml

https://github.com/Particular/NServiceBus/compare/10.0.2...particular-licensing-7.0.1-release-10.0