### PR TITLE
Update Particular.Licensing.Sources package to 5.1.2 on release-8.2

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" AutomaticVersionRange="false" />
     <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" AutomaticVersionRange="false" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" AutomaticVersionRange="false" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" AutomaticVersionRange="false" />
   </ItemGroup>
 

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Fody" Version="6.7.0" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.9.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="5.1.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="5.1.2" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="4.2.0" PrivateAssets="All" />
     <PackageReference Include="PolySharp" Version="1.13.2" PrivateAssets="All" />
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />


### PR DESCRIPTION
Resolves #7707
Resolves #7708

Particular.Licensing.Sources no longer relies on System.Security.Cryptography.Xml

https://github.com/Particular/NServiceBus/compare/8.2.6...particular-licensing-5.1.2-release-8.2