### PR TITLE
Remove System.Security.Cryptography.Xml dependency from release-9.2

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" AutomaticVersionRange="false" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics" Version="8.0.0" AutomaticVersionRange="false" />
     <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" AutomaticVersionRange="false" />
   </ItemGroup>
 
   <ItemGroup Label="Private dependencies">


### PR DESCRIPTION
Follow up for #7719 