### PR TITLE
Fix race conditions in endpoint Stop and expose lifecycle stopper for advanced scenarios

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehavior.cs
@@ -36,6 +36,13 @@ public class EndpointBehavior : IComponentBehavior
             var serviceKey = collectionAdapter.ServiceKey;
 
             collectionAdapter.Inner.AddNServiceBusEndpoint(config, serviceKey);
+            // we don't want to expose the lifecycle in Core, but some super advanced scenarios require
+            // stopping the endpoint and this backdoor allows that without having to expose the lifecycle in Core
+            collectionAdapter.AddKeyedSingleton<Func<CancellationToken, Task>>("Stopper", (provider, key) =>
+            {
+                var endpointLifecycle = provider.GetRequiredKeyedService<IEndpointLifecycle>(serviceKey);
+                return async token => await endpointLifecycle.Stop(token).ConfigureAwait(false);
+            });
 
             return Task.FromResult(new StartableEndpointInstance(serviceKey));
         }, static (startableEndpoint, provider, cancellationToken) => startableEndpoint.Start(provider, cancellationToken));
@@ -45,9 +52,10 @@ public class EndpointBehavior : IComponentBehavior
     {
         public async Task<Func<CancellationToken, Task>> Start(IServiceProvider builder, CancellationToken cancellationToken = default)
         {
-            var endpointLifecycle = builder.GetRequiredKeyedService<IEndpointLifecycle>(serviceKey);
-            await endpointLifecycle.CreateAndStart(cancellationToken).ConfigureAwait(false);
-            return async token => await endpointLifecycle.Stop(token).ConfigureAwait(false);
+            await builder.GetRequiredKeyedService<IEndpointLifecycle>(serviceKey)
+                .CreateAndStart(cancellationToken).ConfigureAwait(false);
+            // This is to dogfood the advanced ability to stop the endpoint
+            return builder.GetRequiredKeyedService<Func<CancellationToken, Task>>(new KeyedServiceKey(serviceKey, "Stopper"));
         }
     }
 

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_resolving_endpoint_specific_keyed_service_globally.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_resolving_endpoint_specific_keyed_service_globally.cs
@@ -2,7 +2,6 @@
 
 using System.Threading.Tasks;
 using AcceptanceTesting;
-using AcceptanceTesting.Support;
 using EndpointTemplates;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;

--- a/src/NServiceBus.Core/Hosting/BaseEndpointLifecycle.cs
+++ b/src/NServiceBus.Core/Hosting/BaseEndpointLifecycle.cs
@@ -17,7 +17,7 @@ class BaseEndpointLifecycle(
             return;
         }
 
-        await createSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await lifeCycleSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -31,7 +31,7 @@ class BaseEndpointLifecycle(
         }
         finally
         {
-            createSemaphore.Release();
+            lifeCycleSemaphore.Release();
         }
     }
 
@@ -48,7 +48,26 @@ class BaseEndpointLifecycle(
             throw new InvalidOperationException("The endpoint must be created before it can be started.");
         }
 
-        endpointInstance = await startableEndpoint.Start(cancellationToken).ConfigureAwait(false);
+        if (endpointInstance != null)
+        {
+            return;
+        }
+
+        await lifeCycleSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            if (endpointInstance != null)
+            {
+                return;
+            }
+
+            endpointInstance = await startableEndpoint.Start(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            lifeCycleSemaphore.Release();
+        }
     }
 
     public async ValueTask<RunningEndpointInstance> CreateAndStart(CancellationToken cancellationToken = default)
@@ -65,7 +84,22 @@ class BaseEndpointLifecycle(
             return;
         }
 
-        await endpointInstance.Stop(cancellationToken).ConfigureAwait(false);
+        await lifeCycleSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            if (endpointInstance == null)
+            {
+                return;
+            }
+
+            await endpointInstance.Stop(cancellationToken).ConfigureAwait(false);
+            endpointInstance = null;
+        }
+        finally
+        {
+            lifeCycleSemaphore.Release();
+        }
     }
 
     public async ValueTask DisposeAsync()
@@ -88,7 +122,7 @@ class BaseEndpointLifecycle(
         }
     }
 
-    readonly SemaphoreSlim createSemaphore = new(1, 1);
+    readonly SemaphoreSlim lifeCycleSemaphore = new(1, 1);
 
     volatile StartableEndpoint? startableEndpoint;
     RunningEndpointInstance? endpointInstance;

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -28,15 +28,11 @@ class RunningEndpointInstance(SettingsHolder settings,
             return;
         }
 
-        using var _ = LogManager.BeginSlotScope(endpointLogSlot);
-        var tokenRegistration = cancellationToken.Register(() => Log.Info("Aborting graceful shutdown."));
         var semaphoreEntered = false;
-
-        await stoppingTokenSource.CancelAsync().ConfigureAwait(false);
-
         try
         {
-            // Ensures to only continue if all parallel invocations can rely on the endpoint instance to be fully stopped.
+            // Serialize Stop so only one caller owns shutdown and cleanup, while other
+            // non-cancelled callers wait until shutdown has completed before returning.
             await stopSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             semaphoreEntered = true;
 
@@ -47,10 +43,15 @@ class RunningEndpointInstance(SettingsHolder settings,
 
             status = Status.Stopping;
 
+            using var _ = LogManager.BeginSlotScope(endpointLogSlot);
+            await using var tokenRegistration = cancellationToken.Register(() => Log.Info("Aborting graceful shutdown."))
+                .ConfigureAwait(false);
+            Log.Info("Initiating shutdown.");
+
+            await stoppingTokenSource.CancelAsync().ConfigureAwait(false);
+
             try
             {
-                Log.Info("Initiating shutdown.");
-
                 // Cannot throw by design
                 await receiveComponent.Stop(cancellationToken).ConfigureAwait(false);
                 await featureComponent.StopFeatures(messageSession, cancellationToken).ConfigureAwait(false);
@@ -73,6 +74,7 @@ class RunningEndpointInstance(SettingsHolder settings,
                 await serviceProviderLease.DisposeAsync()
                     .ConfigureAwait(false);
 
+                stoppingTokenSource.Dispose();
                 status = Status.Stopped;
             }
         }
@@ -82,10 +84,6 @@ class RunningEndpointInstance(SettingsHolder settings,
             {
                 stopSemaphore.Release();
             }
-
-            await tokenRegistration.DisposeAsync().ConfigureAwait(false);
-
-            stoppingTokenSource.Dispose();
         }
     }
 


### PR DESCRIPTION
## Why this fix is needed

While adding support for the [ServiceControl disconnected endpoint count acceptance test](https://github.com/Particular/ServiceControl/blob/master/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_disconnected_count.cs), we introduced a `Func<CancellationToken, Task>` into the acceptance testing framework that allows tests to stop an endpoint mid-lifecycle. This revealed two race conditions in `RunningEndpointInstance.Stop` and an existing bug that causes `ObjectDisposedException` on `stoppingTokenSource`.

### Bug: ObjectDisposedException when Stop is called with an already-cancelled token

When `Stop` is called with a pre-cancelled token (e.g. test timeout), `stoppingTokenSource.CancelAsync()` ran before the semaphore, and `WaitAsync(cancellationToken)` threw immediately. The outer `finally` then disposed `stoppingTokenSource` even though shutdown never actually happened and `status` remained `Running`. A subsequent call to `Stop` would reach `stoppingTokenSource.CancelAsync()` on the already-disposed CTS and throw `ObjectDisposedException`. This is the root cause of failures in [NServiceBus.Metrics.ServiceControl acceptance tests](https://github.com/Particular/NServiceBus.Metrics.ServiceControl/blob/master/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/When_reporting_to_ServiceControl_expires.cs#L19).

### Race 1: Log slot scope disposed on the wrong thread

`BeginSlotScope` was established **before** entering the semaphore. When two callers (the hosted service and the acceptance testing framework) invoked `Stop` concurrently, both acquired the same `AsyncLocal` slot scope. The second caller's scope would overwrite `currentSlot`, and when the first caller's scope disposed, it restored the previous (null) value, causing the second caller to lose its logging context.

### Race 2: CancellationToken registration disposed on the wrong thread

`tokenRegistration` was created before the semaphore and disposed in an outer `finally`. If both callers entered `Stop`, the registration could fire or be disposed on the wrong thread's `AsyncLocal` context.

### Additional issue: unserialized cancellation signal

`stoppingTokenSource.CancelAsync()` was called before acquiring the semaphore, meaning both concurrent callers could observe the stopping signal simultaneously and attempt to enter the shutdown path.

## What changed

### `RunningEndpointInstance.Stop`

- Moved `BeginSlotScope`, `tokenRegistration`, `CancelAsync`, and the inner shutdown logic inside the semaphore-protected region, after `status = Stopping`, so only the owning thread has scope and registration
- Used `await using` for `tokenRegistration` so it disposes before the inner `finally` tears down the service provider
- Moved `stoppingTokenSource.Dispose()` into the inner `finally` block next to `status = Stopped`, so it is only disposed when shutdown actually completes
- If `WaitAsync` throws due to cancellation, neither `CancelAsync` nor `Dispose` are called on `stoppingTokenSource`, leaving it intact for a subsequent call
- Disposal order is now: token registration, slot scope, `UnregisterSlot`, `serviceProviderLease.DisposeAsync()`, `stoppingTokenSource.Dispose()`

### `BaseEndpointLifecycle`

- Added semaphore-protected double-checked locking to `Start` and `Stop` to prevent races between the hosted service's `StopAsync` and `DisposeAsync`
- Renamed `createSemaphore` to `lifeCycleSemaphore` to reflect it now guards all lifecycle transitions

### `EndpointBehavior` (acceptance testing)

- Added a keyed `Func<CancellationToken, Task>` singleton with key `"Stopper"` that resolves `IEndpointLifecycle` and calls `Stop` on it. This is a **hidden backdoor** intentionally not exposed in Core. It exists solely for advanced acceptance testing scenarios where a test needs to stop an endpoint and then continue asserting, which the standard hosted service lifecycle doesn't support. The `StartableEndpointInstance.Start` method dogfoods this stopper function instead of calling lifecycle methods directly.

## Simplified usage

With the stopper now available as a keyed service, the ServiceControl test pattern can be simplified. Instead of using `ToCreateInstance` with manually wired callbacks just to capture the stop function:

```csharp
.WithEndpoint<MonitoredEndpoint>(b => b
    .ToCreateInstance(
        (services, configuration) => EndpointWithExternallyManagedContainer.Create(configuration, services),
        async (startableEndpoint, provider, ct) =>
        {
            context.FirstInstance = await startableEndpoint.Start(provider, ct);
            return context.FirstInstance;
        }))
```

The test can use `WithServiceResolve` after start to acquire the stopper via `KeyedServiceKey`, removing the need for `ToCreateInstance` entirely. This follows the same pattern as `When_resolving_endpoint_specific_keyed_service_globally`:

```csharp
.WithEndpoint<MonitoredEndpoint>(b => b
    .CustomConfig(c => c.EnableMetrics()
        .SendMetricDataToServiceControl(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromMilliseconds(200), "First"))
    .WithServiceResolve((provider, context, _) =>
    {
        var endpointName = Conventions.EndpointNamingConvention(typeof(MonitoredEndpoint));
        context.Stopper = provider.GetRequiredKeyedService<Func<CancellationToken, Task>>(
            new KeyedServiceKey($"{endpointName}0", "Stopper"));
        return Task.CompletedTask;
    }, afterStart: true))
```

Then in the `Done` callback:

```csharp
await context.Stopper(CancellationToken.None);
context.StoppedFirstInstance = true;
```

This approach has several advantages over the `ToCreateInstance` pattern:
- No need to manually wire endpoint creation and start callbacks
- The stopper goes through `IEndpointLifecycle.Stop`, which properly serializes shutdown
- The `KeyedServiceKey` composition follows the established keyed DI conventions