### PR TITLE
Fix race conditions in RunningEndpointInstance.Stop and BaseEndpointLifecycle where concurrent or early-cancelled Stop calls leave the endpoint in a broken state

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_registering_async_disposables_internally_managed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_registering_async_disposables_internally_managed.cs
@@ -3,10 +3,8 @@
 namespace NServiceBus.AcceptanceTests.Core.DependencyInjection;
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using AcceptanceTesting;
-using AcceptanceTesting.Support;
 using Configuration.AdvancedExtensibility;
 using EndpointTemplates;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/NServiceBus.AcceptanceTests/Core/Stopping/When_stop_is_called_with_cancelled_token.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Stopping/When_stop_is_called_with_cancelled_token.cs
@@ -23,8 +23,7 @@ public class When_stop_is_called_with_cancelled_token : NServiceBusAcceptanceTes
         //
         // This test cancels the Run token after the endpoint starts, which causes
         // StopEndpoints to call Stop with an already-canceled token, then DisposeAsync
-        // in the finally block. This is the same scenario that triggered the bug in
-        // NServiceBus.Metrics.ServiceControl acceptance tests.
+        // in the finally block.
         using var cts = new CancellationTokenSource();
         Context? context = null;
 

--- a/src/NServiceBus.AcceptanceTests/Core/Stopping/When_stop_is_called_with_cancelled_token.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Stopping/When_stop_is_called_with_cancelled_token.cs
@@ -1,0 +1,55 @@
+#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.Stopping;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using NUnit.Framework;
+
+public class When_stop_is_called_with_cancelled_token : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_complete_shutdown_gracefully()
+    {
+        // Before the fix, when Stop was called with an already-cancelled token,
+        // stopSemaphore.WaitAsync(cancelledToken) threw OperationCanceledException before
+        // entering the critical section, leaving status as Running. The framework then
+        // called DisposeAsync -> Stop(None), which re-entered and attempted full shutdown
+        // against a DI container already torn down, causing ObjectDisposedException on
+        // stoppingTokenSource or using a disposed ILoggerFactory.
+        //
+        // This test cancels the Run token after the endpoint starts, which causes
+        // StopEndpoints to call Stop with an already-canceled token, then DisposeAsync
+        // in the finally block. This is the same scenario that triggered the bug in
+        // NServiceBus.Metrics.ServiceControl acceptance tests.
+        using var cts = new CancellationTokenSource();
+        Context? context = null;
+
+        await Assert.ThatAsync(async () =>
+        {
+            await Scenario.Define<Context>(ctx =>
+                {
+                    context = ctx;
+                })
+                .WithEndpoint<Endpoint>(b => b
+                    .Resolves(async (_, _, _) =>
+                    {
+                        // Cancel the Run token so that StopEndpoints receives an
+                        // already-canceled token, reproducing the race condition.
+                        await cts.CancelAsync();
+                    }, afterStart: true))
+                .Run(cts.Token);
+        }, Throws.TypeOf<OperationCanceledException>().Or.TypeOf<TimeoutException>());
+        Assert.That(context?.EndpointsStarted.Task.IsCompletedSuccessfully, Is.True, "Endpoints should have started successfully");
+    }
+
+    class Context : ScenarioContext;
+
+    class Endpoint : EndpointConfigurationBuilder
+    {
+        public Endpoint() => EndpointSetup<DefaultServer>();
+    }
+}

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -38,6 +38,16 @@ public class RunningEndpointInstanceTest
     }
 
     [Test]
+    public async Task ShouldAllowMultipleDispose()
+    {
+        var testInstance = Create();
+
+        await testInstance.DisposeAsync();
+
+        Assert.That(async () => await testInstance.DisposeAsync(), Throws.Nothing);
+    }
+
+    [Test]
     public async Task ShouldThrowExceptionAfterInvokingStop()
     {
         var testInstance = Create();

--- a/src/NServiceBus.Core/Hosting/BaseEndpointLifecycle.cs
+++ b/src/NServiceBus.Core/Hosting/BaseEndpointLifecycle.cs
@@ -92,7 +92,7 @@ class BaseEndpointLifecycle(
                 return;
             }
 
-            await endpointInstance.Stop(cancellationToken).ConfigureAwait(false);
+            await endpointInstance.StopCore(cancellationToken).ConfigureAwait(false);
         }
         finally
         {

--- a/src/NServiceBus.Core/Hosting/BaseEndpointLifecycle.cs
+++ b/src/NServiceBus.Core/Hosting/BaseEndpointLifecycle.cs
@@ -79,11 +79,6 @@ class BaseEndpointLifecycle(
 
     public async ValueTask Stop(CancellationToken cancellationToken = default)
     {
-        if (Interlocked.CompareExchange(ref isStopped, 1, 0) == 1)
-        {
-            return;
-        }
-
         // The semaphore is an internal serialization mechanism; the caller's token
         // must not be able to abort the wait. A failed wait leaves endpointInstance
         // non-null, allowing a subsequent DisposeAsync -> Stop(None) re-entry to
@@ -134,5 +129,4 @@ class BaseEndpointLifecycle(
     RunningEndpointInstance? endpointInstance;
     IAsyncDisposable? providerLease;
     int isDisposed;
-    int isStopped;
 }

--- a/src/NServiceBus.Core/Hosting/BaseEndpointLifecycle.cs
+++ b/src/NServiceBus.Core/Hosting/BaseEndpointLifecycle.cs
@@ -79,22 +79,25 @@ class BaseEndpointLifecycle(
 
     public async ValueTask Stop(CancellationToken cancellationToken = default)
     {
-        if (endpointInstance is null)
+        if (Interlocked.CompareExchange(ref isStopped, 1, 0) == 1)
         {
             return;
         }
 
-        await lifeCycleSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        // The semaphore is an internal serialization mechanism; the caller's token
+        // must not be able to abort the wait. A failed wait leaves endpointInstance
+        // non-null, allowing a subsequent DisposeAsync -> Stop(None) re-entry to
+        // attempt full shutdown against a DI container that is already torn down.
+        await lifeCycleSemaphore.WaitAsync(CancellationToken.None).ConfigureAwait(false);
 
         try
         {
-            if (endpointInstance == null)
+            if (endpointInstance is null)
             {
                 return;
             }
 
             await endpointInstance.Stop(cancellationToken).ConfigureAwait(false);
-            endpointInstance = null;
         }
         finally
         {
@@ -109,16 +112,19 @@ class BaseEndpointLifecycle(
             return;
         }
 
-        try
+        var instance = endpointInstance;
+        endpointInstance = null;
+
+        // DisposeAsync calls Stop internally, which is idempotent. This ensures
+        // cleanup runs even if Stop was never called or threw.
+        if (instance is not null)
         {
-            await Stop().ConfigureAwait(false);
+            await instance.DisposeAsync().ConfigureAwait(false);
         }
-        finally
+
+        if (providerLease is not null)
         {
-            if (providerLease is not null)
-            {
-                await providerLease.DisposeAsync().ConfigureAwait(false);
-            }
+            await providerLease.DisposeAsync().ConfigureAwait(false);
         }
     }
 
@@ -128,4 +134,5 @@ class BaseEndpointLifecycle(
     RunningEndpointInstance? endpointInstance;
     IAsyncDisposable? providerLease;
     int isDisposed;
+    int isStopped;
 }

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -77,6 +77,11 @@ class RunningEndpointInstance(SettingsHolder settings,
 
     public async ValueTask DisposeAsync()
     {
+        if (Interlocked.Exchange(ref isDisposed, 1) == 1)
+        {
+            return;
+        }
+
         await Stop().ConfigureAwait(false);
 
         // Unregister the slot before disposing the service provider so no thread can
@@ -150,6 +155,7 @@ class RunningEndpointInstance(SettingsHolder settings,
         }
     }
 
+    int isDisposed;
     volatile Status status = Status.Running;
     readonly SemaphoreSlim stopSemaphore = new(1);
 

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -18,25 +18,27 @@ class RunningEndpointInstance(SettingsHolder settings,
     CancellationTokenSource stoppingTokenSource,
     IAsyncDisposable serviceProviderLease,
 #pragma warning disable CS0618 // Type or member is obsolete -- Change the interface to IMessageSession in the next major
-    object endpointLogSlot) : IEndpointInstance
+    object endpointLogSlot) : IEndpointInstance, IAsyncDisposable
 #pragma warning restore CS0618 // Type or member is obsolete
 {
     public async Task Stop(CancellationToken cancellationToken = default)
     {
-        if (status is Status.Stopped)
+        if (status >= Status.Stopping)
         {
             return;
         }
 
-        var semaphoreEntered = false;
+        // Serialize Stop so only one caller owns shutdown, while other callers wait
+        // until shutdown has completed before returning. The semaphore is an internal
+        // serialization mechanism; the caller's token must not be able to abort the wait
+        // because a failed wait leaves status as Running, allowing a subsequent
+        // DisposeAsync -> Stop(None) re-entry to attempt full shutdown against a DI
+        // container that is already torn down.
+        await stopSemaphore.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+
         try
         {
-            // Serialize Stop so only one caller owns shutdown and cleanup, while other
-            // non-cancelled callers wait until shutdown has completed before returning.
-            await stopSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-            semaphoreEntered = true;
-
-            if (status >= Status.Stopping) // Another invocation is already handling Stop
+            if (status >= Status.Stopping)
             {
                 return;
             }
@@ -63,28 +65,27 @@ class RunningEndpointInstance(SettingsHolder settings,
             {
                 Log.Error("Shutdown of the transport infrastructure failed.", ex);
             }
-            finally
-            {
-                settings.Clear();
-                Log.Info("Shutdown complete.");
-                // Remove all per-slot logging state before disposing the service provider so
-                // no thread can route through the (soon-to-be-disposed) ILoggerFactory after
-                // the provider is torn down.
-                LogManager.UnregisterSlot(endpointLogSlot);
-                await serviceProviderLease.DisposeAsync()
-                    .ConfigureAwait(false);
 
-                stoppingTokenSource.Dispose();
-                status = Status.Stopped;
-            }
+            Log.Info("Shutdown complete.");
         }
         finally
         {
-            if (semaphoreEntered)
-            {
-                stopSemaphore.Release();
-            }
+            status = Status.Stopped;
+            stopSemaphore.Release();
         }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Stop().ConfigureAwait(false);
+
+        // Unregister the slot before disposing the service provider so no thread can
+        // route through the (soon-to-be-disposed) ILoggerFactory after the provider is torn down.
+        LogManager.UnregisterSlot(endpointLogSlot);
+
+        settings.Clear();
+        stoppingTokenSource.Dispose();
+        await serviceProviderLease.DisposeAsync().ConfigureAwait(false);
     }
 
     public Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -21,7 +21,22 @@ class RunningEndpointInstance(SettingsHolder settings,
     object endpointLogSlot) : IEndpointInstance, IAsyncDisposable
 #pragma warning restore CS0618 // Type or member is obsolete
 {
+    // Stop is the legacy interface for shutting down the endpoint over the public API
+    // The modern hosted variant has Stop and DisposeAsync as separate steps, so the legacy Stop implementation
+    // must call DisposeAsync to ensure the endpoint is fully shut down and resources are released.
     public async Task Stop(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await StopCore(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    public async Task StopCore(CancellationToken cancellationToken = default)
     {
         if (status >= Status.Stopping)
         {
@@ -82,7 +97,7 @@ class RunningEndpointInstance(SettingsHolder settings,
             return;
         }
 
-        await Stop().ConfigureAwait(false);
+        await StopCore().ConfigureAwait(false);
 
         // Unregister the slot before disposing the service provider so no thread can
         // route through the (soon-to-be-disposed) ILoggerFactory after the provider is torn down.

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -21,9 +21,11 @@ class RunningEndpointInstance(SettingsHolder settings,
     object endpointLogSlot) : IEndpointInstance, IAsyncDisposable
 #pragma warning restore CS0618 // Type or member is obsolete
 {
-    // Stop is the legacy interface for shutting down the endpoint over the public API
-    // The modern hosted variant has Stop and DisposeAsync as separate steps, so the legacy Stop implementation
-    // must call DisposeAsync to ensure the endpoint is fully shut down and resources are released.
+    // Stop is the legacy interface for shutting down the endpoint over the public API.
+    // The modern hosted variant has Stop and DisposeAsync as separate steps:
+    // BaseEndpointLifecycle.Stop calls StopCore (shutdown only), then DisposeAsync (cleanup).
+    // The legacy Stop implementation must call DisposeAsync to ensure the endpoint is fully
+    // shut down and resources are released.
     public async Task Stop(CancellationToken cancellationToken = default)
     {
         try
@@ -43,11 +45,11 @@ class RunningEndpointInstance(SettingsHolder settings,
             return;
         }
 
-        // Serialize Stop so only one caller owns shutdown, while other callers wait
-        // until shutdown has completed before returning. The semaphore is an internal
-        // serialization mechanism; the caller's token must not be able to abort the wait
-        // because a failed wait leaves status as Running, allowing a subsequent
-        // DisposeAsync -> Stop(None) re-entry to attempt full shutdown against a DI
+        // The first caller to enter StopCore owns shutdown. Later callers that observe
+        // Stopping or Stopped return immediately without waiting. The semaphore is an
+        // internal serialization mechanism; the caller's token must not be able to abort
+        // the wait because a failed wait leaves status as Running, allowing a subsequent
+        // DisposeAsync -> StopCore re-entry to attempt full shutdown against a DI
         // container that is already torn down.
         await stopSemaphore.WaitAsync(CancellationToken.None).ConfigureAwait(false);
 


### PR DESCRIPTION
### Problem

When `Stop` is called with an already-cancelled token (e.g., during host shutdown when the cancellation token has already triggered), `stopSemaphore.WaitAsync(cancelledToken)` throws `OperationCanceledException` before entering the critical section. This leaves `status` as `Running` and `endpointInstance` non-null. The framework then calls `DisposeAsync`, which re-enters `Stop(CancellationToken.None)` and attempts full shutdown against a DI container that is already being torn down by the host, causing `ObjectDisposedException` on `stoppingTokenSource` or accessing a disposed `ILoggerFactory`.

The same race exists in `BaseEndpointLifecycle.Stop`: `lifeCycleSemaphore.WaitAsync(cancelledToken)` can fail, leaving `endpointInstance` non-null, and subsequent `DisposeAsync` re-enters stop against an already-disposed container.

### Solution

**RunningEndpointInstance** is refactored into three methods:

- `StopCore(CancellationToken)` performs shutdown only (cancel stopping token, stop components/transport). It uses `CancellationToken.None` on the semaphore wait because the semaphore is an internal serialization mechanism, not a cancellation point. The first caller to enter `StopCore` owns shutdown; later callers that observe `Stopping` or `Stopped` return immediately without waiting.
- `Stop(CancellationToken)` is the legacy `IEndpointInstance` API. It calls `StopCore` then `DisposeAsync` in a try/finally, so the public contract still covers full shutdown and cleanup.
- `DisposeAsync()` handles cleanup only (unregister log slot, clear settings, dispose CTS/service provider lease). It uses `Interlocked.Exchange` for idempotency and calls `StopCore` as a safety net in case `Stop` was never called.

**BaseEndpointLifecycle** changes:

- `Stop` uses `CancellationToken.None` on `lifeCycleSemaphore.WaitAsync` and calls `endpointInstance.StopCore(cancellationToken)` (not `Stop`), so cleanup is left to the separate `DisposeAsync` call.
- `DisposeAsync` uses `Interlocked.Exchange` on `isDisposed` for idempotency, reads/nulls `endpointInstance` (safe as a reference-type atomic read), then calls `instance.DisposeAsync()` and `providerLease.DisposeAsync()`. No semaphore is needed because `Interlocked.Exchange` already prevents concurrent entry.

**EndpointHostedService** is unchanged. The .NET Generic Host calls `StopAsync(token)` then `DisposeAsync()`, which maps to `lifecycle.Stop(token)` then `lifecycle.DisposeAsync()`. This is the correct two-step flow.

**Internally managed mode** (legacy `IEndpointInstance.Stop()`): calls `StopCore` then `DisposeAsync`, maintaining the original "stop and clean up everything" contract. Double-dispose of the service provider is idempotent.

### Key decisions

- `CancellationToken.None` on semaphore waits: the semaphore is an internal serialization mechanism; the caller token must not abort the wait because a failed wait leaves state as `Running`, allowing a subsequent `DisposeAsync` re-entry to attempt full shutdown against an already-torn-down DI container.
- `StopCore` early return: later callers that observe `Stopping` or `Stopped` return immediately. Only the first caller owns shutdown. This is intentional; waiting would add no value since the outcome is predetermined.
- Separate `Stop` and `DisposeAsync` in `BaseEndpointLifecycle`: allows the hosted service to control the lifecycle with a clean two-step flow (stop, then dispose).
- "Stopper" keyed singleton is intentionally a hidden backdoor for acceptance testing, not exposed in Core.

### Acceptance test

`When_stop_is_called_with_cancelled_token` cancels the scenario token after the endpoint starts, causing `StopEndpoints` to pass an already-cancelled token to `BaseEndpointLifecycle.Stop`. Without the fix, this exposes `ObjectDisposedException` during disposal.