### PR TITLE
Add known types similar to AddHandlerInterceptor

### DIFF
--- a/src/NServiceBus.Core.Analyzer/Sagas/AddSagaInterceptor.cs
+++ b/src/NServiceBus.Core.Analyzer/Sagas/AddSagaInterceptor.cs
@@ -15,12 +15,12 @@ public sealed partial class AddSagaInterceptor : IIncrementalGenerator
             .CreateSyntaxProvider(
                 predicate: static (node, _) => Parser.SyntaxLooksLikeAddSagaMethod(node),
                 transform: static (ctx, _) => (invocation: (InvocationExpressionSyntax)ctx.Node, semanticModel: ctx.SemanticModel))
+            .Combine(knownTypes)
             .Where(static pair =>
             {
                 var (_, knownTypes) = pair;
                 return knownTypes is not null;
             })
-            .Combine(knownTypes)
             .Select(static (pair, cancellationToken) =>
             {
                 var ((invocation, semanticModel), knownTypes) = pair;


### PR DESCRIPTION
Ran across this while spelunking the generator. Isn't this a bug? AddHandler seems to add knownTypes in the correct place?