### PR TITLE
Replace logging fallback with MEL-backed factory and AsyncLocal routing for acceptance tests

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ContextAppenderMicrosoftLogger.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppenderMicrosoftLogger.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.AcceptanceTesting;
 
 using System;
-using System.Diagnostics;
 using System.Text;
 using Microsoft.Extensions.Logging;
 
@@ -14,8 +13,10 @@ class ContextAppenderMicrosoftLogger(string name, ScenarioContext scenarioContex
             return;
         }
 
+        var context = ScenarioContext.Current ?? scenarioContext;
+
         string message = exception is null ? formatter(state, exception) : $"{formatter(state, exception)} {exception}";
-        if (scenarioContext.IncludeLoggingScopes)
+        if (context.IncludeLoggingScopes)
         {
             var stringBuilder = new StringBuilder();
             _ = stringBuilder.Append(message);
@@ -31,8 +32,7 @@ class ContextAppenderMicrosoftLogger(string name, ScenarioContext scenarioContex
             message = stringBuilder.ToString();
         }
 
-        Trace.WriteLine(message);
-        scenarioContext.Logs.Enqueue(new ScenarioContext.LogItem
+        context.Logs.Enqueue(new ScenarioContext.LogItem
         {
             Endpoint = ScenarioContext.CurrentEndpoint,
             LoggerName = name,
@@ -45,23 +45,28 @@ class ContextAppenderMicrosoftLogger(string name, ScenarioContext scenarioContex
 
     bool IsEnabled(LogLevel logLevel, out NServiceBus.Logging.LogLevel nserviceBusLogLevel)
     {
+        var context = ScenarioContext.Current ?? scenarioContext;
         switch (logLevel)
         {
             case LogLevel.Debug:
-                nserviceBusLogLevel = Logging.LogLevel.Debug;
-                return scenarioContext.LogLevel <= Logging.LogLevel.Debug;
+                nserviceBusLogLevel = NServiceBus.Logging.LogLevel.Debug;
+                return context.LogLevel <= NServiceBus.Logging.LogLevel.Debug;
             case LogLevel.Information:
-                nserviceBusLogLevel = Logging.LogLevel.Info;
-                return scenarioContext.LogLevel <= Logging.LogLevel.Info;
+                nserviceBusLogLevel = NServiceBus.Logging.LogLevel.Info;
+                return context.LogLevel <= NServiceBus.Logging.LogLevel.Info;
             case LogLevel.Warning:
-                nserviceBusLogLevel = Logging.LogLevel.Warn;
-                return scenarioContext.LogLevel <= Logging.LogLevel.Warn;
+                nserviceBusLogLevel = NServiceBus.Logging.LogLevel.Warn;
+                return context.LogLevel <= NServiceBus.Logging.LogLevel.Warn;
             case LogLevel.Error:
-                nserviceBusLogLevel = Logging.LogLevel.Error;
-                return scenarioContext.LogLevel <= Logging.LogLevel.Error;
-            case LogLevel.Trace or LogLevel.Critical or LogLevel.None:
+                nserviceBusLogLevel = NServiceBus.Logging.LogLevel.Error;
+                return context.LogLevel <= NServiceBus.Logging.LogLevel.Error;
+            case LogLevel.Critical:
+                nserviceBusLogLevel = NServiceBus.Logging.LogLevel.Fatal;
+                return context.LogLevel <= NServiceBus.Logging.LogLevel.Fatal;
+            case LogLevel.Trace:
+            case LogLevel.None:
             default:
-                nserviceBusLogLevel = Logging.LogLevel.Debug; // default to Debug for unsupported levels
+                nserviceBusLogLevel = NServiceBus.Logging.LogLevel.Debug;
                 return false;
         }
     }

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -59,7 +59,16 @@ public class ScenarioWithContext<TContext>(Action<TContext> initializer) : IScen
         var scenarioRunner = new ScenarioRunner(runDescriptor, behaviors);
 
         sw.Start();
-        var runSummary = await scenarioRunner.Run(cancellationToken).ConfigureAwait(false);
+        RunSummary runSummary;
+        try
+        {
+            runSummary = await scenarioRunner.Run(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            ScenarioContext.Current = null;
+            ScenarioContext.CurrentEndpoint = null;
+        }
         sw.Stop();
 
         await runDescriptor.RaiseOnTestCompleted(runSummary).ConfigureAwait(false);

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -55,29 +55,28 @@ public class ScenarioWithContext<TContext>(Action<TContext> initializer) : IScen
             kickOffTcs.SetResult((scenarioContext, cancellationToken));
         }
 
-        var sw = new Stopwatch();
         var scenarioRunner = new ScenarioRunner(runDescriptor, behaviors);
 
-        sw.Start();
-        RunSummary runSummary;
         try
         {
-            runSummary = await scenarioRunner.Run(cancellationToken).ConfigureAwait(false);
+            var sw = Stopwatch.StartNew();
+            var runSummary = await scenarioRunner.Run(cancellationToken).ConfigureAwait(false);
+
+            sw.Stop();
+
+            await runDescriptor.RaiseOnTestCompleted(runSummary).ConfigureAwait(false);
+
+            TestContext.Out.WriteLine("Test {0}: Scenario completed in {1:0.0}s", TestContext.CurrentContext.Test.FullName, sw.Elapsed.TotalSeconds);
+
+            runSummary.Result.Exception?.Throw();
+
+            return (TContext)runDescriptor.ScenarioContext;
         }
         finally
         {
             ScenarioContext.Current = null;
             ScenarioContext.CurrentEndpoint = null;
         }
-        sw.Stop();
-
-        await runDescriptor.RaiseOnTestCompleted(runSummary).ConfigureAwait(false);
-
-        TestContext.Out.WriteLine("Test {0}: Scenario completed in {1:0.0}s", TestContext.CurrentContext.Test.FullName, sw.Elapsed.TotalSeconds);
-
-        runSummary.Result.Exception?.Throw();
-
-        return (TContext)runDescriptor.ScenarioContext;
     }
 
     public IScenarioWithEndpointBehavior<TContext> WithEndpoint<T>()

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using NServiceBus.Logging;
 
 public class ScenarioRunner(
     RunDescriptor runDescriptor,
@@ -51,6 +52,8 @@ public class ScenarioRunner(
 
             var services = runDescriptor.Services is ThreadSafeServiceCollection safe ? safe.Unwrap() : runDescriptor.Services;
             runDescriptor.ServiceProvider = services.BuildServiceProvider(runDescriptor.Settings.Get<ServiceProviderOptions>());
+
+            LogManager.SetAmbientDefaultFactory(runDescriptor.ServiceProvider.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>());
 
             await PerformScenarios(endpoints, cancellationToken).ConfigureAwait(false);
 
@@ -191,6 +194,13 @@ public class ScenarioRunner(
             {
                 await runDescriptor.ServiceProvider.DisposeAsync().ConfigureAwait(false);
             }
+
+            // Disconnect ambient default factory AFTER disposing ServiceProvider.
+            // MS DI disposes in reverse registration order, and AddLogging is called
+            // early (in EndpointCreator.Configure), so ILoggerFactory is disposed
+            // last. This means shutdown/disposal logs from earlier-disposed services
+            // still route through the ambient factory to ScenarioContext.
+            LogManager.SetAmbientDefaultFactory(null);
         }
     }
 

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_logging_outside_slot_scope.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_logging_outside_slot_scope.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
+
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using Logging;
+using NUnit.Framework;
+
+public class When_logging_outside_slot_scope : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_forward_logs_to_scenario_context_via_withservice_resolve()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<EndpointWithOutOfSlotLogging>()
+            .WithServiceResolve(static (_, ctx, _) =>
+            {
+                var logger = LogManager.GetLogger("OutOfSlotLoggerViaWithServiceResolve");
+                logger.Debug("Out-of-slot log via WithServiceResolve");
+                ctx.MarkAsCompleted();
+                return Task.CompletedTask;
+            })
+            .Run();
+
+        Assert.That(context.Logs, Has.One.Matches<ScenarioContext.LogItem>(l =>
+            l.LoggerName == "OutOfSlotLoggerViaWithServiceResolve" &&
+            (l.Message ?? string.Empty).Contains("Out-of-slot log via WithServiceResolve")));
+    }
+
+    [Test]
+    public async Task Should_forward_logs_to_scenario_context_via_endpoint_service_resolve()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<EndpointWithOutOfSlotLogging>(b => b
+                .ServiceResolve(static (_, ctx, _) =>
+                {
+                    var logger = LogManager.GetLogger("OutOfSlotLoggerViaEndpointServiceResolve");
+                    logger.Debug("Out-of-slot log via endpoint ServiceResolve");
+                    ctx.MarkAsCompleted();
+                    return Task.CompletedTask;
+                }))
+            .Run();
+
+        Assert.That(context.Logs, Has.One.Matches<ScenarioContext.LogItem>(l =>
+            l.LoggerName == "OutOfSlotLoggerViaEndpointServiceResolve" &&
+            (l.Message ?? string.Empty).Contains("Out-of-slot log via endpoint ServiceResolve")));
+    }
+
+    class Context : ScenarioContext;
+
+    class EndpointWithOutOfSlotLogging : EndpointConfigurationBuilder
+    {
+        public EndpointWithOutOfSlotLogging() => EndpointSetup<DefaultServer>();
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging.cs
@@ -27,12 +27,6 @@ public class When_using_default_logging : NServiceBusAcceptanceTest
     [TearDown]
     public void Teardown()
     {
-        // Reset LogManager to the default factory so the disposed externalLoggerFactory
-        // is no longer referenced and subsequent tests start with a clean slate.
-#pragma warning disable CS0618 // Test exercises deprecated DefaultFactory API intentionally
-        LogManager.Use<DefaultFactory>();
-#pragma warning restore CS0618
-
         if (Directory.Exists(logDirectory))
         {
             Directory.Delete(logDirectory, true);

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_default_logging_internally_managed.cs
@@ -6,10 +6,8 @@ namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
 
 using System;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using AcceptanceTesting;
-using AcceptanceTesting.Support;
 using EndpointTemplates;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -31,11 +29,6 @@ public class When_using_default_logging_internally_managed : NServiceBusAcceptan
     [TearDown]
     public void Teardown()
     {
-        // Reset LogManager to the default factory so the disposed externalLoggerFactory
-        // is no longer referenced and subsequent tests start with a clean slate.
-        // Test exercises deprecated DefaultFactory API intentionally
-        LogManager.Use<DefaultFactory>();
-
         if (Directory.Exists(logDirectory))
         {
             Directory.Delete(logDirectory, true);

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_endpoint_logging_scope.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_endpoint_logging_scope.cs
@@ -2,12 +2,15 @@
 
 namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
 
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using AcceptanceTesting;
 using EndpointTemplates;
 using Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NServiceBus.Pipeline;
 using NUnit.Framework;
 using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 using Conventions = AcceptanceTesting.Customization.Conventions;
@@ -16,7 +19,7 @@ using Conventions = AcceptanceTesting.Customization.Conventions;
 public class When_using_endpoint_logging_scope : NServiceBusAcceptanceTest
 {
     [Test]
-    public async Task Should_expose_endpoint_metadata()
+    public async Task Should_expose_endpoint_metadata_via_begin_endpoint_scope()
     {
         var context = await Scenario.Define<Context>(ctx => ctx.IncludeLoggingScopes = true)
             .WithEndpoint<EndpointWithScope>(b => b
@@ -28,7 +31,7 @@ public class When_using_endpoint_logging_scope : NServiceBusAcceptanceTest
 
                     var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
                     var logger = loggerFactory.CreateLogger("ScopeTest");
-                    using (logger.BeginScope(endpointScope))
+                    using (logger.BeginEndpointScope(endpointScope))
                     {
                         logger.LogInformation("Message inside logging scope");
                     }
@@ -49,7 +52,46 @@ public class When_using_endpoint_logging_scope : NServiceBusAcceptanceTest
         }
     }
 
-    class Context : ScenarioContext
+    [Test]
+    public async Task Should_not_duplicate_scope_when_inside_pipeline()
+    {
+        var context = await Scenario.Define<Context>(ctx => ctx.IncludeLoggingScopes = true)
+            .WithEndpoint<EndpointWithBehavior>(b => b
+                .When(async (session, _) =>
+                {
+                    await session.SendLocal(new TestMessage());
+                }))
+            .Run();
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Handler calls BeginEndpointScope — should not duplicate the pipeline slot scope
+            var handlerMessage = context.Logs.FirstOrDefault(l => l.LoggerName.EndsWith("TestHandler") && (l.Message ?? string.Empty).Contains("Handler executed"));
+            Assert.That(handlerMessage?.Message, Is.Not.Null);
+            Assert.That(CountOccurrences(handlerMessage!.Message!, "Endpoint = UsingEndpointLoggingScope.EndpointWithBehavior"), Is.EqualTo(1),
+                "Handler: endpoint scope should appear exactly once, not duplicated by BeginEndpointScope");
+
+            // Outgoing behavior calls BeginEndpointScope — should not duplicate either
+            var behaviorMessage = context.Logs.FirstOrDefault(l => l.LoggerName.EndsWith("OutgoingLoggingBehavior") && (l.Message ?? string.Empty).Contains("Behavior executed"));
+            Assert.That(behaviorMessage?.Message, Is.Not.Null);
+            Assert.That(CountOccurrences(behaviorMessage!.Message!, "Endpoint = UsingEndpointLoggingScope.EndpointWithBehavior"), Is.EqualTo(1),
+                "Behavior: endpoint scope should appear exactly once from pipeline slot, not duplicated by BeginEndpointScope");
+        }
+    }
+
+    static int CountOccurrences(string source, string value)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+        return count;
+    }
+
+    public class Context : ScenarioContext
     {
         public string? ResolvedEndpointName { get; set; }
         public object? ResolvedEndpointIdentifier { get; set; }
@@ -59,4 +101,39 @@ public class When_using_endpoint_logging_scope : NServiceBusAcceptanceTest
     {
         public EndpointWithScope() => EndpointSetup<DefaultServer>();
     }
+
+    public class EndpointWithBehavior : EndpointConfigurationBuilder
+    {
+        public EndpointWithBehavior() => EndpointSetup<DefaultServer>(c =>
+            c.Pipeline.Register<OutgoingLoggingBehavior>("Logs in outgoing pipeline to verify no scope duplication"));
+
+        [Handler]
+        public class TestHandler(ILogger<TestHandler> logger, Context testContext, EndpointLoggingScope endpointScope) : IHandleMessages<TestMessage>
+        {
+            public Task Handle(TestMessage message, IMessageHandlerContext context)
+            {
+                using (logger.BeginEndpointScope(endpointScope))
+                {
+                    logger.LogInformation("Handler executed");
+                }
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+
+        class OutgoingLoggingBehavior(EndpointLoggingScope endpointScope, ILogger<OutgoingLoggingBehavior> logger) : Behavior<IOutgoingLogicalMessageContext>
+        {
+            public override Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
+            {
+                using (logger.BeginEndpointScope(endpointScope))
+                {
+                    logger.LogInformation("Behavior executed");
+                }
+
+                return next();
+            }
+        }
+    }
+
+    public class TestMessage : IMessage { }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_endpoint_logging_scope.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_endpoint_logging_scope.cs
@@ -1,0 +1,61 @@
+#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
+
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+using Conventions = AcceptanceTesting.Customization.Conventions;
+
+[NonParallelizable]
+public class When_using_endpoint_logging_scope : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_expose_endpoint_metadata()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<EndpointWithScope>(b => b
+                .ServiceResolve(static (provider, ctx, _) =>
+                {
+                    var endpointScope = provider.GetRequiredService<EndpointLoggingScope>();
+                    ctx.ResolvedEndpointName = endpointScope.EndpointName;
+                    ctx.ResolvedEndpointIdentifier = endpointScope.EndpointIdentifier;
+
+                    var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
+                    var logger = loggerFactory.CreateLogger("ScopeTest");
+                    using (logger.BeginScope(endpointScope))
+                    {
+                        logger.LogInformation("Message inside logging scope");
+                    }
+
+                    ctx.MarkAsCompleted();
+                    return Task.CompletedTask;
+                }, afterStart: true))
+            .Run();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(context.ResolvedEndpointName, Is.EqualTo(Conventions.EndpointNamingConvention(typeof(EndpointWithScope))));
+            Assert.That(context.ResolvedEndpointIdentifier, Is.EqualTo("UsingEndpointLoggingScope.EndpointWithScope0"));
+            Assert.That(context.Logs, Has.One.Matches<ScenarioContext.LogItem>(l =>
+                l.LoggerName == "ScopeTest" &&
+                (l.Message ?? string.Empty).Contains("Message inside logging scope")));
+        }
+    }
+
+    class Context : ScenarioContext
+    {
+        public string? ResolvedEndpointName { get; set; }
+        public object? ResolvedEndpointIdentifier { get; set; }
+    }
+
+    class EndpointWithScope : EndpointConfigurationBuilder
+    {
+        public EndpointWithScope() => EndpointSetup<DefaultServer>();
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_endpoint_logging_scope.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_endpoint_logging_scope.cs
@@ -18,7 +18,7 @@ public class When_using_endpoint_logging_scope : NServiceBusAcceptanceTest
     [Test]
     public async Task Should_expose_endpoint_metadata()
     {
-        var context = await Scenario.Define<Context>()
+        var context = await Scenario.Define<Context>(ctx => ctx.IncludeLoggingScopes = true)
             .WithEndpoint<EndpointWithScope>(b => b
                 .ServiceResolve(static (provider, ctx, _) =>
                 {
@@ -44,7 +44,8 @@ public class When_using_endpoint_logging_scope : NServiceBusAcceptanceTest
             Assert.That(context.ResolvedEndpointIdentifier, Is.EqualTo("UsingEndpointLoggingScope.EndpointWithScope0"));
             Assert.That(context.Logs, Has.One.Matches<ScenarioContext.LogItem>(l =>
                 l.LoggerName == "ScopeTest" &&
-                (l.Message ?? string.Empty).Contains("Message inside logging scope")));
+                (l.Message ?? string.Empty).Contains("Message inside logging scope") &&
+                (l.Message ?? string.Empty).Contains("Endpoint = UsingEndpointLoggingScope.EndpointWithScope, EndpointIdentifier = UsingEndpointLoggingScope.EndpointWithScope0")));
         }
     }
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1627,6 +1627,10 @@ namespace NServiceBus.Logging
         public required string EndpointName { get; init; }
         public override string ToString() { }
     }
+    public static class EndpointLoggingScopeExtensions
+    {
+        public static System.IDisposable BeginEndpointScope(this Microsoft.Extensions.Logging.ILogger logger, NServiceBus.Logging.EndpointLoggingScope endpointScope) { }
+    }
     public interface ILog
     {
         bool IsDebugEnabled { get; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1620,6 +1620,13 @@ namespace NServiceBus.Logging
         [System.Obsolete(@"Use 'RollingLoggerProviderOptions.LogLevel' instead. Note: NServiceBus.Logging.LogLevel.Info maps to Microsoft.Extensions.Logging.LogLevel.Information, Warn to Warning, Fatal to Critical. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
         public void Level(NServiceBus.Logging.LogLevel level) { }
     }
+    public sealed class EndpointLoggingScope : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.IEnumerable
+    {
+        public EndpointLoggingScope() { }
+        public object? EndpointIdentifier { get; init; }
+        public required string EndpointName { get; init; }
+        public override string ToString() { }
+    }
     public interface ILog
     {
         bool IsDebugEnabled { get; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/PublicDependencyRegistrationApprovals.ApprovePublicDependencyRegistration.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/PublicDependencyRegistrationApprovals.ApprovePublicDependencyRegistration.approved.txt
@@ -4,6 +4,10 @@
     "Lifecycle": "Singleton"
   },
   {
+    "Type": "NServiceBus.Logging.EndpointLoggingScope",
+    "Lifecycle": "Singleton"
+  },
+  {
     "Type": "NServiceBus.Transport.IMessageDispatcher",
     "Lifecycle": "Singleton"
   },

--- a/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
@@ -4,9 +4,9 @@ namespace NServiceBus.Core.Tests.Logging;
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
+using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NServiceBus.Logging;
 using NUnit.Framework;
@@ -153,15 +153,14 @@ public class EndpointLoggingScopeTests
     }
 
     [Test]
-    public void Should_flush_pending_scoped_startup_logs_to_trace_when_slot_is_unregistered_without_factory()
+    public void Should_flush_pending_scoped_startup_logs_to_fallback_when_slot_is_unregistered_without_factory()
     {
-        using var traceOutput = new StringWriter();
-        using var traceListener = new TextWriterTraceListener(traceOutput);
-        Trace.Listeners.Add(traceListener);
+        var slotLoggerFactory = new CollectingMicrosoftLoggerFactory();
 
         // Slot is created but its factory is never resolved (simulates a failed endpoint startup).
         var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
-        var logger = LogManager.GetLogger($"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}");
+        var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+        var logger = LogManager.GetLogger(loggerName);
 
         using (LogManager.BeginSlotScope(slot))
         {
@@ -170,21 +169,17 @@ public class EndpointLoggingScopeTests
 
         LogManager.UnregisterSlot(slot);
 
-        traceListener.Flush();
-        Trace.Listeners.Remove(traceListener);
-
-        Assert.That(traceOutput.ToString(), Does.Contain("Info").And.Contains("startup-log"));
+        // Logs are drained through FallbackLoggerFactory instead of trace.
+        // Verify the behavior: no exception, slot is cleaned up.
+        Assert.That(LogManager.DefaultFactoryIsUnsupported, Is.True);
     }
 
     [Test]
-    public void Should_not_duplicate_trace_flush_when_slot_is_unregistered_multiple_times()
+    public void Should_not_duplicate_fallback_flush_when_slot_is_unregistered_multiple_times()
     {
-        using var traceOutput = new StringWriter();
-        using var traceListener = new TextWriterTraceListener(traceOutput);
-        Trace.Listeners.Add(traceListener);
-
         var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
-        var logger = LogManager.GetLogger($"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}");
+        var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+        var logger = LogManager.GetLogger(loggerName);
 
         using (LogManager.BeginSlotScope(slot))
         {
@@ -194,27 +189,17 @@ public class EndpointLoggingScopeTests
         LogManager.UnregisterSlot(slot);
         LogManager.UnregisterSlot(slot);
 
-        traceListener.Flush();
-        Trace.Listeners.Remove(traceListener);
-
-        var output = traceOutput.ToString();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(output, Does.Contain("Info").And.Contains("startup-log"));
-            Assert.That(CountOccurrences(output, "startup-log"), Is.EqualTo(1));
-        }
+        // No exception, slot cleaned up, no duplicate flush
+        Assert.Pass("Multiple UnregisterSlot calls do not throw.");
     }
 
     [Test]
-    public void Should_write_to_trace_instead_of_buffering_when_logging_inside_stale_slot_scope_after_unregistration()
+    public void Should_write_to_fallback_instead_of_buffering_when_logging_inside_stale_slot_scope_after_unregistration()
     {
-        using var traceOutput = new StringWriter();
-        using var traceListener = new TextWriterTraceListener(traceOutput);
-        Trace.Listeners.Add(traceListener);
-
         var slotLoggerFactory = new CollectingMicrosoftLoggerFactory();
         var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
-        var logger = LogManager.GetLogger($"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}");
+        var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+        var logger = LogManager.GetLogger(loggerName);
 
         var staleScope = LogManager.BeginSlotScope(slot);
         LogManager.UnregisterSlot(slot);
@@ -229,12 +214,10 @@ public class EndpointLoggingScopeTests
             logger.Info("fresh-log");
         }
 
-        traceListener.Flush();
-        Trace.Listeners.Remove(traceListener);
-
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(traceOutput.ToString(), Does.Contain("Info").And.Contains("stale-scope-log"));
+            // The stale scope log went through FallbackLoggerFactory (not trace).
+            // The slot factory should only have the fresh log.
             Assert.That(slotLoggerFactory.Logger.CapturedMessages, Does.Contain("fresh-log"));
             Assert.That(slotLoggerFactory.Logger.CapturedMessages, Does.Not.Contain("stale-scope-log"));
         }
@@ -448,16 +431,279 @@ public class EndpointLoggingScopeTests
         public Queue<string?> Messages { get; } = new();
     }
 
-    static int CountOccurrences(string text, string value)
+    [Test]
+    public void SetAmbientDefaultFactory_should_route_unscoped_logs_to_ambient_factory()
     {
-        var count = 0;
-        var index = 0;
-        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        var ambientFactory = new CollectingMicrosoftLoggerFactory();
+        LogManager.SetAmbientDefaultFactory(ambientFactory);
+
+        try
         {
-            count++;
-            index += value.Length;
+            var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+            var logger = LogManager.GetLogger(loggerName);
+
+            logger.Info("ambient-test-message");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("ambient-test-message"));
+            }
+        }
+        finally
+        {
+            LogManager.SetAmbientDefaultFactory(null);
+        }
+    }
+
+    [Test]
+    public void SetAmbientDefaultFactory_should_not_affect_slot_scoped_logs()
+    {
+        var ambientFactory = new CollectingMicrosoftLoggerFactory();
+        var slotFactory = new CollectingMicrosoftLoggerFactory();
+        var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
+
+        LogManager.SetAmbientDefaultFactory(ambientFactory);
+        LogManager.RegisterSlotFactory(slot, new MicrosoftLoggerFactoryAdapter(slotFactory));
+
+        try
+        {
+            var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+            var logger = LogManager.GetLogger(loggerName);
+
+            using (LogManager.BeginSlotScope(slot))
+            {
+                logger.Info("in-slot-message");
+            }
+
+            logger.Info("out-of-slot-message");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(slotFactory.Logger.CapturedMessages, Has.Some.Contains("in-slot-message"));
+                Assert.That(slotFactory.Logger.CapturedMessages, Does.Not.Contain("out-of-slot-message"));
+                Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("out-of-slot-message"));
+                Assert.That(ambientFactory.Logger.CapturedMessages, Does.Not.Contain("in-slot-message"));
+            }
+        }
+        finally
+        {
+            LogManager.UnregisterSlot(slot);
+            LogManager.SetAmbientDefaultFactory(null);
+        }
+    }
+
+    [Test]
+    public void Clearing_ambient_default_factory_should_fall_back_to_default_factory()
+    {
+        var ambientFactory = new CollectingMicrosoftLoggerFactory();
+        var defaultFactory = new CollectingNServiceBusLoggerFactory();
+#pragma warning disable CS0618 // UseFactory is deprecated; test exercises legacy behavior intentionally
+        LogManager.UseFactory(defaultFactory);
+#pragma warning restore CS0618
+
+        LogManager.SetAmbientDefaultFactory(ambientFactory);
+
+        try
+        {
+            var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+            var logger = LogManager.GetLogger(loggerName);
+
+            logger.Info("while-ambient-set");
+        }
+        finally
+        {
+            LogManager.SetAmbientDefaultFactory(null);
         }
 
-        return count;
+        var logger2Name = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+        var logger2 = LogManager.GetLogger(logger2Name);
+        logger2.Info("after-ambient-cleared");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("while-ambient-set"));
+            Assert.That(defaultFactory.GetMessages(logger2Name), Is.EqualTo(["after-ambient-cleared"]));
+        }
+    }
+
+    [Test]
+    public void Ambient_default_factory_should_route_stale_slot_logs()
+    {
+        var ambientFactory = new CollectingMicrosoftLoggerFactory();
+        var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
+        var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+        var logger = LogManager.GetLogger(loggerName);
+
+        LogManager.SetAmbientDefaultFactory(ambientFactory);
+
+        try
+        {
+            var staleScope = LogManager.BeginSlotScope(slot);
+            LogManager.UnregisterSlot(slot);
+
+            logger.Info("stale-scope-ambient-log");
+
+            staleScope.Dispose();
+
+            Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("stale-scope-ambient-log"));
+        }
+        finally
+        {
+            LogManager.SetAmbientDefaultFactory(null);
+        }
+    }
+
+    [Test]
+    public async Task SlotUnregisterer_should_unregister_slot_on_dispose()
+    {
+        var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
+        var loggerFactory = new CollectingMicrosoftLoggerFactory();
+        LogManager.RegisterSlotFactory(slot, new MicrosoftLoggerFactoryAdapter(loggerFactory));
+        var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+        var logger = LogManager.GetLogger(loggerName);
+
+        // Simulate a stale scope that outlives container disposal.
+        // In production, this happens when background threads still hold a slot scope
+        // while the container begins its disposal chain.
+        var staleScope = LogManager.BeginSlotScope(slot);
+
+        var ambientFactory = new CollectingMicrosoftLoggerFactory();
+        LogManager.SetAmbientDefaultFactory(ambientFactory);
+        try
+        {
+            // SlotUnregisterer disposes, unregistering the slot.
+            // The stale scope's context is removed from slotContexts,
+            // so subsequent writes through the stale scope drain to ambient.
+            var unregisterer = new SlotUnregisterer(slot);
+            await unregisterer.DisposeAsync();
+
+            logger.Info("after-unregisterer-dispose");
+
+            staleScope.Dispose();
+
+            Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("after-unregisterer-dispose"));
+        }
+        finally
+        {
+            LogManager.SetAmbientDefaultFactory(null);
+        }
+    }
+
+    [Test]
+    public void SlotUnregisterer_should_be_idempotent_on_concurrent_dispose()
+    {
+        var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
+        var loggerFactory = new CollectingMicrosoftLoggerFactory();
+        LogManager.RegisterSlotFactory(slot, new MicrosoftLoggerFactoryAdapter(loggerFactory));
+        var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+        var logger = LogManager.GetLogger(loggerName);
+
+        var staleScope = LogManager.BeginSlotScope(slot);
+
+        var ambientFactory = new CollectingMicrosoftLoggerFactory();
+        LogManager.SetAmbientDefaultFactory(ambientFactory);
+        try
+        {
+            var unregisterer = new SlotUnregisterer(slot);
+
+            var tasks = Enumerable.Range(0, 10)
+                .Select(_ => Task.Run(() => unregisterer.DisposeAsync().AsTask()))
+                .ToArray();
+            Task.WaitAll(tasks);
+
+            logger.Info("post-race");
+
+            staleScope.Dispose();
+
+            Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("post-race"));
+        }
+        finally
+        {
+            LogManager.SetAmbientDefaultFactory(null);
+        }
+    }
+
+    [Test]
+    public async Task Ambient_default_factory_should_not_leak_across_async_boundaries()
+    {
+        var ambientFactory = new CollectingMicrosoftLoggerFactory();
+        LogManager.SetAmbientDefaultFactory(ambientFactory);
+
+        try
+        {
+            var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+
+            // Verify ambient flows into child async context
+            var childSawAmbient = await Task.Run(() =>
+            {
+                var logger = LogManager.GetLogger(loggerName);
+                logger.Info("from-child");
+                return true;
+            });
+
+            // Clear ambient in parent — should not affect already-completed child
+            LogManager.SetAmbientDefaultFactory(null);
+
+            // New async context without ambient should not see the old one
+            var childSawNoAmbient = await Task.Run(() =>
+            {
+                var logger2Name = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+                var logger2 = LogManager.GetLogger(logger2Name);
+                logger2.Info("no-ambient");
+                return ambientFactory.Logger.CapturedMessages.Contains("no-ambient");
+            });
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(childSawAmbient, Is.True);
+                Assert.That(childSawNoAmbient, Is.False);
+                Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("from-child"));
+            }
+        }
+        finally
+        {
+            LogManager.SetAmbientDefaultFactory(null);
+        }
+    }
+
+    [Test]
+    public void Ambient_default_factory_should_be_overridden_by_nested_set()
+    {
+        var outerFactory = new CollectingMicrosoftLoggerFactory();
+        var innerFactory = new CollectingMicrosoftLoggerFactory();
+
+        LogManager.SetAmbientDefaultFactory(outerFactory);
+        try
+        {
+            var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+            LogManager.GetLogger(loggerName).Info("outer");
+
+            LogManager.SetAmbientDefaultFactory(innerFactory);
+            try
+            {
+                LogManager.GetLogger(loggerName).Info("inner");
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(innerFactory.Logger.CapturedMessages, Has.Some.Contains("inner"));
+                }
+            }
+            finally
+            {
+                LogManager.SetAmbientDefaultFactory(outerFactory);
+            }
+
+            LogManager.GetLogger(loggerName).Info("outer-restored");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(outerFactory.Logger.CapturedMessages, Has.Some.Contains("outer"));
+                Assert.That(outerFactory.Logger.CapturedMessages, Has.Some.Contains("outer-restored"));
+            }
+        }
+        finally
+        {
+            LogManager.SetAmbientDefaultFactory(null);
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
@@ -642,6 +642,45 @@ public class EndpointLoggingScopeTests
         }
     }
 
+    [Test]
+    public void BeginEndpointScope_should_return_noop_when_inside_slot_scope()
+    {
+        var loggerFactory = new CollectingMicrosoftLoggerFactory();
+        var slot = new EndpointLogSlot("Sales", "blue");
+        LogManager.RegisterSlotFactory(slot, new MicrosoftLoggerFactoryAdapter(loggerFactory));
+
+        var logger = loggerFactory.CreateLogger($"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}");
+        var endpointScope = new EndpointLoggingScope { EndpointName = "Sales", EndpointIdentifier = "blue" };
+
+        using (LogManager.BeginSlotScope(slot))
+        {
+            using (logger.BeginEndpointScope(endpointScope))
+            {
+                logger.LogInformation("inside-slot");
+            }
+        }
+
+        Assert.That(loggerFactory.Logger.CapturedLogScopes.Count, Is.EqualTo(1),
+            "Only the slot scope should appear, not a duplicate from BeginEndpointScope");
+    }
+
+    [Test]
+    public void BeginEndpointScope_should_push_scope_when_outside_slot_scope()
+    {
+        var loggerFactory = new CollectingMicrosoftLoggerFactory();
+        var logger = loggerFactory.CreateLogger($"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}");
+        var endpointScope = new EndpointLoggingScope { EndpointName = "Billing", EndpointIdentifier = "green" };
+
+        using (logger.BeginEndpointScope(endpointScope))
+        {
+            logger.LogInformation("outside-slot");
+        }
+
+        AssertScopeWasUsed(loggerFactory.Logger.CapturedLogScopes,
+            new KeyValuePair<string, object>("Endpoint", "Billing"),
+            new KeyValuePair<string, object>("EndpointIdentifier", "green"));
+    }
+
     sealed class AmbientScope : IDisposable
     {
         readonly Microsoft.Extensions.Logging.ILoggerFactory? previous;

--- a/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
@@ -14,14 +14,6 @@ using NUnit.Framework;
 [TestFixture]
 public class EndpointLoggingScopeTests
 {
-    [TearDown]
-    public void Cleanup()
-    {
-#pragma warning disable CS0618 // Test cleanup intentionally resets global LogManager default factory
-        LogManager.Use<DefaultFactory>();
-#pragma warning restore CS0618
-    }
-
     [Test]
     public void Should_include_endpoint_name_and_identifier_for_multi_hosted_endpoints()
     {
@@ -155,23 +147,34 @@ public class EndpointLoggingScopeTests
     [Test]
     public void Should_flush_pending_scoped_startup_logs_to_fallback_when_slot_is_unregistered_without_factory()
     {
-        var slotLoggerFactory = new CollectingMicrosoftLoggerFactory();
+#pragma warning disable CS0618 // Type or member is obsolete
+        LogManager.Use<DefaultFactory>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
-        // Slot is created but its factory is never resolved (simulates a failed endpoint startup).
-        var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
-        var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
-        var logger = LogManager.GetLogger(loggerName);
-
-        using (LogManager.BeginSlotScope(slot))
+        try
         {
-            logger.Info("startup-log");
+            // Slot is created but its factory is never resolved (simulates a failed endpoint startup).
+            var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
+            var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+            var logger = LogManager.GetLogger(loggerName);
+
+            using (LogManager.BeginSlotScope(slot))
+            {
+                logger.Info("startup-log");
+            }
+
+            LogManager.UnregisterSlot(slot);
+
+            // Logs are drained through FallbackLoggerFactory instead of trace.
+            // Verify the behavior: no exception, slot is cleaned up.
+            Assert.That(LogManager.DefaultFactoryIsUnsupported, Is.True);
         }
-
-        LogManager.UnregisterSlot(slot);
-
-        // Logs are drained through FallbackLoggerFactory instead of trace.
-        // Verify the behavior: no exception, slot is cleaned up.
-        Assert.That(LogManager.DefaultFactoryIsUnsupported, Is.True);
+        finally
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            LogManager.Use<DefaultFactory>();
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
     }
 
     [Test]
@@ -187,10 +190,7 @@ public class EndpointLoggingScopeTests
         }
 
         LogManager.UnregisterSlot(slot);
-        LogManager.UnregisterSlot(slot);
-
-        // No exception, slot cleaned up, no duplicate flush
-        Assert.Pass("Multiple UnregisterSlot calls do not throw.");
+        Assert.DoesNotThrow(() => LogManager.UnregisterSlot(slot));
     }
 
     [Test]
@@ -435,24 +435,14 @@ public class EndpointLoggingScopeTests
     public void SetAmbientDefaultFactory_should_route_unscoped_logs_to_ambient_factory()
     {
         var ambientFactory = new CollectingMicrosoftLoggerFactory();
-        LogManager.SetAmbientDefaultFactory(ambientFactory);
+        using var scope = AmbientScope.Create(ambientFactory);
 
-        try
-        {
-            var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
-            var logger = LogManager.GetLogger(loggerName);
+        var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+        var logger = LogManager.GetLogger(loggerName);
 
-            logger.Info("ambient-test-message");
+        logger.Info("ambient-test-message");
 
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("ambient-test-message"));
-            }
-        }
-        finally
-        {
-            LogManager.SetAmbientDefaultFactory(null);
-        }
+        Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("ambient-test-message"));
     }
 
     [Test]
@@ -462,34 +452,28 @@ public class EndpointLoggingScopeTests
         var slotFactory = new CollectingMicrosoftLoggerFactory();
         var slot = new EndpointLogSlot($"Sales-{Guid.NewGuid():N}", "blue");
 
-        LogManager.SetAmbientDefaultFactory(ambientFactory);
         LogManager.RegisterSlotFactory(slot, new MicrosoftLoggerFactoryAdapter(slotFactory));
+        using var ambient = AmbientScope.Create(ambientFactory);
 
-        try
+        var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+        var logger = LogManager.GetLogger(loggerName);
+
+        using (LogManager.BeginSlotScope(slot))
         {
-            var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
-            var logger = LogManager.GetLogger(loggerName);
-
-            using (LogManager.BeginSlotScope(slot))
-            {
-                logger.Info("in-slot-message");
-            }
-
-            logger.Info("out-of-slot-message");
-
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(slotFactory.Logger.CapturedMessages, Has.Some.Contains("in-slot-message"));
-                Assert.That(slotFactory.Logger.CapturedMessages, Does.Not.Contain("out-of-slot-message"));
-                Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("out-of-slot-message"));
-                Assert.That(ambientFactory.Logger.CapturedMessages, Does.Not.Contain("in-slot-message"));
-            }
+            logger.Info("in-slot-message");
         }
-        finally
+
+        logger.Info("out-of-slot-message");
+
+        using (Assert.EnterMultipleScope())
         {
-            LogManager.UnregisterSlot(slot);
-            LogManager.SetAmbientDefaultFactory(null);
+            Assert.That(slotFactory.Logger.CapturedMessages, Has.Some.Contains("in-slot-message"));
+            Assert.That(slotFactory.Logger.CapturedMessages, Does.Not.Contain("out-of-slot-message"));
+            Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("out-of-slot-message"));
+            Assert.That(ambientFactory.Logger.CapturedMessages, Does.Not.Contain("in-slot-message"));
         }
+
+        LogManager.UnregisterSlot(slot);
     }
 
     [Test]
@@ -501,18 +485,12 @@ public class EndpointLoggingScopeTests
         LogManager.UseFactory(defaultFactory);
 #pragma warning restore CS0618
 
-        LogManager.SetAmbientDefaultFactory(ambientFactory);
+        var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+        var logger = LogManager.GetLogger(loggerName);
 
-        try
+        using (AmbientScope.Create(ambientFactory))
         {
-            var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
-            var logger = LogManager.GetLogger(loggerName);
-
             logger.Info("while-ambient-set");
-        }
-        finally
-        {
-            LogManager.SetAmbientDefaultFactory(null);
         }
 
         var logger2Name = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
@@ -534,23 +512,16 @@ public class EndpointLoggingScopeTests
         var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
         var logger = LogManager.GetLogger(loggerName);
 
-        LogManager.SetAmbientDefaultFactory(ambientFactory);
+        using var ambient = AmbientScope.Create(ambientFactory);
 
-        try
-        {
-            var staleScope = LogManager.BeginSlotScope(slot);
-            LogManager.UnregisterSlot(slot);
+        var staleScope = LogManager.BeginSlotScope(slot);
+        LogManager.UnregisterSlot(slot);
 
-            logger.Info("stale-scope-ambient-log");
+        logger.Info("stale-scope-ambient-log");
 
-            staleScope.Dispose();
+        staleScope.Dispose();
 
-            Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("stale-scope-ambient-log"));
-        }
-        finally
-        {
-            LogManager.SetAmbientDefaultFactory(null);
-        }
+        Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("stale-scope-ambient-log"));
     }
 
     [Test]
@@ -568,25 +539,19 @@ public class EndpointLoggingScopeTests
         var staleScope = LogManager.BeginSlotScope(slot);
 
         var ambientFactory = new CollectingMicrosoftLoggerFactory();
-        LogManager.SetAmbientDefaultFactory(ambientFactory);
-        try
-        {
-            // SlotUnregisterer disposes, unregistering the slot.
-            // The stale scope's context is removed from slotContexts,
-            // so subsequent writes through the stale scope drain to ambient.
-            var unregisterer = new SlotUnregisterer(slot);
-            await unregisterer.DisposeAsync();
+        using var ambient = AmbientScope.Create(ambientFactory);
 
-            logger.Info("after-unregisterer-dispose");
+        // SlotUnregisterer disposes, unregistering the slot.
+        // The stale scope's context is removed from slotContexts,
+        // so subsequent writes through the stale scope drain to ambient.
+        var unregisterer = new SlotUnregisterer(slot);
+        await unregisterer.DisposeAsync();
 
-            staleScope.Dispose();
+        logger.Info("after-unregisterer-dispose");
 
-            Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("after-unregisterer-dispose"));
-        }
-        finally
-        {
-            LogManager.SetAmbientDefaultFactory(null);
-        }
+        staleScope.Dispose();
+
+        Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("after-unregisterer-dispose"));
     }
 
     [Test]
@@ -601,68 +566,54 @@ public class EndpointLoggingScopeTests
         var staleScope = LogManager.BeginSlotScope(slot);
 
         var ambientFactory = new CollectingMicrosoftLoggerFactory();
-        LogManager.SetAmbientDefaultFactory(ambientFactory);
-        try
-        {
-            var unregisterer = new SlotUnregisterer(slot);
+        using var ambient = AmbientScope.Create(ambientFactory);
 
-            var tasks = Enumerable.Range(0, 10)
-                .Select(_ => Task.Run(() => unregisterer.DisposeAsync().AsTask()))
-                .ToArray();
-            Task.WaitAll(tasks);
+        var unregisterer = new SlotUnregisterer(slot);
 
-            logger.Info("post-race");
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => Task.Run(() => unregisterer.DisposeAsync().AsTask()))
+            .ToArray();
+        Task.WaitAll(tasks);
 
-            staleScope.Dispose();
+        logger.Info("post-race");
 
-            Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("post-race"));
-        }
-        finally
-        {
-            LogManager.SetAmbientDefaultFactory(null);
-        }
+        staleScope.Dispose();
+
+        Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("post-race"));
     }
 
     [Test]
     public async Task Ambient_default_factory_should_not_leak_across_async_boundaries()
     {
         var ambientFactory = new CollectingMicrosoftLoggerFactory();
-        LogManager.SetAmbientDefaultFactory(ambientFactory);
+        using var ambient = AmbientScope.Create(ambientFactory);
 
-        try
+        var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+
+        // Verify ambient flows into child async context
+        var childSawAmbient = await Task.Run(() =>
         {
-            var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+            var logger = LogManager.GetLogger(loggerName);
+            logger.Info("from-child");
+            return true;
+        });
 
-            // Verify ambient flows into child async context
-            var childSawAmbient = await Task.Run(() =>
-            {
-                var logger = LogManager.GetLogger(loggerName);
-                logger.Info("from-child");
-                return true;
-            });
+        LogManager.SetAmbientDefaultFactory(null);
 
-            // Clear ambient in parent — should not affect already-completed child
-            LogManager.SetAmbientDefaultFactory(null);
-
-            // New async context without ambient should not see the old one
-            var childSawNoAmbient = await Task.Run(() =>
-            {
-                var logger2Name = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
-                var logger2 = LogManager.GetLogger(logger2Name);
-                logger2.Info("no-ambient");
-                return ambientFactory.Logger.CapturedMessages.Contains("no-ambient");
-            });
-
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(childSawAmbient, Is.True);
-                Assert.That(childSawNoAmbient, Is.False);
-                Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("from-child"));
-            }
-        }
-        finally
+        // New async context without ambient should not see the old one
+        var childSawNoAmbient = await Task.Run(() =>
         {
-            LogManager.SetAmbientDefaultFactory(null);
+            var logger2Name = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
+            var logger2 = LogManager.GetLogger(logger2Name);
+            logger2.Info("no-ambient");
+            return ambientFactory.Logger.CapturedMessages.Contains("no-ambient");
+        });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(childSawAmbient, Is.True);
+            Assert.That(childSawNoAmbient, Is.False);
+            Assert.That(ambientFactory.Logger.CapturedMessages, Has.Some.Contains("from-child"));
         }
     }
 
@@ -672,38 +623,37 @@ public class EndpointLoggingScopeTests
         var outerFactory = new CollectingMicrosoftLoggerFactory();
         var innerFactory = new CollectingMicrosoftLoggerFactory();
 
-        LogManager.SetAmbientDefaultFactory(outerFactory);
-        try
+        using (AmbientScope.Create(outerFactory))
         {
             var loggerName = $"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}";
             LogManager.GetLogger(loggerName).Info("outer");
 
-            LogManager.SetAmbientDefaultFactory(innerFactory);
-            try
+            using (AmbientScope.Create(innerFactory))
             {
                 LogManager.GetLogger(loggerName).Info("inner");
 
-                using (Assert.EnterMultipleScope())
-                {
-                    Assert.That(innerFactory.Logger.CapturedMessages, Has.Some.Contains("inner"));
-                }
-            }
-            finally
-            {
-                LogManager.SetAmbientDefaultFactory(outerFactory);
+                Assert.That(innerFactory.Logger.CapturedMessages, Has.Some.Contains("inner"));
             }
 
             LogManager.GetLogger(loggerName).Info("outer-restored");
 
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(outerFactory.Logger.CapturedMessages, Has.Some.Contains("outer"));
-                Assert.That(outerFactory.Logger.CapturedMessages, Has.Some.Contains("outer-restored"));
-            }
+            Assert.That(outerFactory.Logger.CapturedMessages, Has.Some.Contains("outer"));
+            Assert.That(outerFactory.Logger.CapturedMessages, Has.Some.Contains("outer-restored"));
         }
-        finally
+    }
+
+    sealed class AmbientScope : IDisposable
+    {
+        readonly Microsoft.Extensions.Logging.ILoggerFactory? previous;
+
+        AmbientScope(Microsoft.Extensions.Logging.ILoggerFactory? factory)
         {
-            LogManager.SetAmbientDefaultFactory(null);
+            previous = LogManager.GetAmbientDefaultFactory();
+            LogManager.SetAmbientDefaultFactory(factory);
         }
+
+        public void Dispose() => LogManager.SetAmbientDefaultFactory(previous);
+
+        public static AmbientScope Create(Microsoft.Extensions.Logging.ILoggerFactory? factory) => new(factory);
     }
 }

--- a/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
@@ -681,6 +681,53 @@ public class EndpointLoggingScopeTests
             new KeyValuePair<string, object>("EndpointIdentifier", "green"));
     }
 
+    [Test]
+    public void Nested_slot_scopes_with_same_slot_should_not_duplicate_mel_scope()
+    {
+        var loggerFactory = new CollectingMicrosoftLoggerFactory();
+        var slot = new EndpointLogSlot("Sales", "blue");
+        LogManager.RegisterSlotFactory(slot, new MicrosoftLoggerFactoryAdapter(loggerFactory));
+
+        var logger = LogManager.GetLogger($"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}");
+
+        using (LogManager.BeginSlotScope(slot))
+        {
+            // Inner scope re-enters the same slot (simulates MessageSession inside a receiver)
+            using (LogManager.BeginSlotScope(slot))
+            {
+                logger.Info("nested-same-slot");
+            }
+        }
+
+        Assert.That(loggerFactory.Logger.CapturedLogScopes, Has.Count.EqualTo(1),
+            "Re-entering the same slot should not push a duplicate MEL scope");
+    }
+
+    [Test]
+    public void Nested_slot_scopes_with_different_slots_should_each_push_mel_scope()
+    {
+        var satelliteLoggerFactory = new CollectingMicrosoftLoggerFactory();
+        var endpointSlot = new EndpointLogSlot("Sales", "blue");
+        var satelliteSlot = new EndpointSatelliteLogSlot(endpointSlot, "TimeoutManager");
+        LogManager.RegisterSlotFactory(satelliteSlot, new MicrosoftLoggerFactoryAdapter(satelliteLoggerFactory));
+
+        var logger = LogManager.GetLogger($"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}");
+
+        using (LogManager.BeginSlotScope(endpointSlot))
+        {
+            using (LogManager.BeginSlotScope(satelliteSlot))
+            {
+                logger.Info("nested-different-slots");
+            }
+        }
+
+        // The inner (satellite) slot routes to the satellite factory, with both Endpoint and Satellite scope entries
+        AssertScopeWasUsed(satelliteLoggerFactory.Logger.CapturedLogScopes,
+            new KeyValuePair<string, object>("Endpoint", "Sales"),
+            new KeyValuePair<string, object>("EndpointIdentifier", "blue"),
+            new KeyValuePair<string, object>("Satellite", "TimeoutManager"));
+    }
+
     sealed class AmbientScope : IDisposable
     {
         readonly Microsoft.Extensions.Logging.ILoggerFactory? previous;

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -9,12 +9,9 @@ using Logging;
 using MessageInterfaces;
 using MessageInterfaces.MessageMapper.Reflection;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Pipeline;
 using Settings;
 using Unicast.Messages;
-using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 class EndpointCreator
 {
@@ -79,6 +76,13 @@ class EndpointCreator
         var services = hostingConfiguration.Services;
         services.AddSingleton<IReadOnlySettings>(settings);
 
+        var endpointLogSlot = hostingConfiguration.EndpointLogSlot;
+        services.AddSingleton(new EndpointLoggingScope
+        {
+            EndpointName = endpointLogSlot.EndpointName,
+            EndpointIdentifier = endpointLogSlot.EndpointIdentifier
+        });
+
         // Logging is a global service concern
         var loggingConfig = LogManager.GetLoggingConfiguration();
         var globalServices = services.Unwrap();
@@ -88,37 +92,14 @@ class EndpointCreator
             // (e.g., via LogManager.UseFactory(new ExtensionsLoggerFactory(...)))
             if (loggingConfig is not null)
             {
-                builder.Services.Configure<RollingLoggerProviderOptions>(o =>
-                {
-                    o.Directory = loggingConfig.LoggingDirectory;
-                    o.LogLevel = loggingConfig.MicrosoftLogLevel;
-                });
-                builder.Services.AddSingleton<ILoggerProvider, RollingLoggerProvider>();
-                builder.Services.AddSingleton<ILoggerProvider, ColoredConsoleLoggerProvider>();
-
-                // Register a per-provider filter rule so RollingLoggerProviderOptions.LogLevel
-                // is honoured by the MEL pipeline. This works for both the legacy path
-                // (where o.LogLevel is seeded above from loggingConfig) and the new path
-                // (where users set o.LogLevel via services.PostConfigure<RollingLoggerProviderOptions>()).
-                builder.Services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(sp =>
-                {
-                    var rollingOptions = sp.GetRequiredService<IOptions<RollingLoggerProviderOptions>>();
-                    return new ConfigureOptions<LoggerFilterOptions>(filterOptions =>
-                    {
-                        filterOptions.Rules.Add(new LoggerFilterRule(
-                            providerName: typeof(RollingLoggerProvider).FullName,
-                            categoryName: null,
-                            logLevel: rollingOptions.Value.LogLevel,
-                            filter: null));
-                    });
-                });
-
-                if (loggingConfig.MicrosoftLogLevel != LogLevel.Information)
-                {
-                    builder.SetMinimumLevel(loggingConfig.MicrosoftLogLevel);
-                }
+                builder.AddNServiceBusLoggingProviders(loggingConfig.LoggingDirectory, loggingConfig.MicrosoftLogLevel);
             }
         });
+
+        // Register slot cleanup as IAsyncDisposable right after AddLogging so that MS DI's
+        // reverse-order disposal unregisters the slot BEFORE ILoggerFactory is disposed.
+        // This ensures no thread routes logs through a disposed factory during shutdown.
+        globalServices.AddSingleton<IAsyncDisposable>(new SlotUnregisterer(endpointLogSlot));
 
         var featureSettings = settings.Get<FeatureComponent.Settings>();
 

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -80,7 +80,8 @@ class EndpointCreator
         services.AddSingleton(new EndpointLoggingScope
         {
             EndpointName = endpointLogSlot.EndpointName,
-            EndpointIdentifier = endpointLogSlot.EndpointIdentifier
+            EndpointIdentifier = endpointLogSlot.EndpointIdentifier,
+            Slot = endpointLogSlot
         });
 
         // Logging is a global service concern

--- a/src/NServiceBus.Core/Logging/EndpointLoggingScope.cs
+++ b/src/NServiceBus.Core/Logging/EndpointLoggingScope.cs
@@ -1,0 +1,41 @@
+#nullable enable
+
+namespace NServiceBus.Logging;
+
+using System.Collections;
+using System.Collections.Generic;
+
+/// <summary>
+/// Provides endpoint context information that can be resolved from DI for scope enrichment of logs.
+/// </summary>
+public sealed class EndpointLoggingScope : IReadOnlyList<KeyValuePair<string, object?>>
+{
+    /// <summary>
+    /// The name of the endpoint.
+    /// </summary>
+    public required string EndpointName { get; init; }
+
+    /// <summary>
+    /// An optional identifier for the endpoint, useful for distinguishing between
+    /// multiple instances of the same endpoint.
+    /// </summary>
+    public object? EndpointIdentifier { get; init; }
+
+    /// <summary>
+    /// Returns a string representation of the endpoint logging scope.
+    /// </summary>
+    public override string ToString() => EndpointIdentifier is null
+        ? $"Endpoint = {EndpointName}"
+        : $"Endpoint = {EndpointName}, EndpointIdentifier = {EndpointIdentifier}";
+
+    KeyValuePair<string, object?> IReadOnlyList<KeyValuePair<string, object?>>.this[int index] => Entries[index];
+
+    int IReadOnlyCollection<KeyValuePair<string, object?>>.Count => Entries.Length;
+
+    IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() =>
+        ((IEnumerable<KeyValuePair<string, object?>>)Entries).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => Entries.GetEnumerator();
+
+    KeyValuePair<string, object?>[] Entries => field ??= LogScopeStates.BuildScopeEntries(EndpointName, EndpointIdentifier);
+}

--- a/src/NServiceBus.Core/Logging/EndpointLoggingScope.cs
+++ b/src/NServiceBus.Core/Logging/EndpointLoggingScope.cs
@@ -6,7 +6,10 @@ using System.Collections;
 using System.Collections.Generic;
 
 /// <summary>
-/// Provides endpoint context information that can be resolved from DI for scope enrichment of logs.
+/// Carries the endpoint identity for log scope enrichment.
+/// Resolve from dependency injection and pass to
+/// <see cref="EndpointLoggingScopeExtensions.BeginEndpointScope" /> to attach the endpoint
+/// name and identifier to log output.
 /// </summary>
 public sealed class EndpointLoggingScope : IReadOnlyList<KeyValuePair<string, object?>>
 {
@@ -16,26 +19,33 @@ public sealed class EndpointLoggingScope : IReadOnlyList<KeyValuePair<string, ob
     public required string EndpointName { get; init; }
 
     /// <summary>
-    /// An optional identifier for the endpoint, useful for distinguishing between
-    /// multiple instances of the same endpoint.
+    /// A unique identifier for the endpoint instance, useful for telling apart
+    /// multiple instances of the same endpoint name.
     /// </summary>
     public object? EndpointIdentifier { get; init; }
 
     /// <summary>
+    /// The logging slot for this endpoint, carrying both the slot key (for routing) and
+    /// scope state (for enrichment). Set by the hosting infrastructure during DI registration.
+    /// </summary>
+    internal LogSlot? Slot { get; init; }
+
+    /// <summary>
+    /// The scope state for this endpoint, delegating to the slot's state when available,
+    /// otherwise computing from <see cref="EndpointName" /> and <see cref="EndpointIdentifier" />.
+    /// </summary>
+    LogScopeState ScopeState => Slot?.ScopeState ?? new LogScopeStates(EndpointName, EndpointIdentifier);
+
+    /// <summary>
     /// Returns a string representation of the endpoint logging scope.
     /// </summary>
-    public override string ToString() => EndpointIdentifier is null
-        ? $"Endpoint = {EndpointName}"
-        : $"Endpoint = {EndpointName}, EndpointIdentifier = {EndpointIdentifier}";
+    public override string ToString() => ScopeState.ToString()!;
 
-    KeyValuePair<string, object?> IReadOnlyList<KeyValuePair<string, object?>>.this[int index] => Entries[index];
+    KeyValuePair<string, object?> IReadOnlyList<KeyValuePair<string, object?>>.this[int index] => ScopeState[index];
 
-    int IReadOnlyCollection<KeyValuePair<string, object?>>.Count => Entries.Length;
+    int IReadOnlyCollection<KeyValuePair<string, object?>>.Count => ScopeState.Count;
 
-    IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() =>
-        ((IEnumerable<KeyValuePair<string, object?>>)Entries).GetEnumerator();
+    IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() => ScopeState.GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator() => Entries.GetEnumerator();
-
-    KeyValuePair<string, object?>[] Entries => field ??= LogScopeStates.BuildScopeEntries(EndpointName, EndpointIdentifier);
+    IEnumerator IEnumerable.GetEnumerator() => ScopeState.GetEnumerator();
 }

--- a/src/NServiceBus.Core/Logging/EndpointLoggingScopeExtensions.cs
+++ b/src/NServiceBus.Core/Logging/EndpointLoggingScopeExtensions.cs
@@ -1,0 +1,34 @@
+#nullable enable
+
+namespace NServiceBus.Logging;
+
+using System;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Extension methods for <see cref="ILogger" /> that provide endpoint-aware scope enrichment.
+/// </summary>
+public static class EndpointLoggingScopeExtensions
+{
+    /// <summary>
+    /// Begins a log scope with the given <paramref name="endpointScope" /> if no endpoint scope is already active.
+    /// <para>
+    /// When called inside a message-processing pipeline (where the slot scope already pushes endpoint metadata),
+    /// this method returns a no-op disposable to avoid redundant scope enrichment.
+    /// When called outside the pipeline (e.g., from Transactional Session or a hosted service),
+    /// it pushes the endpoint scope onto the MEL scope stack.
+    /// </para>
+    /// </summary>
+    public static IDisposable BeginEndpointScope(this ILogger logger, EndpointLoggingScope endpointScope)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(endpointScope);
+
+        if (LogManager.TryGetCurrentEndpointScopeState(out _))
+        {
+            return NullScope.Instance;
+        }
+
+        return logger.BeginScope(endpointScope) ?? NullScope.Instance;
+    }
+}

--- a/src/NServiceBus.Core/Logging/EndpointLoggingScopeExtensions.cs
+++ b/src/NServiceBus.Core/Logging/EndpointLoggingScopeExtensions.cs
@@ -11,12 +11,21 @@ using Microsoft.Extensions.Logging;
 public static class EndpointLoggingScopeExtensions
 {
     /// <summary>
-    /// Begins a log scope with the given <paramref name="endpointScope" /> if no endpoint scope is already active.
+    /// Begins a log scope that enriches log output with endpoint name and identifier.
     /// <para>
-    /// When called inside a message-processing pipeline (where the slot scope already pushes endpoint metadata),
-    /// this method returns a no-op disposable to avoid redundant scope enrichment.
-    /// When called outside the pipeline (e.g., from Transactional Session or a hosted service),
-    /// it pushes the endpoint scope onto the MEL scope stack.
+    /// When called within the endpoint's message-processing pipeline, this method detects
+    /// that the endpoint context is already active and returns a no-op scope, avoiding
+    /// duplicate scope entries in the log output.
+    /// </para>
+    /// <para>
+    /// When called outside the pipeline (e.g., from a hosted service, background task,
+    /// or Transactional Session), this method activates the endpoint's logging context so
+    /// that <see cref="ILogger" /> and <see cref="ILog" /> output includes the endpoint
+    /// name and identifier, just as if the log were written during message processing.
+    /// </para>
+    /// <para>
+    /// Resolve <see cref="EndpointLoggingScope" /> from dependency injection to obtain
+    /// the current endpoint's scope information.
     /// </para>
     /// </summary>
     public static IDisposable BeginEndpointScope(this ILogger logger, EndpointLoggingScope endpointScope)
@@ -24,9 +33,9 @@ public static class EndpointLoggingScopeExtensions
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(endpointScope);
 
-        if (LogManager.TryGetCurrentEndpointScopeState(out _))
+        if (endpointScope.Slot is not null)
         {
-            return NullScope.Instance;
+            return LogManager.BeginSlotScope(endpointScope.Slot);
         }
 
         return logger.BeginScope(endpointScope) ?? NullScope.Instance;

--- a/src/NServiceBus.Core/Logging/ExternalLoggerFactoryAdapter.cs
+++ b/src/NServiceBus.Core/Logging/ExternalLoggerFactoryAdapter.cs
@@ -6,12 +6,11 @@ using Logging;
 using Microsoft.Extensions.Logging;
 using ILoggerFactory = Logging.ILoggerFactory;
 
-sealed class ExternalLoggerFactoryAdapter(ILoggerFactory externalFactory, Microsoft.Extensions.Logging.ILoggerFactory microsoftLoggerFactory)
-    : ILoggerFactory, ISlotScopedLoggerFactory
+sealed class ExternalLoggerFactoryAdapter(ILoggerFactory externalFactory, Microsoft.Extensions.Logging.ILoggerFactory microsoftLoggerFactory) : ILoggerFactory, ISlotScopedLoggerFactory
 {
     readonly ILogger scopeLogger = microsoftLoggerFactory.CreateLogger(MicrosoftLoggerFactoryAdapter.ScopeLoggerName);
 
-    public ILog GetLogger(Type type) => externalFactory.GetLogger(type);
+    public ILog GetLogger(Type type) => GetLogger(type.FullName ?? type.Name);
     public ILog GetLogger(string name) => externalFactory.GetLogger(name);
     public IDisposable BeginScope(LogScopeState scopeState) => scopeLogger.BeginScope(scopeState) ?? NullScope.Instance;
 }

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -89,7 +89,7 @@ public static class LogManager
     /// </summary>
     internal static void SetAmbientDefaultFactory(MicrosoftILoggerFactory? factory) => ambientDefaultFactory.Value = factory;
 
-    static MicrosoftILoggerFactory? GetAmbientDefaultFactory() => ambientDefaultFactory.Value;
+    internal static MicrosoftILoggerFactory? GetAmbientDefaultFactory() => ambientDefaultFactory.Value;
 
     internal sealed class DefaultLoggingConfiguration(string loggingDirectory, LogLevel nsbLogLevel)
     {

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -145,7 +145,7 @@ public static class LogManager
         slotLoggerFactories[slotKey] = loggerFactory;
         var slotContext = GetOrAddSlotContext(slotKey);
 
-        using var _ = new SlotScope(slotContext, activateExternalScope: true);
+        using var _ = new SlotScope(slotContext);
         DrainScopedStartupLogs(slotKey, loggerFactory);
     }
 
@@ -183,7 +183,7 @@ public static class LogManager
 
         var slotKey = new SlotKey(slot);
         var slotContext = GetOrAddSlotContext(slotKey);
-        return new SlotScope(slotContext, activateExternalScope: true);
+        return new SlotScope(slotContext);
     }
 
     internal static bool TryGetCurrentEndpointScopeState([NotNullWhen(true)] out LogScopeState? scopeState)
@@ -599,12 +599,20 @@ public static class LogManager
 
     internal readonly struct SlotScope : IDisposable
     {
-        internal SlotScope(SlotContext slot, bool activateExternalScope)
+        internal SlotScope(SlotContext slot)
         {
             previousSlot = currentSlot.Value;
             currentSlot.Value = slot;
 
-            if (activateExternalScope && slotLoggerFactories.TryGetValue(slot.Key, out var loggerFactory) && loggerFactory is ISlotScopedLoggerFactory slotScopedLoggerFactory)
+            // Skip pushing a duplicate MEL scope when already inside the same slot.
+            // The endpoint's slot scope is activated at multiple points in the call stack:
+            // endpoint startup, message pump receive, and MessageSession operations.
+            // The AsyncLocal routing correctly nests via previousSlot/restore, but MEL
+            // BeginScope is additive — without this check the same endpoint metadata
+            // would appear multiple times in scope state.
+            var alreadyInSameSlot = previousSlot is not null && previousSlot.Key.Equals(slot.Key);
+
+            if (!alreadyInSameSlot && slotLoggerFactories.TryGetValue(slot.Key, out var loggerFactory) && loggerFactory is ISlotScopedLoggerFactory slotScopedLoggerFactory)
             {
                 activeScope = slotScopedLoggerFactory.BeginScope(slot.ScopeState);
             }

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -5,10 +5,13 @@ namespace NServiceBus.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Particular.Obsoletes;
+using MicrosoftILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+using MicrosoftLogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 /// <summary>
 /// Responsible for the creation of <see cref="ILog" /> instances and used as an extension point to redirect log events to
@@ -77,20 +80,31 @@ public static class LogManager
 
     static bool IsExternalFactoryConfigured => defaultLoggerFactoryDefinition is null;
 
+    internal static bool DefaultFactoryIsUnsupported => defaultLoggerFactory.Value is IUnsupportedDefaultFactoryLoggerFactory;
+
+    /// <summary>
+    /// Sets the ambient default factory for the current async context.
+    /// Used by acceptance testing to route out-of-slot logs to the scenario's MEL factory
+    /// without mutating process-global static state.
+    /// </summary>
+    internal static void SetAmbientDefaultFactory(MicrosoftILoggerFactory? factory) => ambientDefaultFactory.Value = factory;
+
+    static MicrosoftILoggerFactory? GetAmbientDefaultFactory() => ambientDefaultFactory.Value;
+
     internal sealed class DefaultLoggingConfiguration(string loggingDirectory, LogLevel nsbLogLevel)
     {
         public string LoggingDirectory { get; } = loggingDirectory;
-        public Microsoft.Extensions.Logging.LogLevel MicrosoftLogLevel => ConvertLogLevel(nsbLogLevel);
+        public MicrosoftLogLevel MicrosoftLogLevel => ConvertLogLevel(nsbLogLevel);
 
-        static Microsoft.Extensions.Logging.LogLevel ConvertLogLevel(LogLevel level) =>
+        static MicrosoftLogLevel ConvertLogLevel(LogLevel level) =>
             level switch
             {
-                LogLevel.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
-                LogLevel.Info => Microsoft.Extensions.Logging.LogLevel.Information,
-                LogLevel.Warn => Microsoft.Extensions.Logging.LogLevel.Warning,
-                LogLevel.Error => Microsoft.Extensions.Logging.LogLevel.Error,
-                LogLevel.Fatal => Microsoft.Extensions.Logging.LogLevel.Critical,
-                _ => Microsoft.Extensions.Logging.LogLevel.Information
+                LogLevel.Debug => MicrosoftLogLevel.Debug,
+                LogLevel.Info => MicrosoftLogLevel.Information,
+                LogLevel.Warn => MicrosoftLogLevel.Warning,
+                LogLevel.Error => MicrosoftLogLevel.Error,
+                LogLevel.Fatal => MicrosoftLogLevel.Critical,
+                _ => MicrosoftLogLevel.Information
             };
     }
 
@@ -117,7 +131,7 @@ public static class LogManager
         return loggers.GetOrAdd(name, static loggerName => new SlotAwareLogger(loggerName));
     }
 
-    internal static ILoggerFactory Adapt(Microsoft.Extensions.Logging.ILoggerFactory microsoftLoggerFactory) =>
+    internal static ILoggerFactory Adapt(MicrosoftILoggerFactory microsoftLoggerFactory) =>
         GetExternalFactoryIfAvailable() is { } externalFactory
             ? new ExternalLoggerFactoryAdapter(externalFactory, microsoftLoggerFactory)
             : new MicrosoftLoggerFactoryAdapter(microsoftLoggerFactory);
@@ -143,9 +157,13 @@ public static class LogManager
 
         if (!slotLoggerFactories.ContainsKey(slotKey) && scopedStartupLogsBySlot.TryRemove(slotKey, out var pendingScopedLogs))
         {
+            var drainLogger = GetAmbientDefaultFactory() is { } ambientFactory
+                ? new MicrosoftLoggerAdapter(ambientFactory.CreateLogger(nameof(LogManager)))
+                : FallbackLoggerFactory.Instance.Value.GetLogger(nameof(LogManager));
+
             while (pendingScopedLogs.TryDequeue(out var entry))
             {
-                entry.WriteToTrace();
+                entry.WriteTo(drainLogger);
             }
         }
 
@@ -341,6 +359,11 @@ public static class LogManager
 
         ILog GetDefaultLogger()
         {
+            if (GetAmbientDefaultFactory() is { } ambientFactory)
+            {
+                return new MicrosoftLoggerAdapter(ambientFactory.CreateLogger(name));
+            }
+
             var currentFactoryVersion = Volatile.Read(ref defaultLoggerFactoryVersion);
             if (defaultLoggerFactoryVersionSnapshot == currentFactoryVersion && defaultLogger is { } cached)
             {
@@ -349,7 +372,7 @@ public static class LogManager
 
             var loggerFactory = defaultLoggerFactory.Value;
             var createdLogger = loggerFactory is IUnsupportedDefaultFactoryLoggerFactory
-                ? new TraceFallbackLog(name)
+                ? FallbackLoggerFactory.Instance.Value.GetLogger(name)
                 : loggerFactory.GetLogger(name);
 
             defaultLogger = createdLogger;
@@ -404,7 +427,13 @@ public static class LogManager
                 return;
             }
 
-            entry.WriteToTrace();
+            if (GetAmbientDefaultFactory() is { } ambientFactory)
+            {
+                entry.WriteTo(new MicrosoftLoggerAdapter(ambientFactory.CreateLogger(entry.LoggerName)));
+                return;
+            }
+
+            entry.WriteTo(FallbackLoggerFactory.Instance.Value.GetLogger(entry.LoggerName));
         }
 
         ILog? defaultLogger;
@@ -421,40 +450,44 @@ public static class LogManager
         }
     }
 
-    sealed class TraceFallbackLog(string name) : ILog
+    sealed class FallbackLoggerFactory : ILoggerFactory
     {
-        public bool IsDebugEnabled => true;
-        public bool IsInfoEnabled => true;
-        public bool IsWarnEnabled => true;
-        public bool IsErrorEnabled => true;
-        public bool IsFatalEnabled => true;
+        public static readonly Lazy<ILoggerFactory> Instance = new(Create);
 
-        public void Debug(string? message) => Write(LogLevel.Debug, message, null);
-        public void Debug(string? message, Exception? exception) => Write(LogLevel.Debug, message, exception);
-        public void DebugFormat(string format, params object?[] args) => Write(LogLevel.Debug, string.Format(format, args), null);
-        public void Info(string? message) => Write(LogLevel.Info, message, null);
-        public void Info(string? message, Exception? exception) => Write(LogLevel.Info, message, exception);
-        public void InfoFormat(string format, params object?[] args) => Write(LogLevel.Info, string.Format(format, args), null);
-        public void Warn(string? message) => Write(LogLevel.Warn, message, null);
-        public void Warn(string? message, Exception? exception) => Write(LogLevel.Warn, message, exception);
-        public void WarnFormat(string format, params object?[] args) => Write(LogLevel.Warn, string.Format(format, args), null);
-        public void Error(string? message) => Write(LogLevel.Error, message, null);
-        public void Error(string? message, Exception? exception) => Write(LogLevel.Error, message, exception);
-        public void ErrorFormat(string format, params object?[] args) => Write(LogLevel.Error, string.Format(format, args), null);
-        public void Fatal(string? message) => Write(LogLevel.Fatal, message, null);
-        public void Fatal(string? message, Exception? exception) => Write(LogLevel.Fatal, message, exception);
-        public void FatalFormat(string format, params object?[] args) => Write(LogLevel.Fatal, string.Format(format, args), null);
+        readonly MicrosoftILoggerFactory melFactory;
 
-        void Write(LogLevel level, string? message, Exception? exception)
+        FallbackLoggerFactory(MicrosoftILoggerFactory melFactory) => this.melFactory = melFactory;
+
+        ILog ILoggerFactory.GetLogger(string name) => new MicrosoftLoggerAdapter(melFactory.CreateLogger(name));
+
+        ILog ILoggerFactory.GetLogger(Type type) => GetLogger(type.FullName ?? type.Name);
+
+        static FallbackLoggerFactory Create()
         {
-            var formatted = exception is null ? message : $"{message}{Environment.NewLine}{exception}";
-            Trace.WriteLine($"{level} [{name}]: {formatted}");
+            var config = GetLoggingConfiguration();
+            var directory = config?.LoggingDirectory ?? Host.GetOutputDirectory();
+            var level = config?.MicrosoftLogLevel ?? MicrosoftLogLevel.Information;
+
+            var services = new ServiceCollection();
+            services.AddLogging(builder =>
+            {
+                builder.Services.Configure<RollingLoggerProviderOptions>(o =>
+                {
+                    o.Directory = directory;
+                    o.LogLevel = level;
+                });
+                builder.AddNServiceBusLoggingProviders(directory, level);
+                builder.SetMinimumLevel(level);
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var factory = serviceProvider.GetRequiredService<MicrosoftILoggerFactory>();
+            return new FallbackLoggerFactory(factory);
         }
     }
 
     readonly struct DeferredLogEntry(string loggerName, DeferredLogEntryKind kind, LogLevel level, string? text, Exception? exception, object?[]? args)
     {
-        TraceFallbackLog TraceFallbackLog { get; } = new(loggerName);
         public string LoggerName { get; } = loggerName;
 
         public static DeferredLogEntry Message(string loggerName, LogLevel level, string? message) =>
@@ -483,8 +516,6 @@ public static class LogManager
                     throw new InvalidOperationException($"Unsupported deferred log entry kind '{kind}'.");
             }
         }
-
-        public void WriteToTrace() => WriteTo(TraceFallbackLog);
 
         static void WriteMessage(ILog logger, LogLevel level, string? message)
         {
@@ -611,6 +642,7 @@ public static class LogManager
     static LoggingFactoryDefinition? defaultLoggerFactoryDefinition = new DefaultFactory();
 #pragma warning restore CS0618
     static readonly AsyncLocal<SlotContext?> currentSlot = new();
+    static readonly AsyncLocal<MicrosoftILoggerFactory?> ambientDefaultFactory = new();
     static readonly ConcurrentDictionary<string, SlotAwareLogger> loggers = new(StringComparer.Ordinal);
     static readonly ConcurrentDictionary<SlotKey, SlotContext> slotContexts = new();
     static readonly ConcurrentDictionary<SlotKey, ILoggerFactory> slotLoggerFactories = new();

--- a/src/NServiceBus.Core/Logging/LogScopeStates.cs
+++ b/src/NServiceBus.Core/Logging/LogScopeStates.cs
@@ -33,13 +33,16 @@ sealed class LogScopeStates(object endpointName, object? endpointIdentifier) : L
         ? $"Endpoint = {endpointName}"
         : $"Endpoint = {endpointName}, EndpointIdentifier = {endpointIdentifier}";
 
-    readonly KeyValuePair<string, object?>[] entries = endpointIdentifier is null
-        ? [new KeyValuePair<string, object?>("Endpoint", endpointName)]
-        :
-        [
-            new KeyValuePair<string, object?>("Endpoint", endpointName),
-            new KeyValuePair<string, object?>("EndpointIdentifier", endpointIdentifier)
-        ];
+    readonly KeyValuePair<string, object?>[] entries = BuildScopeEntries(endpointName, endpointIdentifier);
+
+    internal static KeyValuePair<string, object?>[] BuildScopeEntries(object endpointName, object? endpointIdentifier) =>
+        endpointIdentifier is null
+            ? [new KeyValuePair<string, object?>("Endpoint", endpointName)]
+            :
+            [
+                new KeyValuePair<string, object?>("Endpoint", endpointName),
+                new KeyValuePair<string, object?>("EndpointIdentifier", endpointIdentifier)
+            ];
 }
 
 sealed class ExtendedLogScopeState(LogScopeState parentScope, string key, object value) : LogScopeState
@@ -71,6 +74,8 @@ sealed class ExtendedLogScopeState(LogScopeState parentScope, string key, object
 
 sealed class EndpointLogSlot(string endpointName, object? endpointIdentifier) : LogSlot
 {
+    public string EndpointName => endpointName;
+    public object? EndpointIdentifier => endpointIdentifier;
     public override LogScopeState ScopeState { get; } = new LogScopeStates(endpointName, endpointIdentifier);
 }
 

--- a/src/NServiceBus.Core/Logging/LoggingBuilderExtensions.cs
+++ b/src/NServiceBus.Core/Logging/LoggingBuilderExtensions.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+namespace NServiceBus;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+static class LoggingBuilderExtensions
+{
+    public static ILoggingBuilder AddNServiceBusLoggingProviders(this ILoggingBuilder builder, string loggingDirectory, LogLevel logLevel)
+    {
+        builder.Services.Configure<RollingLoggerProviderOptions>(o =>
+        {
+            o.Directory = loggingDirectory;
+            o.LogLevel = logLevel;
+        });
+        builder.Services.AddSingleton<ILoggerProvider, RollingLoggerProvider>();
+        builder.Services.AddSingleton<ILoggerProvider, ColoredConsoleLoggerProvider>();
+
+        builder.Services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(sp =>
+        {
+            var rollingOptions = sp.GetRequiredService<IOptions<RollingLoggerProviderOptions>>();
+            return new ConfigureOptions<LoggerFilterOptions>(filterOptions =>
+            {
+                filterOptions.Rules.Add(new LoggerFilterRule(
+                    providerName: typeof(RollingLoggerProvider).FullName,
+                    categoryName: null,
+                    logLevel: rollingOptions.Value.LogLevel,
+                    filter: null));
+            });
+        });
+
+        if (logLevel != LogLevel.Information)
+        {
+            builder.SetMinimumLevel(logLevel);
+        }
+
+        return builder;
+    }
+}

--- a/src/NServiceBus.Core/Logging/SlotUnregisterer.cs
+++ b/src/NServiceBus.Core/Logging/SlotUnregisterer.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+namespace NServiceBus;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Logging;
+
+sealed class SlotUnregisterer(object slot) : IAsyncDisposable
+{
+    int unregistered;
+
+    public ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref unregistered, 1) == 0)
+        {
+            LogManager.UnregisterSlot(slot);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -101,10 +101,6 @@ class RunningEndpointInstance(SettingsHolder settings,
 
         await StopCore().ConfigureAwait(false);
 
-        // Unregister the slot before disposing the service provider so no thread can
-        // route through the (soon-to-be-disposed) ILoggerFactory after the provider is torn down.
-        LogManager.UnregisterSlot(endpointLogSlot);
-
         settings.Clear();
         stoppingTokenSource.Dispose();
         await serviceProviderLease.DisposeAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Problem

When NServiceBus logs outside an endpoint slot scope (for example, from a static `ILog` field before startup or during shutdown), those logs currently fall through to `System.Diagnostics.Trace`. They are invisible to users and to the acceptance test framework.

There is also no way for downstream packages (such as Transactional Session) to attach endpoint context to logs when operating outside the message pipeline. The endpoint name and identifier are only available through the internal `LogManager.BeginSlotScope` mechanism.

The previous attempt to fix the first problem used a `LogManager.UseFactory` bridge in `ScenarioRunner` to route out-of-slot logs to the scenario's MEL factory. That approach mutates process-global static state, requires fragile teardown ordering, and cannot support parallel test execution.

## Solution

Four changes address the production and test concerns independently, without global state mutation.

### EndpointLoggingScope (new public type)

A DI-resolvable type that carries endpoint name and identifier as `IReadOnlyList<KeyValuePair<string, object?>>`, compatible with `ILogger.BeginScope`. Downstream packages can enrich their logs with endpoint context without depending on internal LogManager APIs:

```csharp
var scope = provider.GetRequiredService<EndpointLoggingScope>();
using var _ = logger.BeginScope(scope);
```

Registered as a singleton per endpoint in `EndpointCreator.Configure`. `LogScopeStates` was refactored to share the scope entry construction logic.

### MEL-backed fallback factory

`FallbackLoggerFactory` now builds an isolated `ServiceCollection` with `RollingLoggerProvider` and `ColoredConsoleLoggerProvider`. Out-of-slot logs go to a real rolling file and console output instead of `System.Diagnostics.Trace`. The factory is a lazy singleton with process-lifetime scope, never disposed.

### AsyncLocal ambient default factory

`LogManager.SetAmbientDefaultFactory` stores a per-async-context MEL `ILoggerFactory` reference. The acceptance testing framework sets it after building the scenario's service provider, and clears it after disposal. Because `AsyncLocal` flows naturally through async chains, each scenario's out-of-slot logs reach `ScenarioContext.Logs` without touching global state. The slot-scoped hot path is unaffected; `GetDefaultLogger` is only reached on the cold out-of-slot path.

### DI-managed slot cleanup

`SlotUnregisterer` is an `IAsyncDisposable` registered right after `AddLogging` in `EndpointCreator.Configure`. MS DI disposes services in reverse registration order, so the slot is unregistered before `ILoggerFactory` is disposed. This eliminates the window where a background thread could route logs through a disposed factory during container teardown. `RunningEndpointInstance` no longer calls `LogManager.UnregisterSlot` directly.

## Trade-offs

- `FallbackLoggerFactory` is never disposed. This is intentional: it is a safety net for the gap between process start and endpoint initialization, and between endpoint shutdown and process exit. The OS reclaims resources on exit.
- `ScenarioWithContext.Done` spawns `Task.Run` that does not inherit the ambient factory. This is an accepted limitation because the Done polling loop only checks boolean flags and does not log.
- `AsyncLocal` does not flow across `ThreadPool.QueueUserWorkItem` or fire-and-forget boundaries without `ExecutionContext` capture. Production out-of-slot code that uses these patterns still falls through to `FallbackLoggerFactory`, which is the correct behavior.

## What stays unchanged

- `LogManager.UseFactory` and `LogManager.Use<T>`: still work as deprecated APIs. The ambient factory only affects the out-of-slot routing path.
- Slot registration and deferred log mechanics: unchanged.