### PR TITLE
Add test independence support with TestRunId header and skip behavior

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Customization/EndpointConfigurationExtensions.cs
+++ b/src/NServiceBus.AcceptanceTesting/Customization/EndpointConfigurationExtensions.cs
@@ -108,6 +108,16 @@ public static class EndpointConfigurationExtensions
             "Enforces all subscribed events have corresponding mappings in the PublisherMetadata");
     }
 
+    /// <summary>
+    /// Enables test independence by adding a TestRunId header to outgoing messages
+    /// and skipping messages from other test runs on receipt.
+    /// </summary>
+    public static void EnableTestIndependence(this EndpointConfiguration config)
+    {
+        config.Pipeline.Register("AcceptanceTesting.TestRunId", typeof(TestRunIdHeaderBehavior), "Adds the current TestRunId header to outgoing messages");
+        config.Pipeline.Register("AcceptanceTesting.TestRunSkip", typeof(TestRunIdSkipBehavior), "Skips messages from other test runs");
+    }
+
     static void AddHandlerWithReflection(Type handlerType, EndpointConfiguration endpointConfiguration) =>
         AddHandlerWithReflectionMethod.InvokeGeneric(null, [endpointConfiguration], [handlerType]);
 

--- a/src/NServiceBus.AcceptanceTesting/Support/TestRunIdHeaderBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/TestRunIdHeaderBehavior.cs
@@ -1,0 +1,14 @@
+namespace NServiceBus.AcceptanceTesting.Support;
+
+using System;
+using System.Threading.Tasks;
+using Pipeline;
+
+class TestRunIdHeaderBehavior(ScenarioContext scenarioContext) : IBehavior<IOutgoingPhysicalMessageContext, IOutgoingPhysicalMessageContext>
+{
+    public Task Invoke(IOutgoingPhysicalMessageContext context, Func<IOutgoingPhysicalMessageContext, Task> next)
+    {
+        context.Headers["$AcceptanceTesting.TestRunId"] = scenarioContext.TestRunId.ToString();
+        return next(context);
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/Support/TestRunIdSkipBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/TestRunIdSkipBehavior.cs
@@ -1,0 +1,22 @@
+namespace NServiceBus.AcceptanceTesting.Support;
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Pipeline;
+
+class TestRunIdSkipBehavior(ScenarioContext scenarioContext) : IBehavior<ITransportReceiveContext, ITransportReceiveContext>
+{
+    public Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
+    {
+        var testRunId = scenarioContext.TestRunId.ToString();
+
+        if (context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out var runId) && runId != testRunId)
+        {
+            TestContext.Out.WriteLine($"Skipping message {context.Message.MessageId} from previous test run");
+            return Task.CompletedTask;
+        }
+
+        return next(context);
+    }
+}


### PR DESCRIPTION
It seems we are reinventing the wheel all the time. This could simply be something Core ATT framework ships out of the box