### PR TITLE
Fix method usage

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Stopping/When_stop_is_called_with_cancelled_token.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Stopping/When_stop_is_called_with_cancelled_token.cs
@@ -34,7 +34,7 @@ public class When_stop_is_called_with_cancelled_token : NServiceBusAcceptanceTes
                     context = ctx;
                 })
                 .WithEndpoint<Endpoint>(b => b
-                    .Resolves(async (_, _, _) =>
+                    .ServiceResolve(async (_, _, _) =>
                     {
                         // Cancel the Run token so that StopEndpoints receives an
                         // already-canceled token, reproducing the race condition.


### PR DESCRIPTION
#7753 introduced a change which broke #7750 but when master changes PR's do not automatically recompile against latest so the PR stayed green and was mergable. 