### PR TITLE
Add option to acceptance testing to register the context appender logger provider

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Customization/LoggingBuilderExtensions.cs
+++ b/src/NServiceBus.AcceptanceTesting/Customization/LoggingBuilderExtensions.cs
@@ -1,0 +1,21 @@
+namespace NServiceBus.AcceptanceTesting.Customization;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+public static class LoggingBuilderExtensions
+{
+    extension(ILoggingBuilder loggingBuilder)
+    {
+        /// <summary>
+        /// Adds a logger provider that appends the log messages to the scenario context.
+        /// </summary>
+        /// <param name="scenarioContext">The scenario context to append the log messages to.</param>
+        public ILoggingBuilder AddContextAppender(ScenarioContext scenarioContext)
+        {
+            loggingBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider>(new ContextAppenderLoggerProvider(scenarioContext)));
+            return loggingBuilder;
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -27,7 +27,7 @@ public class ScenarioWithContext<TContext>(Action<TContext> initializer) : IScen
         services.AddScenarioContext(scenarioContext);
         services.AddLogging(builder =>
         {
-            builder.AddProvider(new ContextAppenderLoggerProvider(scenarioContext));
+            builder.AddContextAppender(scenarioContext);
 
             builder.SetMinimumLevel(scenarioContext.LogLevel switch
             {

--- a/src/NServiceBus.Core/Logging/LoggingBuilderExtensions.cs
+++ b/src/NServiceBus.Core/Logging/LoggingBuilderExtensions.cs
@@ -2,8 +2,11 @@
 
 namespace NServiceBus;
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Options;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
@@ -11,13 +14,26 @@ static class LoggingBuilderExtensions
 {
     public static ILoggingBuilder AddNServiceBusLoggingProviders(this ILoggingBuilder builder, string loggingDirectory, LogLevel logLevel)
     {
-        builder.Services.Configure<RollingLoggerProviderOptions>(o =>
+        builder.AddNServiceBusRollingFileProvider(options =>
         {
-            o.Directory = loggingDirectory;
-            o.LogLevel = logLevel;
+            options.Directory = loggingDirectory;
+            options.LogLevel = logLevel;
         });
-        builder.Services.AddSingleton<ILoggerProvider, RollingLoggerProvider>();
-        builder.Services.AddSingleton<ILoggerProvider, ColoredConsoleLoggerProvider>();
+        builder.AddNServiceBusColoredConsoleProvider();
+
+        if (logLevel != LogLevel.Information)
+        {
+            builder.SetMinimumLevel(logLevel);
+        }
+
+        return builder;
+    }
+
+    static ILoggingBuilder AddNServiceBusRollingFileProvider(this ILoggingBuilder builder, Action<RollingLoggerProviderOptions> configure)
+    {
+        builder.AddConfiguration();
+
+        builder.Services.Configure(configure);
 
         builder.Services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(sp =>
         {
@@ -32,11 +48,15 @@ static class LoggingBuilderExtensions
             });
         });
 
-        if (logLevel != LogLevel.Information)
-        {
-            builder.SetMinimumLevel(logLevel);
-        }
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, RollingLoggerProvider>());
+        return builder;
+    }
 
+    static ILoggingBuilder AddNServiceBusColoredConsoleProvider(this ILoggingBuilder builder)
+    {
+        builder.AddConfiguration();
+
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, ColoredConsoleLoggerProvider>());
         return builder;
     }
 }


### PR DESCRIPTION
ServiceControl also wants to forward all logs to the ScenarioContext, and this extension method enables adding the provider to the service control logging configuration. Otherwise we'd have to write ugly code like

```csharp
var appenderProvider = runDescriptor.Services.Single(x => x.ServiceType == typeof(ILoggerProvider) && x.ImplementationInstance?.GetType().Name.Contains("ContextAppender") is true);
                hostBuilder.Services.AddLogging(loggingBuilder =>
                {
                    if (appenderProvider.ImplementationInstance is ILoggerProvider provider)
                    {
                        loggingBuilder.AddProvider(provider);
                    }
                });
```