### PR TITLE
Make WriteDiagnosticsToLog additive to the file or custom diagnostic writer

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/DiagnosticsWriterTests.ShouldSupportWritingToLogAndWriter.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/DiagnosticsWriterTests.ShouldSupportWritingToLogAndWriter.approved.txt
@@ -1,0 +1,3 @@
+{"Endpoint":{"EndpointName":"MyEndpointOne"}}
+<timestamp> INFO  TestingLoggerFactory Logging to testing logger with level Debug
+<timestamp> INFO  NServiceBus.HostStartupDiagnosticsWriter Startup diagnostics: {"Endpoint":{"EndpointName":"MyEndpointOne"}}.

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/DiagnosticsWriterTests.ShouldSupportWritingToLogEvenWhenWriterFails.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/DiagnosticsWriterTests.ShouldSupportWritingToLogEvenWhenWriterFails.approved.txt
@@ -1,0 +1,4 @@
+<timestamp> INFO  NServiceBus.HostStartupDiagnosticsWriter Startup diagnostics: {"Endpoint":{"EndpointName":"MyEndpointOne"}}.
+<timestamp> ERROR NServiceBus.HostStartupDiagnosticsWriter Failed to write startup diagnostics using the custom delegate defined by CustomDiagnosticsWriter
+System.InvalidOperationException: Test
+   at NServiceBus.HostStartupDiagnosticsWriter.Write(List`1 entries, CancellationToken cancellationToken) in StartupDiagnostics/HostStartupDiagnosticsWriter.cs

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/DiagnosticsWriterTests.ShouldSupportWritingToLogEvenWhenWriterIsNoOp.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/DiagnosticsWriterTests.ShouldSupportWritingToLogEvenWhenWriterIsNoOp.approved.txt
@@ -1,0 +1,1 @@
+<timestamp> INFO  NServiceBus.HostStartupDiagnosticsWriter Startup diagnostics: {"Endpoint":{"EndpointName":"MyEndpointOne"}}.

--- a/src/NServiceBus.Core.Tests/Helpers/StackTraceScrubber.cs
+++ b/src/NServiceBus.Core.Tests/Helpers/StackTraceScrubber.cs
@@ -1,0 +1,33 @@
+#nullable enable
+
+namespace NServiceBus.Core.Tests.Helpers;
+
+using System;
+using System.Text.RegularExpressions;
+
+public static partial class StackTraceScrubber
+{
+    public static string ScrubFileInfoFromStackTrace(string value)
+    {
+        var scrubbedPaths = StackTracePathRegex().Replace(value, static match =>
+        {
+            var path = match.Groups["path"].Value;
+            var parts = path.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
+
+            return parts.Length switch
+            {
+                >= 2 => $"{parts[^2]}/{parts[^1]}",
+                1 => parts[0],
+                _ => string.Empty
+            };
+        });
+
+        return StackTraceLineInfoRegex().Replace(scrubbedPaths, string.Empty);
+    }
+
+    [GeneratedRegex(@"(?<path>(?:[A-Za-z]:)?(?:[/\\][^:/\\\r\n]+)+\.cs)")]
+    private static partial Regex StackTracePathRegex();
+
+    [GeneratedRegex(@"(?<=\.cs):\p{L}+\s+\d+")]
+    private static partial Regex StackTraceLineInfoRegex();
+}

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/DiagnosticsWriterTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/DiagnosticsWriterTests.cs
@@ -1,14 +1,34 @@
 namespace NServiceBus.Core.Tests.OpenTelemetry;
 
 using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using NServiceBus.Logging;
 using NUnit.Framework;
 using Particular.Approvals;
+using Testing;
+using Tests.Helpers;
 
 [TestFixture]
-public class DiagnosticsWriterTests
+public partial class DiagnosticsWriterTests
 {
+    static StringBuilder logStatements = new StringBuilder();
+
+    [OneTimeSetUp]
+    public void LoggerSetup()
+    {
+#pragma warning disable CS0618 // Use<T> and TestingLoggerFactory (via LoggingFactoryDefinition) are deprecated; test setup uses them intentionally
+        LogManager.Use<TestingLoggerFactory>()
+            .WriteTo(new StringWriter(logStatements));
+#pragma warning restore CS0618
+    }
+
+    [TearDown]
+    public void TearDown() => logStatements.Clear();
+
     [Test]
     public async Task ShouldWriteWhenDuplicateEntriesPresent()
     {
@@ -48,4 +68,54 @@ public class DiagnosticsWriterTests
 
         Approver.Verify(output);
     }
+
+    [Test]
+    public async Task ShouldSupportWritingToLogAndWriter()
+    {
+        var output = string.Empty;
+        var testWriter = new Func<string, CancellationToken, Task>((diagnosticOutput, _) =>
+        {
+            output = diagnosticOutput;
+            return Task.CompletedTask;
+        });
+        var diagnostics = new StartupDiagnosticEntries();
+        diagnostics.Add("Endpoint", new { EndpointName = "MyEndpointOne" });
+
+        var writer = new HostStartupDiagnosticsWriter(testWriter, true, true);
+
+        await writer.Write(diagnostics.entries);
+
+        Approver.Verify(output + Environment.NewLine + logStatements, s => TimestampScrubber().Replace(s, "<timestamp>"));
+    }
+
+    [Test]
+    public async Task ShouldSupportWritingToLogEvenWhenWriterIsNoOp()
+    {
+        var testWriter = new Func<string, CancellationToken, Task>((_, _) => Task.CompletedTask);
+        var diagnostics = new StartupDiagnosticEntries();
+        diagnostics.Add("Endpoint", new { EndpointName = "MyEndpointOne" });
+
+        var writer = new HostStartupDiagnosticsWriter(testWriter, true, true);
+
+        await writer.Write(diagnostics.entries);
+
+        Approver.Verify(logStatements.ToString(), s => TimestampScrubber().Replace(s, "<timestamp>"));
+    }
+
+    [Test]
+    public async Task ShouldSupportWritingToLogEvenWhenWriterFails()
+    {
+        var testWriter = new Func<string, CancellationToken, Task>((_, _) => Task.FromException<InvalidOperationException>(new InvalidOperationException("Test")));
+        var diagnostics = new StartupDiagnosticEntries();
+        diagnostics.Add("Endpoint", new { EndpointName = "MyEndpointOne" });
+
+        var writer = new HostStartupDiagnosticsWriter(testWriter, true, true);
+
+        await writer.Write(diagnostics.entries);
+
+        Approver.Verify(logStatements.ToString(), inputToScrub => StackTraceScrubber.ScrubFileInfoFromStackTrace(TimestampScrubber().Replace(inputToScrub, "<timestamp>")));
+    }
+
+    [GeneratedRegex(@"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}", RegexOptions.Compiled)]
+    private static partial Regex TimestampScrubber();
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineTests.cs
@@ -9,6 +9,7 @@ using System.Runtime.ExceptionServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Extensibility;
+using Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using NServiceBus.Pipeline;
 using NUnit.Framework;
@@ -212,32 +213,8 @@ public partial class PipelineTests
             Assert.That(stackTrace, Does.Not.Contain("PipelineNode"));
         }
 
-        Approver.Verify(stackTrace, scrubber: ScrubFileInfoFromStackTrace);
+        Approver.Verify(stackTrace, scrubber: StackTraceScrubber.ScrubFileInfoFromStackTrace);
     }
-
-    static string ScrubFileInfoFromStackTrace(string value)
-    {
-        var scrubbedPaths = StackTracePathRegex().Replace(value, static match =>
-        {
-            var path = match.Groups["path"].Value;
-            var parts = path.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
-
-            return parts.Length switch
-            {
-                >= 2 => $"{parts[^2]}/{parts[^1]}",
-                1 => parts[0],
-                _ => string.Empty
-            };
-        });
-
-        return StackTraceLineInfoRegex().Replace(scrubbedPaths, string.Empty);
-    }
-
-    [GeneratedRegex(@"(?<path>(?:[A-Za-z]:)?(?:[/\\][^:/\\\r\n]+)+\.cs)")]
-    private static partial Regex StackTracePathRegex();
-
-    [GeneratedRegex(@"(?<=\.cs):\p{L}+\s+\d+")]
-    private static partial Regex StackTraceLineInfoRegex();
 
     class StageFork(string instance, TextWriter writer) : IStageForkConnector<ITransportReceiveContext, IIncomingPhysicalMessageContext, IBatchDispatchContext>
     {

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/DiagnosticSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/DiagnosticSettingsExtensions.cs
@@ -40,7 +40,7 @@ public static class DiagnosticSettingsExtensions
     }
 
     /// <summary>
-    /// Writes diagnostics to log instead of to the file or the custom diagnostic writer.
+    /// Writes diagnostics to log in addition to the file or the custom diagnostic writer.
     /// </summary>
     /// <param name="config">Configuration object to extend.</param>
     public static void WriteDiagnosticsToLog(this EndpointConfiguration config)

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriter.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriter.cs
@@ -23,21 +23,19 @@ class HostStartupDiagnosticsWriter(Func<string, CancellationToken, Task> diagnos
             .Select(e => new { e.Name, Data = e.Data is Func<object> func ? func() : e.Data })
             .ToDictionary(e => e.Name, e => e.Data, StringComparer.OrdinalIgnoreCase);
 
-        // Always compact AssemblyScanning section when writing to log
-        if (writeDiagnosticsToLog &&
-            dictionary.TryGetValue(AssemblyScanningDiagnostics.SectionName, out var assemblyScanningSection) &&
-            assemblyScanningSection is AssemblyScanningDiagnostics assemblyScanningDiagnostics)
+        if (writeDiagnosticsToLog)
         {
-            dictionary[AssemblyScanningDiagnostics.SectionName] = assemblyScanningDiagnostics.CreateCompactedVersion();
-        }
-
-        string data;
-
-        try
-        {
-            data = JsonSerializer.Serialize(dictionary, diagnosticsOptions);
-            if (writeDiagnosticsToLog)
+            var logDictionary = new Dictionary<string, object>(dictionary, StringComparer.OrdinalIgnoreCase);
+            // Always compact AssemblyScanning section when writing to log
+            if (logDictionary.TryGetValue(AssemblyScanningDiagnostics.SectionName, out var assemblyScanningSection) &&
+                assemblyScanningSection is AssemblyScanningDiagnostics assemblyScanningDiagnostics)
             {
+                logDictionary[AssemblyScanningDiagnostics.SectionName] = assemblyScanningDiagnostics.CreateCompactedVersion();
+            }
+
+            try
+            {
+                var data = JsonSerializer.Serialize(logDictionary, diagnosticsOptions);
                 // Safety net: truncate if still exceeds threshold (e.g., due to other large sections)
                 if (data.Length > LogSafeThreshold)
                 {
@@ -45,18 +43,18 @@ class HostStartupDiagnosticsWriter(Func<string, CancellationToken, Task> diagnos
                     data = string.Concat(data.AsSpan(0, LogSafeThreshold), "... (truncated)");
                 }
                 Logger.InfoFormat("Startup diagnostics: {0}.", data);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error("Failed to serialize startup diagnostics", exception);
                 return;
             }
         }
-        catch (Exception exception)
-        {
-            Logger.Error("Failed to serialize startup diagnostics", exception);
-            return;
-        }
+
         try
         {
-            await diagnosticsWriter(data, cancellationToken)
-                .ConfigureAwait(false);
+            var data = JsonSerializer.Serialize(dictionary, diagnosticsOptions);
+            await diagnosticsWriter(data, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
         {


### PR DESCRIPTION
Follow up on #7660 

As part of the work for Azure Functions we realize there are valid reasons to override the custom diagnostic writer to, for example, write the full information to blob storage and optionally write it to the log.

This is why we are making writing to log additive instead of exclusive. The functions default will disable the file writing by providing a no-op writer and customers can then opt-into custom writer themselves and/or writing to the logs.