### PR TITLE
Align Name of Acceptance test API overload introduced as part of #7668

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
@@ -75,7 +75,7 @@ public class EndpointBehaviorBuilder<TContext>(IEndpointConfigurationFactory end
         return this;
     }
 
-    public EndpointBehaviorBuilder<TContext> Resolves(Func<IServiceProvider, TContext, CancellationToken, Task> action, bool afterStart = false)
+    public EndpointBehaviorBuilder<TContext> ServiceResolve(Func<IServiceProvider, TContext, CancellationToken, Task> action, bool afterStart = false)
     {
         var actions = afterStart ? behavior.ResolveAfterStart : behavior.ResolvesBeforeStart;
         actions.Add((services, context, token) => action(services, (TContext)context, token));


### PR DESCRIPTION
Aligns the name of the second overload introduced in https://github.com/Particular/NServiceBus/pull/7668 (which is 10.2 area and therefore non-breaking)