### PR TITLE
Start obsoleting the usage of IncomingMessage on the error context

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/CaptureRecoverabilityActionBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/CaptureRecoverabilityActionBehavior.cs
@@ -18,9 +18,9 @@ class CaptureRecoverabilityActionBehavior(string endpointName, bool doNotFailOnE
             case MoveToError moveToErrorAction:
                 {
                     var failedMessage = new FailedMessage(
-                        context.FailedMessage.MessageId,
-                        new Dictionary<string, string>(context.FailedMessage.Headers),
-                        context.FailedMessage.Body,
+                        context.MessageId,
+                        new Dictionary<string, string>(context.Headers),
+                        context.Body,
                         context.Exception,
                         moveToErrorAction.ErrorQueue);
 
@@ -45,6 +45,6 @@ class CaptureRecoverabilityActionBehavior(string endpointName, bool doNotFailOnE
 
         return;
 
-        void MarkMessageAsCompleted() => scenarioContext.UnfinishedFailedMessages.AddOrUpdate(context.FailedMessage.MessageId, _ => false, static (_, _) => false);
+        void MarkMessageAsCompleted() => scenarioContext.UnfinishedFailedMessages.AddOrUpdate(context.MessageId, _ => false, static (_, _) => false);
     }
 }

--- a/src/NServiceBus.AcceptanceTests/ApprovalFiles/When_pipelines_are_built.Should_preserve_order.approved.txt
+++ b/src/NServiceBus.AcceptanceTests/ApprovalFiles/When_pipelines_are_built.Should_preserve_order.approved.txt
@@ -68,8 +68,9 @@
                                         (IInvokeHandlerContext context10) => InvokeHandlerTerminator.Invoke(context10)))))))))))
 
 (IRecoverabilityContext context0) => CaptureRecoverabilityActionBehavior.Invoke(context0,
-    (IRecoverabilityContext context1) => RecoverabilityRoutingConnector.Invoke(context1,
-        (IRoutingContext context2) => ThrowIfCannotDeferMessageBehavior.Invoke(context2,
-            (IRoutingContext context3) => AttachSenderRelatedInfoOnMessageBehavior.Invoke(context3,
-                (IRoutingContext context4) => RoutingToDispatchConnector.Invoke(context4,
-                    (IDispatchContext context5) => ImmediateDispatchTerminator.Invoke(context5))))))
+    (IRecoverabilityContext context1) => ForceNewParentWhenNecessaryDuringRecoverabilityBehavior.Invoke(context1,
+        (IRecoverabilityContext context2) => RecoverabilityRoutingConnector.Invoke(context2,
+            (IRoutingContext context3) => ThrowIfCannotDeferMessageBehavior.Invoke(context3,
+                (IRoutingContext context4) => AttachSenderRelatedInfoOnMessageBehavior.Invoke(context4,
+                    (IRoutingContext context5) => RoutingToDispatchConnector.Invoke(context5,
+                        (IDispatchContext context6) => ImmediateDispatchTerminator.Invoke(context6)))))))

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_message_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_message_moved_to_error_queue.cs
@@ -1,62 +1,65 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry.Traces;
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using AcceptanceTesting.Support;
 using EndpointTemplates;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting;
+using NServiceBus.Pipeline;
 using NUnit.Framework;
+using Conventions = AcceptanceTesting.Customization.Conventions;
 
 public class When_incoming_message_moved_to_error_queue : OpenTelemetryAcceptanceTest
 {
     [Test]
-    public void Should_add_start_new_trace_header()
+    public async Task Should_add_start_new_trace_header()
     {
-        var exception = Assert.CatchAsync<MessageFailedException>(async () =>
-        {
-            await Scenario.Define<Context>()
-                .WithEndpoint<FailingEndpoint>(e => e
-                    .When(s => s.SendLocal(new FailingMessage())))
-                .Run();
-        });
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<FailingEndpoint>(e => e
+                .When(s => s.SendLocal(new FailingMessage()))
+                .DoNotFailOnErrorMessages())
+            .WithEndpoint<ErrorSpy>()
+            .Run();
 
-        var failedMessage = exception.FailedMessage;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(failedMessage.Headers.ContainsKey(Headers.StartNewTrace), Is.True);
-            Assert.That(failedMessage.Headers[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
-        }
+        Assert.That(context.ErrorMessageHeaders[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
     }
 
     public class Context : ScenarioContext
     {
-        public bool HandlerInvoked { get; set; }
+        public Dictionary<string, string> ErrorMessageHeaders { get; set; }
     }
 
     public class FailingEndpoint : EndpointConfigurationBuilder
     {
-        public FailingEndpoint() => EndpointSetup<DefaultServer>();
+        static readonly string ErrorQueueAddress = Conventions.EndpointNamingConvention(typeof(ErrorSpy));
+
+        public FailingEndpoint() => EndpointSetup<DefaultServer>(c => c.SendFailedMessagesTo(ErrorQueueAddress));
 
         [Handler]
-        public class FailingMessageHandler : IHandleMessages<FailingMessage>
+        public class FailingMessageHandler() : IHandleMessages<FailingMessage>
         {
+            public Task Handle(FailingMessage message, IMessageHandlerContext context) => throw new SimulatedException(ErrorMessage);
+        }
+    }
 
-            Context textContext;
+    class ErrorSpy : EndpointConfigurationBuilder
+    {
+        public ErrorSpy() => EndpointSetup<DefaultServer>(c => c.Pipeline.Register<ErrorMessageDetector>("Detect incoming error messages"));
 
-            public FailingMessageHandler(Context textContext) => this.textContext = textContext;
-
-            public Task Handle(FailingMessage message, IMessageHandlerContext context)
+        class ErrorMessageDetector(Context testContext) : Behavior<ITransportReceiveContext>
+        {
+            public override Task Invoke(ITransportReceiveContext context, Func<Task> next)
             {
-                textContext.HandlerInvoked = true;
-                throw new SimulatedException(ErrorMessage);
+                testContext.ErrorMessageHeaders = context.Message.Headers;
+                testContext.MarkAsCompleted();
+                return next();
             }
         }
     }
 
-    public class FailingMessage : IMessage
-    {
-    }
+    public class FailingMessage : IMessage;
 
     const string ErrorMessage = "oh no!";
 }

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_custom_policy_executed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_custom_policy_executed.cs
@@ -25,10 +25,16 @@ public class When_custom_policy_executed : NServiceBusAcceptanceTest
         Assert.That(context.ErrorContexts, Has.Count.EqualTo(2), "because the custom policy should have been invoked twice");
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(context.ErrorContexts[0].Message, Is.Not.Null);
+            Assert.That(context.ErrorContexts[0].MessageId, Is.Not.Null);
+            Assert.That(context.ErrorContexts[0].NativeMessageId, Is.Not.Null);
+            Assert.That(context.ErrorContexts[0].Headers, Is.Not.Empty);
+            Assert.That(context.ErrorContexts[0].ReceiveProperties, Is.Not.Null);
             Assert.That(context.ErrorContexts[0].Exception, Is.TypeOf<SimulatedException>());
-            Assert.That(context.ErrorContexts[0].DelayedDeliveriesPerformed, Is.EqualTo(0));
-            Assert.That(context.ErrorContexts[1].Message, Is.Not.Null);
+            Assert.That(context.ErrorContexts[0].DelayedDeliveriesPerformed, Is.Zero);
+            Assert.That(context.ErrorContexts[1].MessageId, Is.Not.Null);
+            Assert.That(context.ErrorContexts[1].NativeMessageId, Is.Not.Null);
+            Assert.That(context.ErrorContexts[1].Headers, Is.Not.Empty);
+            Assert.That(context.ErrorContexts[1].ReceiveProperties, Is.Not.Null);
             Assert.That(context.ErrorContexts[1].Exception, Is.TypeOf<SimulatedException>());
             Assert.That(context.ErrorContexts[1].DelayedDeliveriesPerformed, Is.EqualTo(1));
         }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1954,8 +1954,8 @@ namespace NServiceBus.Pipeline
         int DelayedDeliveriesPerformed { get; }
         System.Exception Exception { get; }
         [System.Obsolete("For access to the message body, headers, native message ID or the receive propert" +
-            "ies using the corresponding properties directly exposed on the context.. Will be" +
-            " treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+            "ies use the corresponding properties directly exposed on the context.. Will be t" +
+            "reated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
         NServiceBus.Transport.IncomingMessage FailedMessage { get; }
         System.Collections.Generic.Dictionary<string, string> Headers { get; }
         int ImmediateProcessingFailures { get; }
@@ -2443,8 +2443,8 @@ namespace NServiceBus.Transport
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public int ImmediateProcessingFailures { get; }
         [System.Obsolete("For access to the message body, headers, native message ID or the receive propert" +
-            "ies using the corresponding properties directly exposed on the context.. Will be" +
-            " treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+            "ies use the corresponding properties directly exposed on the context.. Will be t" +
+            "reated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
         public NServiceBus.Transport.IncomingMessage Message { get; }
         public string MessageId { get; }
         public string NativeMessageId { get; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1936,9 +1936,9 @@ namespace NServiceBus.Pipeline
         System.ReadOnlyMemory<byte> Body { get; }
         int DelayedDeliveriesPerformed { get; }
         System.Exception Exception { get; }
-        [System.Obsolete("For access to the message body, headers, native message ID or the receive propert" +
-            "ies using the corresponding properties directly exposed on the context.. Will be" +
-            " treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+        [System.Obsolete("For access to the message body, headers, native message ID, or the receive proper" +
+            "ties use the corresponding properties directly exposed on the context. Will be t" +
+            "reated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
         NServiceBus.Transport.IncomingMessage FailedMessage { get; }
         System.Collections.Generic.Dictionary<string, string> Headers { get; }
         int ImmediateProcessingFailures { get; }
@@ -1953,8 +1953,8 @@ namespace NServiceBus.Pipeline
         System.ReadOnlyMemory<byte> Body { get; }
         int DelayedDeliveriesPerformed { get; }
         System.Exception Exception { get; }
-        [System.Obsolete("For access to the message body, headers, native message ID or the receive propert" +
-            "ies use the corresponding properties directly exposed on the context.. Will be t" +
+        [System.Obsolete("For access to the message body, headers, native message ID, or the receive proper" +
+            "ties use the corresponding properties directly exposed on the context. Will be t" +
             "reated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
         NServiceBus.Transport.IncomingMessage FailedMessage { get; }
         System.Collections.Generic.Dictionary<string, string> Headers { get; }
@@ -2442,8 +2442,8 @@ namespace NServiceBus.Transport
         public NServiceBus.Extensibility.ContextBag Extensions { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public int ImmediateProcessingFailures { get; }
-        [System.Obsolete("For access to the message body, headers, native message ID or the receive propert" +
-            "ies use the corresponding properties directly exposed on the context.. Will be t" +
+        [System.Obsolete("For access to the message body, headers, native message ID, or the receive proper" +
+            "ties use the corresponding properties directly exposed on the context. Will be t" +
             "reated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
         public NServiceBus.Transport.IncomingMessage Message { get; }
         public string MessageId { get; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1933,21 +1933,37 @@ namespace NServiceBus.Pipeline
     }
     public interface IRecoverabilityActionContext : NServiceBus.Extensibility.IExtendable, NServiceBus.ICancellableContext, NServiceBus.Pipeline.IBehaviorContext
     {
+        System.ReadOnlyMemory<byte> Body { get; }
         int DelayedDeliveriesPerformed { get; }
         System.Exception Exception { get; }
+        [System.Obsolete("For access to the message body, headers, native message ID or the receive propert" +
+            "ies using the corresponding properties directly exposed on the context.. Will be" +
+            " treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
         NServiceBus.Transport.IncomingMessage FailedMessage { get; }
+        System.Collections.Generic.Dictionary<string, string> Headers { get; }
         int ImmediateProcessingFailures { get; }
+        string MessageId { get; }
         System.Collections.Generic.IReadOnlyDictionary<string, string> Metadata { get; }
+        string NativeMessageId { get; }
         string ReceiveAddress { get; }
+        NServiceBus.Transport.ReceiveProperties ReceiveProperties { get; }
     }
     public interface IRecoverabilityContext : NServiceBus.Extensibility.IExtendable, NServiceBus.ICancellableContext, NServiceBus.Pipeline.IBehaviorContext
     {
+        System.ReadOnlyMemory<byte> Body { get; }
         int DelayedDeliveriesPerformed { get; }
         System.Exception Exception { get; }
+        [System.Obsolete("For access to the message body, headers, native message ID or the receive propert" +
+            "ies using the corresponding properties directly exposed on the context.. Will be" +
+            " treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
         NServiceBus.Transport.IncomingMessage FailedMessage { get; }
+        System.Collections.Generic.Dictionary<string, string> Headers { get; }
         int ImmediateProcessingFailures { get; }
+        string MessageId { get; }
         System.Collections.Generic.Dictionary<string, string> Metadata { get; }
+        string NativeMessageId { get; }
         string ReceiveAddress { get; }
+        NServiceBus.Transport.ReceiveProperties ReceiveProperties { get; }
         NServiceBus.RecoverabilityAction RecoverabilityAction { get; set; }
         NServiceBus.RecoverabilityConfig RecoverabilityConfiguration { get; }
         NServiceBus.Pipeline.IRecoverabilityActionContext PreventChanges();
@@ -2420,12 +2436,20 @@ namespace NServiceBus.Transport
     {
         public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string nativeMessageId, System.ReadOnlyMemory<byte> body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures, string receiveAddress, NServiceBus.Extensibility.ContextBag context) { }
         public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string nativeMessageId, System.ReadOnlyMemory<byte> body, NServiceBus.Transport.ReceiveProperties receiveProperties, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures, string receiveAddress, NServiceBus.Extensibility.ContextBag context) { }
+        public System.ReadOnlyMemory<byte> Body { get; }
         public int DelayedDeliveriesPerformed { get; }
         public System.Exception Exception { get; }
         public NServiceBus.Extensibility.ContextBag Extensions { get; }
+        public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public int ImmediateProcessingFailures { get; }
+        [System.Obsolete("For access to the message body, headers, native message ID or the receive propert" +
+            "ies using the corresponding properties directly exposed on the context.. Will be" +
+            " treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
         public NServiceBus.Transport.IncomingMessage Message { get; }
+        public string MessageId { get; }
+        public string NativeMessageId { get; }
         public string ReceiveAddress { get; }
+        public NServiceBus.Transport.ReceiveProperties ReceiveProperties { get; }
         public NServiceBus.Transport.TransportTransaction TransportTransaction { get; }
     }
     public enum ErrorHandleResult

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ForceNewParentWhenNecessaryDuringRecoverabilityBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ForceNewParentWhenNecessaryDuringRecoverabilityBehaviorTests.cs
@@ -1,0 +1,65 @@
+namespace NServiceBus.Core.Tests.OpenTelemetry;
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Testing;
+
+[TestFixture]
+public class ForceNewParentWhenNecessaryDuringRecoverabilityBehaviorTests
+{
+    [Test]
+    public async Task Should_not_modify_when_trace_not_present()
+    {
+        var behavior = new ForceNewParentWhenNecessaryDuringRecoverabilityBehavior();
+
+        var context = new TestableRecoverabilityContext();
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(context.Headers, Does.Not.ContainKey(Headers.StartNewTrace));
+            Assert.That(context.Metadata, Does.Not.ContainKey(Headers.StartNewTrace));
+        }
+    }
+
+    [Test]
+    public async Task Should_add_start_new_trace_header_when_trace_present_during_delayed_delivery()
+    {
+        var behavior = new ForceNewParentWhenNecessaryDuringRecoverabilityBehavior();
+
+        var context = new TestableRecoverabilityContext
+        {
+            Headers = { { Headers.DiagnosticsTraceParent, "traceparent" } },
+            RecoverabilityAction = new DelayedRetry(TimeSpan.FromSeconds(10))
+        };
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(context.Headers, Does.ContainKey(Headers.StartNewTrace));
+            Assert.That(context.Metadata, Does.ContainKey(Headers.StartNewTrace));
+        }
+    }
+
+    [Test]
+    public async Task Should_add_start_new_trace_metadata_when_trace_present_during_move_to_error()
+    {
+        var behavior = new ForceNewParentWhenNecessaryDuringRecoverabilityBehavior();
+
+        var context = new TestableRecoverabilityContext
+        {
+            Headers = { { Headers.DiagnosticsTraceParent, "traceparent" } },
+            RecoverabilityAction = new MoveToError("errorqueue")
+        };
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(context.Headers, Does.Not.ContainKey(Headers.StartNewTrace));
+            Assert.That(context.Metadata, Does.ContainKey(Headers.StartNewTrace));
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryRecoverabilityActionTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryRecoverabilityActionTests.cs
@@ -46,14 +46,12 @@ public class DelayedRetryRecoverabilityActionTests
         var now = DateTimeOffset.UtcNow;
         var routingContexts = delayedRetryAction.GetRoutingContexts(recoverabilityContext);
 
-        var incomingMessage = recoverabilityContext.FailedMessage;
-
         var outgoingMessageHeaders = routingContexts.Single().Message.Headers;
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(outgoingMessageHeaders[Headers.DelayedRetries], Is.EqualTo("3"));
-            Assert.That(incomingMessage.Headers[Headers.DelayedRetries], Is.EqualTo(delayedDeliveriesPerformed.ToString()));
+            Assert.That(recoverabilityContext.Headers[Headers.DelayedRetries], Is.EqualTo(delayedDeliveriesPerformed.ToString()));
         }
 
         var utcDateTime = DateTimeOffsetHelper.ToDateTimeOffset(outgoingMessageHeaders[Headers.DelayedRetriesTimestamp]);
@@ -62,7 +60,7 @@ public class DelayedRetryRecoverabilityActionTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(utcDateTime, Is.GreaterThanOrEqualTo(adjustedNow));
-            Assert.That(incomingMessage.Headers[Headers.DelayedRetriesTimestamp], Is.EqualTo(originalHeadersTimestamp));
+            Assert.That(recoverabilityContext.Headers[Headers.DelayedRetriesTimestamp], Is.EqualTo(originalHeadersTimestamp));
         }
     }
 
@@ -79,18 +77,18 @@ public class DelayedRetryRecoverabilityActionTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(outgoingMessageHeaders[Headers.DelayedRetries], Is.EqualTo("1"));
-            Assert.That(recoverabilityContext.FailedMessage.Headers.ContainsKey(Headers.DelayedRetries), Is.False);
+            Assert.That(recoverabilityContext.Headers.ContainsKey(Headers.DelayedRetries), Is.False);
             Assert.That(outgoingMessageHeaders.ContainsKey(Headers.DelayedRetriesTimestamp), Is.True);
-            Assert.That(recoverabilityContext.FailedMessage.Headers.ContainsKey(Headers.DelayedRetriesTimestamp), Is.False);
+            Assert.That(recoverabilityContext.Headers.ContainsKey(Headers.DelayedRetriesTimestamp), Is.False);
         }
     }
 
-    static TestableRecoverabilityContext CreateRecoverabilityContext(Dictionary<string, string> headers = null, int delayedDeliveriesPerformed = 0)
-    {
-        return new TestableRecoverabilityContext
+    static TestableRecoverabilityContext CreateRecoverabilityContext(Dictionary<string, string> headers = null, int delayedDeliveriesPerformed = 0) =>
+        new()
         {
-            FailedMessage = new IncomingMessage("messageId", headers ?? [], ReadOnlyMemory<byte>.Empty),
+            MessageId = "messageId",
+            Headers = headers ?? [],
+            Body = ReadOnlyMemory<byte>.Empty,
             DelayedDeliveriesPerformed = delayedDeliveriesPerformed
         };
-    }
 }

--- a/src/NServiceBus.Core.Tests/Recoverability/ErrorContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/ErrorContextTests.cs
@@ -39,8 +39,8 @@ public class ErrorContextTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(errorContext.Message.ReceiveProperties, Is.SameAs(receiveProperties));
-            Assert.That(errorContext.Message.ReceiveProperties["Native.Key"], Is.EqualTo("Value"));
+            Assert.That(errorContext.ReceiveProperties, Is.SameAs(receiveProperties));
+            Assert.That(errorContext.ReceiveProperties["Native.Key"], Is.EqualTo("Value"));
         }
     }
 
@@ -60,6 +60,6 @@ public class ErrorContextTests
             context: context
         );
 
-        Assert.That(errorContext.Message.ReceiveProperties, Is.SameAs(ReceiveProperties.Empty));
+        Assert.That(errorContext.ReceiveProperties, Is.SameAs(ReceiveProperties.Empty));
     }
 }

--- a/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
@@ -48,7 +48,7 @@ public class MoveToErrorsExecutorTests
 
         var outgoingMessageHeaders = routingContext.Message.Headers;
 
-        Assert.That(recoverabilityContext.FailedMessage.Headers, Is.SupersetOf(outgoingMessageHeaders));
+        Assert.That(recoverabilityContext.Headers, Is.SupersetOf(outgoingMessageHeaders));
     }
 
     [Test]
@@ -85,7 +85,7 @@ public class MoveToErrorsExecutorTests
         {
             Assert.That(outgoingMessageHeaders, Contains.Item(new KeyValuePair<string, string>("staticFaultMetadataKey", "staticFaultMetadataValue")));
             // check for leaking headers
-            Assert.That(recoverabilityContext.FailedMessage.Headers.ContainsKey("staticFaultMetadataKey"), Is.False);
+            Assert.That(recoverabilityContext.Headers.ContainsKey("staticFaultMetadataKey"), Is.False);
         }
     }
 
@@ -93,11 +93,13 @@ public class MoveToErrorsExecutorTests
     {
         var recoverabilityContext = new TestableRecoverabilityContext
         {
-            FailedMessage = new IncomingMessage(messageId, messageHeaders ?? [], ReadOnlyMemory<byte>.Empty),
+            MessageId = messageId,
+            Headers = messageHeaders ?? [],
+            Body = ReadOnlyMemory<byte>.Empty,
             Exception = raisedException ?? new Exception(exceptionMessage)
         };
 
-        if (metadata != default)
+        if (metadata != null)
         {
             recoverabilityContext.Metadata = metadata;
         }

--- a/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
@@ -1,10 +1,10 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
-    using NServiceBus;
     using System;
     using System.Reflection;
     using MessageNamespaceA;
     using MessageNamespaceB;
+    using NServiceBus;
     using NServiceBus.Features;
     using NServiceBus.Routing;
     using NUnit.Framework;

--- a/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Routing;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryFeature.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryFeature.cs
@@ -17,5 +17,10 @@ sealed class OpenTelemetryFeature : Feature
             new OpenTelemetrySendBehavior(),
             "Manages the depth of the trace for sends"
         );
+
+        context.Pipeline.Register(
+            new ForceNewParentWhenNecessaryDuringRecoverabilityBehavior(),
+            "Overrides the parent trace when necessary during recoverability to avoid creating a child trace of the delayed or failed message's trace"
+        );
     }
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ForceNewParentWhenNecessaryDuringRecoverabilityBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ForceNewParentWhenNecessaryDuringRecoverabilityBehavior.cs
@@ -1,0 +1,31 @@
+namespace NServiceBus;
+
+using System;
+using System.Threading.Tasks;
+using Pipeline;
+
+class ForceNewParentWhenNecessaryDuringRecoverabilityBehavior : IBehavior<IRecoverabilityContext, IRecoverabilityContext>
+{
+    public Task Invoke(IRecoverabilityContext context, Func<IRecoverabilityContext, Task> next)
+    {
+        if (!context.Headers.ContainsKey(Headers.DiagnosticsTraceParent))
+        {
+            return next(context);
+        }
+
+        if (context.RecoverabilityAction is MoveToError or DelayedRetry)
+        {
+            // Setting it to the metadata makes sure it is propagated to the headers
+            // even in more advanced scenarios like native dead-lettering
+            context.Metadata[Headers.StartNewTrace] = bool.TrueString;
+        }
+
+        // DelayedRetry never uses fault metadata so we have to populate it manually to the header
+        if (context.RecoverabilityAction is DelayedRetry)
+        {
+            context.Headers[Headers.StartNewTrace] = context.Metadata[Headers.StartNewTrace];
+        }
+
+        return next(context);
+    }
+}

--- a/src/NServiceBus.Core/Recoverability/DefaultRecoverabilityPolicy.cs
+++ b/src/NServiceBus.Core/Recoverability/DefaultRecoverabilityPolicy.cs
@@ -3,6 +3,7 @@
 namespace NServiceBus;
 
 using System;
+using System.Collections.Generic;
 using Transport;
 
 /// <summary>
@@ -33,7 +34,7 @@ public static class DefaultRecoverabilityPolicy
             return RecoverabilityAction.ImmediateRetry();
         }
 
-        if (TryGetDelay(errorContext.Message, errorContext.DelayedDeliveriesPerformed, config.Delayed, out var delay))
+        if (TryGetDelay(errorContext.Headers, errorContext.DelayedDeliveriesPerformed, config.Delayed, out var delay))
         {
             return RecoverabilityAction.DelayedRetry(delay);
         }
@@ -41,7 +42,7 @@ public static class DefaultRecoverabilityPolicy
         return RecoverabilityAction.MoveToError(config.Failed.ErrorQueue);
     }
 
-    static bool TryGetDelay(IncomingMessage message, int delayedDeliveriesPerformed, DelayedConfig config, out TimeSpan delay)
+    static bool TryGetDelay(Dictionary<string, string> headers, int delayedDeliveriesPerformed, DelayedConfig config, out TimeSpan delay)
     {
         delay = TimeSpan.MinValue;
 
@@ -55,7 +56,7 @@ public static class DefaultRecoverabilityPolicy
             return false;
         }
 
-        if (HasReachedMaxTime(message))
+        if (HasReachedMaxTime(headers))
         {
             return false;
         }
@@ -65,9 +66,9 @@ public static class DefaultRecoverabilityPolicy
         return true;
     }
 
-    static bool HasReachedMaxTime(IncomingMessage message)
+    static bool HasReachedMaxTime(Dictionary<string, string> headers)
     {
-        if (!message.Headers.TryGetValue(Headers.DelayedRetriesTimestamp, out var timestampHeader))
+        if (!headers.TryGetValue(Headers.DelayedRetriesTimestamp, out var timestampHeader))
         {
             return false;
         }
@@ -96,5 +97,4 @@ public static class DefaultRecoverabilityPolicy
 
         return false;
     }
-
 }

--- a/src/NServiceBus.Core/Recoverability/DelayedRetriesHeaderExtensions.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetriesHeaderExtensions.cs
@@ -3,22 +3,22 @@
 namespace NServiceBus;
 
 using System;
+using System.Collections.Generic;
 using Transport;
 
 static class DelayedRetriesHeaderExtensions
 {
-    public static int GetDelayedDeliveriesPerformed(this IncomingMessage message)
+    internal static int GetDelayedDeliveriesPerformed(this Dictionary<string, string> headers)
     {
-        if (message.Headers.TryGetValue(Headers.DelayedRetries, out var value))
+        if (headers.TryGetValue(Headers.DelayedRetries, out var delayedDeliveriesPerformedHeader) && int.TryParse(delayedDeliveriesPerformedHeader, out var delayedDeliveriesPerformed))
         {
-            if (int.TryParse(value, out var i))
-            {
-                return i;
-            }
+            return delayedDeliveriesPerformed;
         }
 
         return 0;
     }
+
+    public static int GetDelayedDeliveriesPerformed(this IncomingMessage message) => message.Headers.GetDelayedDeliveriesPerformed();
 
     public static void SetCurrentDelayedDeliveries(this OutgoingMessage message, int currentDelayedRetry)
     {
@@ -29,8 +29,5 @@ static class DelayedRetriesHeaderExtensions
         }
     }
 
-    public static void SetDelayedDeliveryTimestamp(this OutgoingMessage message, DateTimeOffset timestamp)
-    {
-        message.Headers[Headers.DelayedRetriesTimestamp] = DateTimeOffsetHelper.ToWireFormattedString(timestamp);
-    }
+    public static void SetDelayedDeliveryTimestamp(this OutgoingMessage message, DateTimeOffset timestamp) => message.Headers[Headers.DelayedRetriesTimestamp] = DateTimeOffsetHelper.ToWireFormattedString(timestamp);
 }

--- a/src/NServiceBus.Core/Recoverability/DelayedRetriesHeaderExtensions.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetriesHeaderExtensions.cs
@@ -20,14 +20,7 @@ static class DelayedRetriesHeaderExtensions
 
     public static int GetDelayedDeliveriesPerformed(this IncomingMessage message) => message.Headers.GetDelayedDeliveriesPerformed();
 
-    public static void SetCurrentDelayedDeliveries(this OutgoingMessage message, int currentDelayedRetry)
-    {
-        message.Headers[Headers.DelayedRetries] = currentDelayedRetry.ToString();
-        if (message.Headers.ContainsKey(Headers.DiagnosticsTraceParent))
-        {
-            message.Headers[Headers.StartNewTrace] = bool.TrueString;
-        }
-    }
+    public static void SetCurrentDelayedDeliveries(this OutgoingMessage message, int currentDelayedRetry) => message.Headers[Headers.DelayedRetries] = currentDelayedRetry.ToString();
 
     public static void SetDelayedDeliveryTimestamp(this OutgoingMessage message, DateTimeOffset timestamp) => message.Headers[Headers.DelayedRetriesTimestamp] = DateTimeOffsetHelper.ToWireFormattedString(timestamp);
 }

--- a/src/NServiceBus.Core/Recoverability/DelayedRetry.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetry.cs
@@ -34,12 +34,11 @@ public class DelayedRetry : RecoverabilityAction
     /// <inheritdoc />
     public override IReadOnlyCollection<IRoutingContext> GetRoutingContexts(IRecoverabilityActionContext context)
     {
-        var message = context.FailedMessage;
         var exception = context.Exception;
 
-        Logger.Warn($"Delayed Retry will reschedule message '{message.MessageId}' after a delay of {Delay} because of an exception:", exception);
+        Logger.Warn($"Delayed Retry will reschedule message '{context.MessageId}' after a delay of {Delay} because of an exception:", exception);
 
-        var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
+        var outgoingMessage = new OutgoingMessage(context.MessageId, new Dictionary<string, string>(context.Headers), context.Body);
 
         var currentDelayedRetriesAttempt = context.DelayedDeliveriesPerformed + 1;
 
@@ -49,7 +48,11 @@ public class DelayedRetry : RecoverabilityAction
                 attempt: currentDelayedRetriesAttempt,
                 delay: Delay,
                 immediateRetry: false,
-                message,
+                context.NativeMessageId,
+                context.MessageId,
+                context.Headers,
+                context.Body,
+                context.ReceiveProperties,
                 exception));
         }
 
@@ -61,7 +64,7 @@ public class DelayedRetry : RecoverabilityAction
         {
             DelayDeliveryWith = new DelayDeliveryWith(Delay)
         });
-        return new[] { routingContext };
+        return [routingContext];
     }
 
     static readonly ILog Logger = LogManager.GetLogger<DelayedRetry>();

--- a/src/NServiceBus.Core/Recoverability/Discard.cs
+++ b/src/NServiceBus.Core/Recoverability/Discard.cs
@@ -2,7 +2,6 @@
 
 namespace NServiceBus;
 
-using System;
 using System.Collections.Generic;
 using Logging;
 using Pipeline;
@@ -16,10 +15,7 @@ public class Discard : RecoverabilityAction
     /// <summary>
     /// Creates the action with the stated reason.
     /// </summary>
-    public Discard(string reason)
-    {
-        Reason = reason;
-    }
+    public Discard(string reason) => Reason = reason;
 
     /// <summary>
     /// The reason why a message was discarded.
@@ -34,8 +30,8 @@ public class Discard : RecoverabilityAction
     /// <inheritdoc />
     public override IReadOnlyCollection<IRoutingContext> GetRoutingContexts(IRecoverabilityActionContext context)
     {
-        Logger.Info($"Discarding message with id '{context.FailedMessage.MessageId}'. Reason: {Reason}", context.Exception);
-        return Array.Empty<IRoutingContext>();
+        Logger.Info($"Discarding message with id '{context.MessageId}'. Reason: {Reason}", context.Exception);
+        return [];
     }
 
     static readonly ILog Logger = LogManager.GetLogger<Discard>();

--- a/src/NServiceBus.Core/Recoverability/Faults/MessageFaulted.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MessageFaulted.cs
@@ -3,9 +3,10 @@
 namespace NServiceBus;
 
 using System;
+using System.Collections.Generic;
 using Transport;
 
-sealed class MessageFaulted(string errorQueue, IncomingMessage failedMessage, Exception exception) : MessageProcessingFailed(failedMessage, exception)
+sealed class MessageFaulted(string errorQueue, string nativeMessageId, string messageId, Dictionary<string, string> headers, ReadOnlyMemory<byte> body, ReceiveProperties receiveProperties, Exception exception) : MessageProcessingFailed(nativeMessageId, messageId, headers, body, receiveProperties, exception)
 {
     public string ErrorQueue { get; } = errorQueue;
 }

--- a/src/NServiceBus.Core/Recoverability/Faults/MessageProcessingFailed.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MessageProcessingFailed.cs
@@ -3,10 +3,15 @@
 namespace NServiceBus;
 
 using System;
+using System.Collections.Generic;
 using Transport;
 
-abstract class MessageProcessingFailed(IncomingMessage failedMessage, Exception exception)
+abstract class MessageProcessingFailed(string nativeMessageId, string messageId, Dictionary<string, string> headers, ReadOnlyMemory<byte> body, ReceiveProperties receiveProperties, Exception exception)
 {
-    public IncomingMessage Message { get; } = failedMessage;
+    public string NativeMessageId { get; } = nativeMessageId;
+    public string MessageId { get; } = messageId;
+    public Dictionary<string, string> Headers { get; } = headers;
+    public ReadOnlyMemory<byte> Body { get; } = body;
+    public ReceiveProperties ReceiveProperties { get; } = receiveProperties;
     public Exception Exception { get; } = exception;
 }

--- a/src/NServiceBus.Core/Recoverability/Faults/MessageToBeRetried.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MessageToBeRetried.cs
@@ -3,10 +3,11 @@
 namespace NServiceBus;
 
 using System;
+using System.Collections.Generic;
 using Transport;
 
-sealed class MessageToBeRetried(int attempt, TimeSpan delay, bool immediateRetry, IncomingMessage failedMessage, Exception exception)
-    : MessageProcessingFailed(failedMessage, exception)
+sealed class MessageToBeRetried(int attempt, TimeSpan delay, bool immediateRetry, string nativeMessageId, string messageId, Dictionary<string, string> headers, ReadOnlyMemory<byte> body, ReceiveProperties receiveProperties, Exception exception)
+    : MessageProcessingFailed(nativeMessageId, messageId, headers, body, receiveProperties, exception)
 {
     public int Attempt { get; } = attempt;
     public TimeSpan Delay { get; } = delay;

--- a/src/NServiceBus.Core/Recoverability/IRecoverabilityActionContext.cs
+++ b/src/NServiceBus.Core/Recoverability/IRecoverabilityActionContext.cs
@@ -15,8 +15,8 @@ public interface IRecoverabilityActionContext : IBehaviorContext
     /// <summary>
     /// The message that failed processing.
     /// </summary>
-    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID or the receive properties using the corresponding properties directly exposed on the context.", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
-    [Obsolete("For access to the message body, headers, native message ID or the receive properties using the corresponding properties directly exposed on the context.. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID, or the receive properties use the corresponding properties directly exposed on the context", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
+    [Obsolete("For access to the message body, headers, native message ID, or the receive properties use the corresponding properties directly exposed on the context. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
     IncomingMessage FailedMessage { get; }
 
 #pragma warning disable CS0618 // Type or member is obsolete. once FailedMessage is removed simply turn these properties into get only properties.

--- a/src/NServiceBus.Core/Recoverability/IRecoverabilityActionContext.cs
+++ b/src/NServiceBus.Core/Recoverability/IRecoverabilityActionContext.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Pipeline;
 using System;
 using System.Collections.Generic;
 using NServiceBus.Transport;
+using Particular.Obsoletes;
 
 /// <summary>
 /// Provide context to recoverability actions.
@@ -14,7 +15,36 @@ public interface IRecoverabilityActionContext : IBehaviorContext
     /// <summary>
     /// The message that failed processing.
     /// </summary>
+    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID or the receive properties using the corresponding properties directly exposed on the context.", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
+    [Obsolete("For access to the message body, headers, native message ID or the receive properties using the corresponding properties directly exposed on the context.. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
     IncomingMessage FailedMessage { get; }
+
+#pragma warning disable CS0618 // Type or member is obsolete. once FailedMessage is removed simply turn these properties into get only properties.
+    /// <summary>
+    /// The message ID of the failed message.
+    /// </summary>
+    string MessageId => FailedMessage.MessageId;
+
+    /// <summary>
+    /// The native message ID of the failed message.
+    /// </summary>
+    string NativeMessageId => FailedMessage.NativeMessageId;
+
+    /// <summary>
+    /// The message headers of the failed message.
+    /// </summary>
+    Dictionary<string, string> Headers => FailedMessage.Headers;
+
+    /// <summary>
+    /// The message body of the failed message.
+    /// </summary>
+    ReadOnlyMemory<byte> Body => FailedMessage.Body;
+
+    /// <summary>
+    /// Properties received from the transport that can be propagated to outgoing dispatch operations.
+    /// </summary>
+    ReceiveProperties ReceiveProperties => FailedMessage.ReceiveProperties;
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     /// The exception that caused processing to fail.

--- a/src/NServiceBus.Core/Recoverability/IRecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/IRecoverabilityContext.cs
@@ -15,8 +15,8 @@ public interface IRecoverabilityContext : IBehaviorContext
     /// <summary>
     /// The message that failed processing.
     /// </summary>
-    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID or the receive properties using the corresponding properties directly exposed on the context.", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
-    [Obsolete("For access to the message body, headers, native message ID or the receive properties using the corresponding properties directly exposed on the context.. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID or the receive properties use the corresponding properties directly exposed on the context.", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
+    [Obsolete("For access to the message body, headers, native message ID or the receive properties use the corresponding properties directly exposed on the context.. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
     IncomingMessage FailedMessage { get; }
 
 #pragma warning disable CS0618 // Type or member is obsolete. once FailedMessage is removed simply turn these properties into get only properties.
@@ -41,7 +41,7 @@ public interface IRecoverabilityContext : IBehaviorContext
     ReadOnlyMemory<byte> Body => FailedMessage.Body;
 
     /// <summary>
-    /// Properties received from the transport that can be propagated to outgoing dispatch operations.
+    /// Properties received from the transport that will be propagated to outgoing dispatch operations.
     /// </summary>
     ReceiveProperties ReceiveProperties => FailedMessage.ReceiveProperties;
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/NServiceBus.Core/Recoverability/IRecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/IRecoverabilityContext.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Pipeline;
 using System;
 using System.Collections.Generic;
 using NServiceBus.Transport;
+using Particular.Obsoletes;
 
 /// <summary>
 /// Provide context to behaviors on the recoverability pipeline.
@@ -14,7 +15,36 @@ public interface IRecoverabilityContext : IBehaviorContext
     /// <summary>
     /// The message that failed processing.
     /// </summary>
+    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID or the receive properties using the corresponding properties directly exposed on the context.", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
+    [Obsolete("For access to the message body, headers, native message ID or the receive properties using the corresponding properties directly exposed on the context.. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
     IncomingMessage FailedMessage { get; }
+
+#pragma warning disable CS0618 // Type or member is obsolete. once FailedMessage is removed simply turn these properties into get only properties.
+    /// <summary>
+    /// The message ID of the failed message.
+    /// </summary>
+    string MessageId => FailedMessage.MessageId;
+
+    /// <summary>
+    /// The native message ID of the failed message.
+    /// </summary>
+    string NativeMessageId => FailedMessage.NativeMessageId;
+
+    /// <summary>
+    /// The message headers of the failed message.
+    /// </summary>
+    Dictionary<string, string> Headers => FailedMessage.Headers;
+
+    /// <summary>
+    /// The message body of the failed message.
+    /// </summary>
+    ReadOnlyMemory<byte> Body => FailedMessage.Body;
+
+    /// <summary>
+    /// Properties received from the transport that can be propagated to outgoing dispatch operations.
+    /// </summary>
+    ReceiveProperties ReceiveProperties => FailedMessage.ReceiveProperties;
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     /// The exception that caused processing to fail.

--- a/src/NServiceBus.Core/Recoverability/IRecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/IRecoverabilityContext.cs
@@ -15,8 +15,8 @@ public interface IRecoverabilityContext : IBehaviorContext
     /// <summary>
     /// The message that failed processing.
     /// </summary>
-    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID or the receive properties use the corresponding properties directly exposed on the context.", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
-    [Obsolete("For access to the message body, headers, native message ID or the receive properties use the corresponding properties directly exposed on the context.. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID, or the receive properties use the corresponding properties directly exposed on the context", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
+    [Obsolete("For access to the message body, headers, native message ID, or the receive properties use the corresponding properties directly exposed on the context. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
     IncomingMessage FailedMessage { get; }
 
 #pragma warning disable CS0618 // Type or member is obsolete. once FailedMessage is removed simply turn these properties into get only properties.

--- a/src/NServiceBus.Core/Recoverability/ImmediateRetry.cs
+++ b/src/NServiceBus.Core/Recoverability/ImmediateRetry.cs
@@ -28,20 +28,23 @@ public class ImmediateRetry : RecoverabilityAction
     /// <inheritdoc />
     public override IReadOnlyCollection<IRoutingContext> GetRoutingContexts(IRecoverabilityActionContext context)
     {
-        var message = context.FailedMessage;
         var exception = context.Exception;
 
-        Logger.Info($"Immediate Retry is going to retry message '{message.MessageId}' because of an exception:", exception);
+        Logger.Info($"Immediate Retry is going to retry message '{context.MessageId}' because of an exception:", exception);
         if (context is IRecoverabilityActionContextNotifications notifications)
         {
             notifications.Add(new MessageToBeRetried(
                 attempt: context.ImmediateProcessingFailures - 1,
                 delay: TimeSpan.Zero,
                 immediateRetry: true,
-                message,
+                context.NativeMessageId,
+                context.MessageId,
+                context.Headers,
+                context.Body,
+                context.ReceiveProperties,
                 exception));
         }
-        return Array.Empty<IRoutingContext>();
+        return [];
     }
 
     static readonly ILog Logger = LogManager.GetLogger<ImmediateRetry>();

--- a/src/NServiceBus.Core/Recoverability/MoveToError.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToError.cs
@@ -49,8 +49,7 @@ public class MoveToError : RecoverabilityAction
 
         if (context.Headers.ContainsKey(Headers.DiagnosticsTraceParent))
         {
-            // TODO: Bug?
-            context.Headers[Headers.StartNewTrace] = bool.TrueString;
+            outgoingMessageHeaders[Headers.StartNewTrace] = bool.TrueString;
         }
 
         foreach (var faultMetadata in metadata)

--- a/src/NServiceBus.Core/Recoverability/MoveToError.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToError.cs
@@ -47,11 +47,6 @@ public class MoveToError : RecoverabilityAction
         _ = outgoingMessageHeaders.Remove(Headers.ImmediateRetries);
         var outgoingMessage = new OutgoingMessage(context.MessageId, outgoingMessageHeaders, context.Body);
 
-        if (context.Headers.ContainsKey(Headers.DiagnosticsTraceParent))
-        {
-            outgoingMessageHeaders[Headers.StartNewTrace] = bool.TrueString;
-        }
-
         foreach (var faultMetadata in metadata)
         {
             outgoingMessageHeaders[faultMetadata.Key] = faultMetadata.Value;

--- a/src/NServiceBus.Core/Recoverability/MoveToError.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToError.cs
@@ -33,35 +33,34 @@ public class MoveToError : RecoverabilityAction
     public override IReadOnlyCollection<IRoutingContext> GetRoutingContexts(IRecoverabilityActionContext context)
     {
         var metadata = context.Metadata;
-        var message = context.FailedMessage;
         var exception = context.Exception;
 
-        Logger.Error($"Moving message '{message.MessageId}' to the error queue '{ErrorQueue}' because processing failed due to an exception:", exception);
+        Logger.Error($"Moving message '{context.MessageId}' to the error queue '{ErrorQueue}' because processing failed due to an exception:", exception);
 
         if (context is IRecoverabilityActionContextNotifications notifications)
         {
-            notifications.Add(new MessageFaulted(ErrorQueue, message, exception));
+            notifications.Add(new MessageFaulted(ErrorQueue, context.NativeMessageId, context.MessageId, context.Headers, context.Body, context.ReceiveProperties, exception));
         }
 
-        var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
+        var outgoingMessageHeaders = new Dictionary<string, string>(context.Headers);
+        _ = outgoingMessageHeaders.Remove(Headers.DelayedRetries);
+        _ = outgoingMessageHeaders.Remove(Headers.ImmediateRetries);
+        var outgoingMessage = new OutgoingMessage(context.MessageId, outgoingMessageHeaders, context.Body);
 
-        var headers = outgoingMessage.Headers;
-        headers.Remove(Headers.DelayedRetries);
-        headers.Remove(Headers.ImmediateRetries);
-
-        if (message.Headers.ContainsKey(Headers.DiagnosticsTraceParent))
+        if (context.Headers.ContainsKey(Headers.DiagnosticsTraceParent))
         {
-            message.Headers[Headers.StartNewTrace] = bool.TrueString;
+            // TODO: Bug?
+            context.Headers[Headers.StartNewTrace] = bool.TrueString;
         }
 
         foreach (var faultMetadata in metadata)
         {
-            headers[faultMetadata.Key] = faultMetadata.Value;
+            outgoingMessageHeaders[faultMetadata.Key] = faultMetadata.Value;
         }
-        return new[]
-        {
+        return
+        [
             context.CreateRoutingContext(outgoingMessage, new UnicastRoutingStrategy(ErrorQueue))
-        };
+        ];
     }
 
     static readonly ILog Logger = LogManager.GetLogger<MoveToError>();

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
@@ -24,7 +24,14 @@ sealed class RecoverabilityContext : PipelineRootContext, IRecoverabilityContext
         ContextBag parent,
         CancellationToken cancellationToken) : base(serviceProvider, messageOperations, pipelineCache, cancellationToken, parent)
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         FailedMessage = errorContext.Message;
+#pragma warning restore CS0618 // Type or member is obsolete
+        MessageId = errorContext.MessageId;
+        NativeMessageId = errorContext.NativeMessageId;
+        Headers = errorContext.Headers;
+        Body = errorContext.Body;
+        ReceiveProperties = errorContext.ReceiveProperties;
         Exception = errorContext.Exception;
         ReceiveAddress = errorContext.ReceiveAddress;
         ImmediateProcessingFailures = errorContext.ImmediateProcessingFailures;
@@ -45,6 +52,16 @@ sealed class RecoverabilityContext : PipelineRootContext, IRecoverabilityContext
     public int ImmediateProcessingFailures { get; }
 
     public int DelayedDeliveriesPerformed { get; }
+
+    public string MessageId { get; }
+
+    public string NativeMessageId { get; }
+
+    public Dictionary<string, string> Headers { get; }
+
+    public ReadOnlyMemory<byte> Body { get; }
+
+    public ReceiveProperties ReceiveProperties { get; }
 
     IReadOnlyDictionary<string, string> IRecoverabilityActionContext.Metadata => Metadata;
 

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using Extensibility;
 using NServiceBus.Transport;
+using Particular.Obsoletes;
 using Pipeline;
 
 sealed class RecoverabilityContext : PipelineRootContext, IRecoverabilityContext, IRecoverabilityActionContext, IRecoverabilityActionContextNotifications
@@ -24,7 +25,7 @@ sealed class RecoverabilityContext : PipelineRootContext, IRecoverabilityContext
         ContextBag parent,
         CancellationToken cancellationToken) : base(serviceProvider, messageOperations, pipelineCache, cancellationToken, parent)
     {
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete. Can be removed in the next major when FailedMessage is removed from the interface.
         FailedMessage = errorContext.Message;
 #pragma warning restore CS0618 // Type or member is obsolete
         MessageId = errorContext.MessageId;
@@ -43,7 +44,9 @@ sealed class RecoverabilityContext : PipelineRootContext, IRecoverabilityContext
         Extensions.Set(errorContext.TransportTransaction);
     }
 
-    public IncomingMessage FailedMessage { get; }
+    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID or the receive properties use the corresponding properties directly exposed on the context.", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
+    [Obsolete("For access to the message body, headers, native message ID or the receive properties use the corresponding properties directly exposed on the context.. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+    public IncomingMessage FailedMessage { get; } // Can be removed in the next major when FailedMessage is removed from the interface.
 
     public Exception Exception { get; }
 

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
@@ -44,8 +44,8 @@ sealed class RecoverabilityContext : PipelineRootContext, IRecoverabilityContext
         Extensions.Set(errorContext.TransportTransaction);
     }
 
-    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID or the receive properties use the corresponding properties directly exposed on the context.", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
-    [Obsolete("For access to the message body, headers, native message ID or the receive properties use the corresponding properties directly exposed on the context.. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID, or the receive properties use the corresponding properties directly exposed on the context", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
+    [Obsolete("For access to the message body, headers, native message ID, or the receive properties use the corresponding properties directly exposed on the context. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
     public IncomingMessage FailedMessage { get; } // Can be removed in the next major when FailedMessage is removed from the interface.
 
     public Exception Exception { get; }

--- a/src/NServiceBus.Core/Recoverability/SatelliteRecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/SatelliteRecoverabilityExecutor.cs
@@ -66,7 +66,7 @@ class SatelliteRecoverabilityExecutor<TState>(
         CancellationToken cancellationToken)
         : IRecoverabilityActionContext
     {
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete. Can be removed in the next major when FailedMessage is removed from the interface.
         public IncomingMessage FailedMessage { get; } = errorContext.Message;
 #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/src/NServiceBus.Core/Recoverability/SatelliteRecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/SatelliteRecoverabilityExecutor.cs
@@ -66,7 +66,19 @@ class SatelliteRecoverabilityExecutor<TState>(
         CancellationToken cancellationToken)
         : IRecoverabilityActionContext
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         public IncomingMessage FailedMessage { get; } = errorContext.Message;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        public string MessageId { get; } = errorContext.MessageId;
+
+        public string NativeMessageId { get; } = errorContext.NativeMessageId;
+
+        public Dictionary<string, string> Headers { get; } = errorContext.Headers;
+
+        public ReadOnlyMemory<byte> Body { get; } = errorContext.Body;
+
+        public ReceiveProperties ReceiveProperties { get; } = errorContext.ReceiveProperties;
 
         public Exception Exception { get; } = errorContext.Exception;
 

--- a/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
@@ -58,8 +58,8 @@ public partial class DelayedRetriesSettings : ExposeSettings
                 return Task.CompletedTask;
             }
 
-            var headerCopy = new Dictionary<string, string>(retry.Message.Headers);
-            return notificationCallback(new DelayedRetryMessage(retry.Message.MessageId, headerCopy, retry.Message.Body, retry.Exception, retry.Attempt), cancellationToken);
+            var headerCopy = new Dictionary<string, string>(retry.Headers);
+            return notificationCallback(new DelayedRetryMessage(retry.MessageId, headerCopy, retry.Body, retry.Exception, retry.Attempt), cancellationToken);
         });
 
         return this;

--- a/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
@@ -46,8 +46,8 @@ public partial class ImmediateRetriesSettings : ExposeSettings
                 return Task.CompletedTask;
             }
 
-            var headerCopy = new Dictionary<string, string>(retry.Message.Headers);
-            return notificationCallback(new ImmediateRetryMessage(retry.Message.MessageId, headerCopy, retry.Message.Body, retry.Exception, retry.Attempt), cancellationToken);
+            var headerCopy = new Dictionary<string, string>(retry.Headers);
+            return notificationCallback(new ImmediateRetryMessage(retry.MessageId, headerCopy, retry.Body, retry.Exception, retry.Attempt), cancellationToken);
         });
 
         return this;

--- a/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
@@ -42,8 +42,8 @@ public partial class RetryFailedSettings : ExposeSettings
         var subscriptions = Settings.Get<RecoverabilityComponent.Configuration>();
         subscriptions.MessageFaultedNotification.Subscribe((faulted, cancellationToken) =>
         {
-            var headerCopy = new Dictionary<string, string>(faulted.Message.Headers);
-            return notificationCallback(new FailedMessage(faulted.Message.MessageId, headerCopy, faulted.Message.Body, faulted.Exception, faulted.ErrorQueue), cancellationToken);
+            var headerCopy = new Dictionary<string, string>(faulted.Headers);
+            return notificationCallback(new FailedMessage(faulted.MessageId, headerCopy, faulted.Body, faulted.Exception, faulted.ErrorQueue), cancellationToken);
         });
 
         return this;

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -110,8 +110,8 @@ public class ErrorContext
     /// <summary>
     /// Failed incoming message.
     /// </summary>
-    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID or the receive properties use the corresponding properties directly exposed on the context.", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
-    [Obsolete("For access to the message body, headers, native message ID or the receive properties use the corresponding properties directly exposed on the context.. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID, or the receive properties use the corresponding properties directly exposed on the context", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
+    [Obsolete("For access to the message body, headers, native message ID, or the receive properties use the corresponding properties directly exposed on the context. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
     public IncomingMessage Message => new(NativeMessageId, Headers, Body, ReceiveProperties);
 
     /// <summary>

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -110,8 +110,8 @@ public class ErrorContext
     /// <summary>
     /// Failed incoming message.
     /// </summary>
-    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID or the receive properties using the corresponding properties directly exposed on the context.", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
-    [Obsolete("For access to the message body, headers, native message ID or the receive properties using the corresponding properties directly exposed on the context.. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID or the receive properties use the corresponding properties directly exposed on the context.", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
+    [Obsolete("For access to the message body, headers, native message ID or the receive properties use the corresponding properties directly exposed on the context.. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
     public IncomingMessage Message => new(NativeMessageId, Headers, Body, ReceiveProperties);
 
     /// <summary>

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using Extensibility;
+using Particular.Obsoletes;
 
 /// <summary>
 /// The context for messages that has failed processing.
@@ -49,12 +50,15 @@ public class ErrorContext
         Exception = exception;
         TransportTransaction = transportTransaction;
         ImmediateProcessingFailures = immediateProcessingFailures;
-
-        Message = new IncomingMessage(nativeMessageId, headers, body, receiveProperties);
+        NativeMessageId = nativeMessageId;
+        MessageId = IncomingMessage.GetOrSetMessageIdFromHeaders(headers, nativeMessageId);
+        Headers = headers;
+        Body = body;
+        ReceiveProperties = receiveProperties;
 
         ReceiveAddress = receiveAddress;
 
-        DelayedDeliveriesPerformed = Message.GetDelayedDeliveriesPerformed();
+        DelayedDeliveriesPerformed = headers.GetDelayedDeliveriesPerformed();
         Extensions = context;
     }
 
@@ -79,9 +83,36 @@ public class ErrorContext
     public int DelayedDeliveriesPerformed { get; }
 
     /// <summary>
+    /// The message ID.
+    /// </summary>
+    public string MessageId { get; }
+
+    /// <summary>
+    /// The native message ID.
+    /// </summary>
+    public string NativeMessageId { get; }
+
+    /// <summary>
+    /// The message headers.
+    /// </summary>
+    public Dictionary<string, string> Headers { get; }
+
+    /// <summary>
+    /// The message body.
+    /// </summary>
+    public ReadOnlyMemory<byte> Body { get; }
+
+    /// <summary>
+    /// Properties received from the transport that can be propagated to outgoing dispatch operations.
+    /// </summary>
+    public ReceiveProperties ReceiveProperties { get; }
+
+    /// <summary>
     /// Failed incoming message.
     /// </summary>
-    public IncomingMessage Message { get; }
+    [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID or the receive properties using the corresponding properties directly exposed on the context.", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]
+    [Obsolete("For access to the message body, headers, native message ID or the receive properties using the corresponding properties directly exposed on the context.. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+    public IncomingMessage Message => new(NativeMessageId, Headers, Body, ReceiveProperties);
 
     /// <summary>
     /// Transport address that received the failed message.

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -32,23 +32,10 @@ public class IncomingMessage
         ArgumentNullException.ThrowIfNull(headers);
         ArgumentNullException.ThrowIfNull(receiveProperties);
 
-        if (headers.TryGetValue(NServiceBus.Headers.MessageId, out var originalMessageId) && !string.IsNullOrEmpty(originalMessageId))
-        {
-            MessageId = originalMessageId;
-        }
-        else
-        {
-            MessageId = nativeMessageId;
-
-            headers[NServiceBus.Headers.MessageId] = nativeMessageId;
-        }
-
         NativeMessageId = nativeMessageId;
-
+        MessageId = GetOrSetMessageIdFromHeaders(headers, nativeMessageId);
         Headers = headers;
-
         Body = body;
-
         ReceiveProperties = receiveProperties;
     }
 
@@ -76,6 +63,29 @@ public class IncomingMessage
     /// Gets/sets a byte array to the body content of the message.
     /// </summary>
     public ReadOnlyMemory<byte> Body { get; private set; }
+
+    /// <summary>
+    /// This method is used to ensure that the message ID header is present in the header dictionary.
+    /// If the header is already present, it returns its value. If not, it adds the native message ID to the headers and returns it as the message ID.
+    /// </summary>
+    /// <param name="headers">The message headers to inspects and potentially mutate.</param>
+    /// <param name="nativeMessageId">The native message ID.</param>
+    /// <returns>The original message ID or the native message ID depending on the availability of the MessageId header.</returns>
+    internal static string GetOrSetMessageIdFromHeaders(Dictionary<string, string> headers, string nativeMessageId)
+    {
+        string messageId;
+        if (headers.TryGetValue(NServiceBus.Headers.MessageId, out var originalMessageId) && !string.IsNullOrEmpty(originalMessageId))
+        {
+            messageId = originalMessageId;
+        }
+        else
+        {
+            messageId = nativeMessageId;
+
+            headers[NServiceBus.Headers.MessageId] = nativeMessageId;
+        }
+        return messageId;
+    }
 
     /// <summary>
     /// Use this method to update the body of this message.

--- a/src/NServiceBus.Testing.Fakes/TestableRecoverabilityContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableRecoverabilityContext.cs
@@ -13,7 +13,32 @@ public partial class TestableRecoverabilityContext : TestableBehaviorContext, IR
     /// <summary>
     /// The message that failed processing.
     /// </summary>
-    public IncomingMessage FailedMessage { get; set; } = new IncomingMessage(Guid.NewGuid().ToString(), [], ReadOnlyMemory<byte>.Empty);
+    public IncomingMessage FailedMessage { get; set; } = new(Guid.NewGuid().ToString(), [], ReadOnlyMemory<byte>.Empty);
+
+    /// <summary>
+    /// The message ID of the failed message.
+    /// </summary>
+    public string MessageId { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// The native message ID of the failed message.
+    /// </summary>
+    public string NativeMessageId { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// The message headers of the failed message.
+    /// </summary>
+    public Dictionary<string, string> Headers { get; set; } = [];
+
+    /// <summary>
+    /// The message body of the failed message.
+    /// </summary>
+    public ReadOnlyMemory<byte> Body { get; set; } = ReadOnlyMemory<byte>.Empty;
+
+    /// <summary>
+    /// Properties received from the transport that will be propagated to outgoing dispatch operations.
+    /// </summary>
+    public ReceiveProperties ReceiveProperties { get; set; } = ReceiveProperties.Empty;
 
     /// <summary>
     /// The exception that caused processing to fail.

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -115,7 +115,7 @@ public abstract class NServiceBusTransportTest
             (context, token) =>
                 context.Headers.Contains(TestIdHeaderName, testId) ? onMessage(context, token) : Task.CompletedTask,
             (context, token) =>
-                context.Message.Headers.Contains(TestIdHeaderName, testId) ? onError(context, token) : Task.FromResult(ErrorHandleResult.Handled),
+                context.Headers.Contains(TestIdHeaderName, testId) ? onError(context, token) : Task.FromResult(ErrorHandleResult.Handled),
             cancellationToken);
     }
 

--- a/src/NServiceBus.TransportTests/When_modifying_headers_before_on_error.cs
+++ b/src/NServiceBus.TransportTests/When_modifying_headers_before_on_error.cs
@@ -33,6 +33,6 @@ public class When_modifying_headers_before_on_error : NServiceBusTransportTest
 
         var errorContext = await errorHandled.Task;
 
-        Assert.That(errorContext.Message.Headers["test-header"], Is.EqualTo("original"));
+        Assert.That(errorContext.Headers["test-header"], Is.EqualTo("original"));
     }
 }

--- a/src/NServiceBus.TransportTests/When_modifying_headers_in_on_error.cs
+++ b/src/NServiceBus.TransportTests/When_modifying_headers_in_on_error.cs
@@ -22,7 +22,7 @@ public class When_modifying_headers_in_on_error : NServiceBusTransportTest
             (context, _) =>
             {
                 retrying = true;
-                context.Message.Headers["test-header"] = "modified";
+                context.Headers["test-header"] = "modified";
                 return Task.FromResult(ErrorHandleResult.RetryRequired);
             },
             transactionMode);

--- a/src/NServiceBus.TransportTests/When_on_message_throws.cs
+++ b/src/NServiceBus.TransportTests/When_on_message_throws.cs
@@ -33,7 +33,7 @@ public class When_on_message_throws : NServiceBusTransportTest
         {
             Assert.That(errorContext.Exception.Message, Is.EqualTo("Simulated exception"), "Should preserve the exception");
             Assert.That(errorContext.ImmediateProcessingFailures, Is.EqualTo(1), "Should track the number of delivery attempts");
-            Assert.That(errorContext.Message.Headers["MyHeader"], Is.EqualTo("MyValue"), "Should pass the message headers");
+            Assert.That(errorContext.Headers["MyHeader"], Is.EqualTo("MyValue"), "Should pass the message headers");
         }
     }
 }

--- a/src/NServiceBus.TransportTests/When_on_message_throws_after_delayed_retry.cs
+++ b/src/NServiceBus.TransportTests/When_on_message_throws_after_delayed_retry.cs
@@ -23,7 +23,7 @@ public class When_on_message_throws_after_delayed_retry : NServiceBusTransportTe
                 if (!sendingDelayedMessage)
                 {
                     sendingDelayedMessage = true;
-                    await SendMessage(InputQueueName, context.Message.Headers, context.TransportTransaction, cancellationToken: cancellationToken);
+                    await SendMessage(InputQueueName, context.Headers, context.TransportTransaction, cancellationToken: cancellationToken);
                 }
                 else
                 {


### PR DESCRIPTION
Follow up on #7662 

This PR flattens the relevant `IncomingMessage` data onto the pipeline and error contexts.

Instead of requiring consumers to go through an `IncomingMessage` instance to access message details, the contexts now expose the message information directly. This makes the pipeline/error context the primary surface for message-processing state and better reflects that `IncomingMessage` is created as part of the pipeline flow, after envelope unwrapping.

### Motivation

During review, it became clear that `IncomingMessage` should be treated as a pipeline concept. The envelope unwrapper is responsible for creating it from the transport-provided message context, which means the pipeline context already has the information needed to represent the message being processed.

Given that, carrying an `IncomingMessage` object around as the main way to access message state makes the context model less clear. The properties that are needed by pipeline behaviors and error/recoverability handling belong directly on the corresponding contexts.

This also avoids having Core duplicate preservation logic around nested message objects. The transport provides the original message data, the pipeline creates the incoming message representation, and the contexts expose the relevant message state directly where it is used.

### Changes

- Moves the relevant `IncomingMessage` properties onto the pipeline context as flat context properties.
- Moves the relevant failed-message properties onto the error/recoverability context as flat context properties.
- Updates message handling code to use the context-level properties instead of reaching through an `IncomingMessage`.
- Updates recoverability and error-handling flows to access failed-message data directly from the context.
- Keeps the envelope unwrapper responsible for creating the incoming message representation from the transport message context.
- Updates tests to reflect the new context shape and verify the same message data remains available during processing and recoverability.

### Behavioral impact

There should be no intended behavioral change in how messages are processed, retried, or moved to the error queue.

The change is primarily a context-modeling refactor:

- message data remains available during normal pipeline execution;
- failed-message data remains available during recoverability/error handling;
- the data is now exposed directly on the relevant context instead of being accessed through a nested `IncomingMessage`.

This makes the ownership boundaries clearer:

- the transport provides the raw message context;
- the envelope unwrapper creates the incoming message representation;
- the pipeline and error contexts expose the message state needed by behaviors and recoverability actions.