### PR TITLE
Update Particular.Licensing.Sources to 6.1.1 on release-9.2

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Fody" Version="6.8.1" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.9.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="6.1.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="4.2.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Related to https://github.com/Particular/NServiceBus/issues/7705

Particular.Licensing.Sources no longer relies on System.Security.Cryptography.Xml

https://github.com/Particular/NServiceBus/compare/9.2.10...particular-licensing-6.1.1-release-9.2