### PR TITLE
Move AddHandler logging

### DIFF
--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -150,8 +150,8 @@ partial class ReceiveComponent
         }
 
 
-        var logger = builder.GetRequiredService<ILogger<MessageHandlerRegistry>>();
-        if (logger.IsEnabled(LogLevel.Debug))
+        var logger = LogManager.GetLogger<MessageHandlerRegistry>();
+        if (logger.IsDebugEnabled)
         {
             var messageHandlerRegistry = configuration.MessageHandlerRegistry;
             foreach (var messageType in messageHandlerRegistry.GetMessageTypes())
@@ -159,7 +159,7 @@ partial class ReceiveComponent
                 var handlers = messageHandlerRegistry.GetHandlersFor(messageType);
                 foreach (var messageHandler in handlers)
                 {
-                    logger.LogDebug("Associated '{MessageType}' message with '{HandlerType}' {Type} handler.", messageType, messageHandler.HandlerType, messageHandler.IsTimeoutHandler ? "timeout" : "message");
+                    logger.DebugFormat("Associated '{0}' message with '{1}' {2} handler.", messageType, messageHandler.HandlerType, messageHandler.IsTimeoutHandler ? "timeout" : "message");
                 }
             }
         }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -9,10 +9,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Logging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Outbox;
 using Pipeline;
 using Transport;
 using Unicast;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 partial class ReceiveComponent
 {
@@ -80,9 +82,7 @@ partial class ReceiveComponent
         hostingConfiguration.Services.AddSingleton(messageHandlerRegistry);
         foreach (var messageType in messageHandlerRegistry.GetMessageTypes())
         {
-            handlerDiagnostics[messageType.FullName!] = messageHandlerRegistry.GetHandlersFor(messageType)
-                .Select(handler => handler.HandlerType.FullName!)
-                .ToList();
+            handlerDiagnostics[messageType.FullName!] = [.. messageHandlerRegistry.GetHandlersFor(messageType).Select(handler => handler.HandlerType.FullName!)];
         }
 
         var receiveSettings = new List<ReceiveSettings>
@@ -147,6 +147,21 @@ partial class ReceiveComponent
         if (configuration.IsSendOnlyEndpoint)
         {
             return;
+        }
+
+
+        var logger = builder.GetRequiredService<ILogger<MessageHandlerRegistry>>();
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            var messageHandlerRegistry = configuration.MessageHandlerRegistry;
+            foreach (var messageType in messageHandlerRegistry.GetMessageTypes())
+            {
+                var handlers = messageHandlerRegistry.GetHandlersFor(messageType);
+                foreach (var messageHandler in handlers)
+                {
+                    logger.LogDebug("Associated '{MessageType}' message with '{HandlerType}' {Type} handler.", messageType, messageHandler.HandlerType, messageHandler.IsTimeoutHandler ? "timeout" : "message");
+                }
+            }
         }
 
         var mainProcessingLogSlot = CreateReceiverProcessingLogSlot(endpointLogSlot, MainReceiverId);

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -9,12 +9,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Logging;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Outbox;
 using Pipeline;
 using Transport;
 using Unicast;
-using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 partial class ReceiveComponent
 {
@@ -149,7 +147,9 @@ partial class ReceiveComponent
             return;
         }
 
-
+        // Resolving the logger here with the LogManager for now since we want to do a consistent sweep of all LogManager usage
+        // in the next minor when GetLogger might be deprecated. But we do it late when the service provider is available
+        // to make sure the logger is already properly wired up.
         var logger = LogManager.GetLogger<MessageHandlerRegistry>();
         if (logger.IsDebugEnabled)
         {

--- a/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Particular.Obsoletes;
 using Pipeline;
@@ -124,7 +123,6 @@ public class MessageHandlerRegistry
             return;
         }
 
-        Log.DebugFormat("Associated '{0}' message with '{1}' message handler.", typeof(TMessage), typeof(THandler));
         var handlerFactories = GetOrCreate<THandler>();
         handlerFactories.Add(new MessageHandlerFactory<THandlerAdapter, TMessage, THandler>());
     }
@@ -141,7 +139,6 @@ public class MessageHandlerRegistry
             return;
         }
 
-        Log.DebugFormat("Associated '{0}' message with '{1}' timeout handler.", typeof(TMessage), typeof(THandler));
         var handlerFactories = GetOrCreate<THandler>();
         handlerFactories.Add(new TimeoutHandlerFactory<THandler, TMessage>());
     }
@@ -213,7 +210,6 @@ public class MessageHandlerRegistry
     readonly Dictionary<Type, List<IMessageHandlerFactory>> messageHandlerFactories = [];
     readonly HashSet<HandlerAndMessage> deduplicationSet = [];
     static readonly Type IHandleMessagesType = typeof(IHandleMessages<>);
-    static readonly ILog Log = LogManager.GetLogger<MessageHandlerRegistry>();
 
     internal const string TrimmingMessage = "Registering handlers using assembly scanning is not supported in trimming scenarios.";
 


### PR DESCRIPTION
This PR moves the AddHandler logging to a place where DI is available as a preparation for future logging changes. It will also make sure the logs are properly associated with the right endpoint scope