### PR TITLE
BeginEndpointScope enriches all loggers before endpoint start

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_endpoint_logging_scope.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_endpoint_logging_scope.cs
@@ -53,22 +53,24 @@ public class When_using_endpoint_logging_scope : NServiceBusAcceptanceTest
     }
 
     [Test]
-    public async Task Should_enrich_mel_logger_before_endpoint_start()
+    public async Task Should_enrich_both_loggers_before_endpoint_start()
     {
         // Uses ServiceResolve without afterStart (runs before endpoint start) so the
         // slot factory is not yet registered. BeginEndpointScope must still enrich
-        // ILogger output via logger.BeginScope because the host hasn't started.
+        // both ILogger and legacy ILog output — ILogger via logger.BeginScope,
+        // and ILog via SlotScope deferral (queued and flushed after endpoint start).
         var context = await Scenario.Define<Context>(ctx => ctx.IncludeLoggingScopes = true)
             .WithEndpoint<EndpointWithScope>(b => b
                 .ServiceResolve(static (provider, ctx, _) =>
                 {
                     var endpointScope = provider.GetRequiredService<EndpointLoggingScope>();
 
-                    var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-                    var logger = loggerFactory.CreateLogger("PreStartScopeTest");
-                    using (logger.BeginEndpointScope(endpointScope))
+                    var legacyLogger = LogManager.GetLogger("PreStartLegacyLogger");
+                    var melLogger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("PreStartMelLogger");
+                    using (melLogger.BeginEndpointScope(endpointScope))
                     {
-                        logger.LogInformation("Message before endpoint start inside scope");
+                        legacyLogger.Info("Legacy logger before endpoint start inside scope");
+                        melLogger.LogInformation("MEL logger before endpoint start inside scope");
                     }
 
                     ctx.MarkAsCompleted();
@@ -76,10 +78,20 @@ public class When_using_endpoint_logging_scope : NServiceBusAcceptanceTest
                 }))
             .Run();
 
-        Assert.That(context.Logs, Has.One.Matches<ScenarioContext.LogItem>(l =>
-            l.LoggerName == "PreStartScopeTest" &&
-            (l.Message ?? string.Empty).Contains("Message before endpoint start inside scope") &&
-            (l.Message ?? string.Empty).Contains("Endpoint = UsingEndpointLoggingScope.EndpointWithScope")));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(context.Logs, Has.One.Matches<ScenarioContext.LogItem>(l =>
+                l.LoggerName == "PreStartMelLogger" &&
+                (l.Message ?? string.Empty).Contains("MEL logger before endpoint start inside scope") &&
+                (l.Message ?? string.Empty).Contains("Endpoint = UsingEndpointLoggingScope.EndpointWithScope")),
+                "MEL ILogger should be enriched via logger.BeginScope before endpoint start");
+
+            Assert.That(context.Logs, Has.One.Matches<ScenarioContext.LogItem>(l =>
+                l.LoggerName == "PreStartLegacyLogger" &&
+                (l.Message ?? string.Empty).Contains("Legacy logger before endpoint start inside scope") &&
+                (l.Message ?? string.Empty).Contains("Endpoint = UsingEndpointLoggingScope.EndpointWithScope")),
+                "Legacy ILog should be deferred and flushed with scope enrichment after endpoint start");
+        }
     }
 
     [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_endpoint_logging_scope.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_using_endpoint_logging_scope.cs
@@ -53,6 +53,36 @@ public class When_using_endpoint_logging_scope : NServiceBusAcceptanceTest
     }
 
     [Test]
+    public async Task Should_enrich_mel_logger_before_endpoint_start()
+    {
+        // Uses ServiceResolve without afterStart (runs before endpoint start) so the
+        // slot factory is not yet registered. BeginEndpointScope must still enrich
+        // ILogger output via logger.BeginScope because the host hasn't started.
+        var context = await Scenario.Define<Context>(ctx => ctx.IncludeLoggingScopes = true)
+            .WithEndpoint<EndpointWithScope>(b => b
+                .ServiceResolve(static (provider, ctx, _) =>
+                {
+                    var endpointScope = provider.GetRequiredService<EndpointLoggingScope>();
+
+                    var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
+                    var logger = loggerFactory.CreateLogger("PreStartScopeTest");
+                    using (logger.BeginEndpointScope(endpointScope))
+                    {
+                        logger.LogInformation("Message before endpoint start inside scope");
+                    }
+
+                    ctx.MarkAsCompleted();
+                    return Task.CompletedTask;
+                }))
+            .Run();
+
+        Assert.That(context.Logs, Has.One.Matches<ScenarioContext.LogItem>(l =>
+            l.LoggerName == "PreStartScopeTest" &&
+            (l.Message ?? string.Empty).Contains("Message before endpoint start inside scope") &&
+            (l.Message ?? string.Empty).Contains("Endpoint = UsingEndpointLoggingScope.EndpointWithScope")));
+    }
+
+    [Test]
     public async Task Should_not_duplicate_scope_when_inside_pipeline()
     {
         var context = await Scenario.Define<Context>(ctx => ctx.IncludeLoggingScopes = true)

--- a/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
@@ -650,7 +650,7 @@ public class EndpointLoggingScopeTests
         LogManager.RegisterSlotFactory(slot, new MicrosoftLoggerFactoryAdapter(loggerFactory));
 
         var logger = loggerFactory.CreateLogger($"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}");
-        var endpointScope = new EndpointLoggingScope { EndpointName = "Sales", EndpointIdentifier = "blue" };
+        var endpointScope = new EndpointLoggingScope { EndpointName = "Sales", EndpointIdentifier = "blue", Slot = slot };
 
         using (LogManager.BeginSlotScope(slot))
         {
@@ -665,14 +665,17 @@ public class EndpointLoggingScopeTests
     }
 
     [Test]
-    public void BeginEndpointScope_should_push_scope_when_outside_slot_scope()
+    public void BeginEndpointScope_should_push_both_slot_and_mel_scope_when_factory_not_registered()
     {
         var loggerFactory = new CollectingMicrosoftLoggerFactory();
         var logger = loggerFactory.CreateLogger($"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}");
-        var endpointScope = new EndpointLoggingScope { EndpointName = "Billing", EndpointIdentifier = "green" };
+        var slot = new EndpointLogSlot("Billing", "green");
+        var endpointScope = new EndpointLoggingScope { EndpointName = "Billing", EndpointIdentifier = "green", Slot = slot };
 
         using (logger.BeginEndpointScope(endpointScope))
         {
+            Assert.That(LogManager.TryGetCurrentEndpointScopeState(out _), Is.True,
+                "SlotScope should be active even when factory is not registered");
             logger.LogInformation("outside-slot");
         }
 

--- a/src/NServiceBus.Core.Tests/MessageSessionTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageSessionTests.cs
@@ -32,7 +32,7 @@ public class MessageSessionTests
             }
         };
 
-        var session = new MessageSession(loggingSlot: new object());
+        var session = new MessageSession(loggingSlot: new EndpointLogSlot("Test", null));
         session.Initialize(new ThrowingServiceProvider(), messageOperations, new ThrowingPipelineCache(), CancellationToken.None);
 
         await session.Send(new object());
@@ -56,7 +56,7 @@ public class MessageSessionTests
             }
         };
 
-        var session = new MessageSession(loggingSlot: new object());
+        var session = new MessageSession(loggingSlot: new EndpointLogSlot("Test", null));
         session.Initialize(new ThrowingServiceProvider(), messageOperations, new ThrowingPipelineCache(), new CancellationToken(true));
 
         Assert.ThrowsAsync<OperationCanceledException>(async () =>
@@ -77,7 +77,7 @@ public class MessageSessionTests
             }
         };
 
-        var session = new MessageSession(loggingSlot: new object());
+        var session = new MessageSession(loggingSlot: new EndpointLogSlot("Test", null));
         session.Initialize(new ThrowingServiceProvider(), messageOperations, new ThrowingPipelineCache(), CancellationToken.None);
 
         Assert.ThrowsAsync<OperationCanceledException>(async () => await session.Send(new object(), new CancellationToken(true)));
@@ -86,7 +86,7 @@ public class MessageSessionTests
     [Test]
     public async Task Deferred_session_should_wait_until_initialized()
     {
-        var deferredSession = new MessageSession(loggingSlot: new object());
+        var deferredSession = new MessageSession(loggingSlot: new EndpointLogSlot("Test", null));
         var messageOperations = new TestableMessageOperations();
 
         var sendTask = deferredSession.Send(new object(), new SendOptions());

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -235,7 +235,7 @@ class EndpointCreator
     }
 
     internal MessageSession MessageSession { get; private set; }
-    internal object EndpointLogSlot => hostingConfiguration.EndpointLogSlot;
+    internal LogSlot EndpointLogSlot => hostingConfiguration.EndpointLogSlot;
 
     PipelineComponent pipelineComponent;
     FeatureComponent featureComponent;

--- a/src/NServiceBus.Core/Hosting/EndpointCreationStrategy.cs
+++ b/src/NServiceBus.Core/Hosting/EndpointCreationStrategy.cs
@@ -6,13 +6,13 @@ using System;
 
 interface IEndpointCreationStrategy
 {
-    object EndpointLogSlot { get; }
+    LogSlot EndpointLogSlot { get; }
     StartableEndpoint CreateStartableEndpoint(IServiceProvider serviceProvider);
 }
 
 sealed class InternalContainerEndpointCreationStrategy(EndpointCreator endpointCreator, IAsyncDisposable? serviceProviderLease = null) : IEndpointCreationStrategy
 {
-    public object EndpointLogSlot => endpointCreator.EndpointLogSlot;
+    public LogSlot EndpointLogSlot => endpointCreator.EndpointLogSlot;
 
     public StartableEndpoint CreateStartableEndpoint(IServiceProvider serviceProvider)
     {
@@ -25,7 +25,7 @@ sealed class InternalContainerEndpointCreationStrategy(EndpointCreator endpointC
 
 sealed class ExternalContainerEndpointCreationStrategy(EndpointCreator endpointCreator) : IEndpointCreationStrategy
 {
-    public object EndpointLogSlot => endpointCreator.EndpointLogSlot;
+    public LogSlot EndpointLogSlot => endpointCreator.EndpointLogSlot;
 
     public StartableEndpoint CreateStartableEndpoint(IServiceProvider serviceProvider)
     {

--- a/src/NServiceBus.Core/Logging/EndpointLoggingScopeExtensions.cs
+++ b/src/NServiceBus.Core/Logging/EndpointLoggingScopeExtensions.cs
@@ -33,11 +33,27 @@ public static class EndpointLoggingScopeExtensions
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(endpointScope);
 
-        if (endpointScope.Slot is { IsFactoryRegistered: true })
+        if (endpointScope.Slot is not null)
         {
-            return LogManager.BeginSlotScope(endpointScope.Slot);
+            var slotScope = LogManager.BeginSlotScope(endpointScope.Slot);
+
+            if (!endpointScope.Slot.IsFactoryRegistered)
+            {
+                return new CompositeDisposable(slotScope, logger.BeginScope(endpointScope));
+            }
+
+            return slotScope;
         }
 
         return logger.BeginScope(endpointScope) ?? NullScope.Instance;
+    }
+
+    sealed class CompositeDisposable(IDisposable first, IDisposable? second) : IDisposable
+    {
+        public void Dispose()
+        {
+            first.Dispose();
+            second?.Dispose();
+        }
     }
 }

--- a/src/NServiceBus.Core/Logging/EndpointLoggingScopeExtensions.cs
+++ b/src/NServiceBus.Core/Logging/EndpointLoggingScopeExtensions.cs
@@ -33,7 +33,7 @@ public static class EndpointLoggingScopeExtensions
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(endpointScope);
 
-        if (endpointScope.Slot is not null)
+        if (endpointScope.Slot is { IsFactoryRegistered: true })
         {
             return LogManager.BeginSlotScope(endpointScope.Slot);
         }

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -136,7 +136,7 @@ public static class LogManager
             ? new ExternalLoggerFactoryAdapter(externalFactory, microsoftLoggerFactory)
             : new MicrosoftLoggerFactoryAdapter(microsoftLoggerFactory);
 
-    internal static void RegisterSlotFactory(object slot, ILoggerFactory loggerFactory)
+    internal static void RegisterSlotFactory(LogSlot slot, ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(slot);
         ArgumentNullException.ThrowIfNull(loggerFactory);
@@ -150,7 +150,7 @@ public static class LogManager
         DrainScopedStartupLogs(slotKey, loggerFactory);
     }
 
-    internal static void UnregisterSlot(object slot)
+    internal static void UnregisterSlot(LogSlot slot)
     {
         ArgumentNullException.ThrowIfNull(slot);
 
@@ -178,7 +178,7 @@ public static class LogManager
         }
     }
 
-    internal static SlotScope BeginSlotScope(object slot)
+    internal static SlotScope BeginSlotScope(LogSlot slot)
     {
         ArgumentNullException.ThrowIfNull(slot);
 

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -143,6 +143,7 @@ public static class LogManager
 
         var slotKey = new SlotKey(slot);
         slotLoggerFactories[slotKey] = loggerFactory;
+        slot.IsFactoryRegistered = true;
         var slotContext = GetOrAddSlotContext(slotKey);
 
         using var _ = new SlotScope(slotContext);

--- a/src/NServiceBus.Core/Logging/LogScopeStates.cs
+++ b/src/NServiceBus.Core/Logging/LogScopeStates.cs
@@ -19,6 +19,7 @@ abstract class LogScopeState : IReadOnlyList<KeyValuePair<string, object?>>
 abstract class LogSlot
 {
     public abstract LogScopeState ScopeState { get; }
+    internal volatile bool IsFactoryRegistered;
 }
 
 sealed class LogScopeStates(object endpointName, object? endpointIdentifier) : LogScopeState

--- a/src/NServiceBus.Core/Logging/SlotUnregisterer.cs
+++ b/src/NServiceBus.Core/Logging/SlotUnregisterer.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Logging;
 
-sealed class SlotUnregisterer(object slot) : IAsyncDisposable
+sealed class SlotUnregisterer(LogSlot slot) : IAsyncDisposable
 {
     int unregistered;
 

--- a/src/NServiceBus.Core/MessageSession.cs
+++ b/src/NServiceBus.Core/MessageSession.cs
@@ -10,7 +10,7 @@ using Logging;
 
 class MessageSession : IMessageSession
 {
-    internal MessageSession(object loggingSlot)
+    internal MessageSession(LogSlot loggingSlot)
     {
         this.loggingSlot = loggingSlot;
         initializedTaskCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -84,7 +84,7 @@ class MessageSession : IMessageSession
         ArgumentNullException.ThrowIfNull(message);
         ArgumentNullException.ThrowIfNull(sendOptions);
 
-        using var _ = LogManager.BeginSlotScope(loggingSlot!);
+        using var _ = LogManager.BeginSlotScope(loggingSlot);
         await WaitUntilInitialized(cancellationToken).ConfigureAwait(false);
         using var linkedTokenSource = CreateOperationLinkedTokenSource(cancellationToken);
         await messageOperations.Send(CreateContext(linkedTokenSource.Token), message, sendOptions).ConfigureAwait(false);
@@ -95,7 +95,7 @@ class MessageSession : IMessageSession
         ArgumentNullException.ThrowIfNull(messageConstructor);
         ArgumentNullException.ThrowIfNull(sendOptions);
 
-        using var _ = LogManager.BeginSlotScope(loggingSlot!);
+        using var _ = LogManager.BeginSlotScope(loggingSlot);
         await WaitUntilInitialized(cancellationToken).ConfigureAwait(false);
         using var linkedTokenSource = CreateOperationLinkedTokenSource(cancellationToken);
         await messageOperations.Send(CreateContext(linkedTokenSource.Token), messageConstructor, sendOptions).ConfigureAwait(false);
@@ -106,7 +106,7 @@ class MessageSession : IMessageSession
         ArgumentNullException.ThrowIfNull(message);
         ArgumentNullException.ThrowIfNull(publishOptions);
 
-        using var _ = LogManager.BeginSlotScope(loggingSlot!);
+        using var _ = LogManager.BeginSlotScope(loggingSlot);
         await WaitUntilInitialized(cancellationToken).ConfigureAwait(false);
         using var linkedTokenSource = CreateOperationLinkedTokenSource(cancellationToken);
         await messageOperations.Publish(CreateContext(linkedTokenSource.Token), message, publishOptions).ConfigureAwait(false);
@@ -117,7 +117,7 @@ class MessageSession : IMessageSession
         ArgumentNullException.ThrowIfNull(messageConstructor);
         ArgumentNullException.ThrowIfNull(publishOptions);
 
-        using var _ = LogManager.BeginSlotScope(loggingSlot!);
+        using var _ = LogManager.BeginSlotScope(loggingSlot);
         await WaitUntilInitialized(cancellationToken).ConfigureAwait(false);
         using var linkedTokenSource = CreateOperationLinkedTokenSource(cancellationToken);
         await messageOperations.Publish(CreateContext(linkedTokenSource.Token), messageConstructor, publishOptions).ConfigureAwait(false);
@@ -128,7 +128,7 @@ class MessageSession : IMessageSession
         ArgumentNullException.ThrowIfNull(eventType);
         ArgumentNullException.ThrowIfNull(subscribeOptions);
 
-        using var _ = LogManager.BeginSlotScope(loggingSlot!);
+        using var _ = LogManager.BeginSlotScope(loggingSlot);
         await WaitUntilInitialized(cancellationToken).ConfigureAwait(false);
         using var linkedTokenSource = CreateOperationLinkedTokenSource(cancellationToken);
         await messageOperations.Subscribe(CreateContext(linkedTokenSource.Token), eventType, subscribeOptions).ConfigureAwait(false);
@@ -136,7 +136,7 @@ class MessageSession : IMessageSession
 
     public async Task SubscribeAll(Type[] eventTypes, SubscribeOptions subscribeOptions, CancellationToken cancellationToken = default)
     {
-        using var _ = LogManager.BeginSlotScope(loggingSlot!);
+        using var _ = LogManager.BeginSlotScope(loggingSlot);
         await WaitUntilInitialized(cancellationToken).ConfigureAwait(false);
         // set a flag on the context so that subscribe implementations know which send API was used.
         subscribeOptions.Context.Set(SubscribeAllFlagKey, true);
@@ -149,13 +149,13 @@ class MessageSession : IMessageSession
         ArgumentNullException.ThrowIfNull(eventType);
         ArgumentNullException.ThrowIfNull(unsubscribeOptions);
 
-        using var _ = LogManager.BeginSlotScope(loggingSlot!);
+        using var _ = LogManager.BeginSlotScope(loggingSlot);
         await WaitUntilInitialized(cancellationToken).ConfigureAwait(false);
         using var linkedTokenSource = CreateOperationLinkedTokenSource(cancellationToken);
         await messageOperations.Unsubscribe(CreateContext(linkedTokenSource.Token), eventType, unsubscribeOptions).ConfigureAwait(false);
     }
 
-    readonly object? loggingSlot;
+    readonly LogSlot loggingSlot;
     IServiceProvider? serviceProvider;
     MessageOperations? messageOperations;
     IPipelineCache? pipelineCache;

--- a/src/NServiceBus.Core/Receiving/LogWrappedMessageReceiver.cs
+++ b/src/NServiceBus.Core/Receiving/LogWrappedMessageReceiver.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using NServiceBus.Logging;
 using NServiceBus.Transport;
 
-class LogWrappedMessageReceiver(IMessageReceiver receiver, object endpointLogSlot) : IMessageReceiver
+class LogWrappedMessageReceiver(IMessageReceiver receiver, LogSlot endpointLogSlot) : IMessageReceiver
 {
     public ISubscriptionManager Subscriptions => receiver.Subscriptions;
     public string Id => receiver.Id;

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -16,7 +16,7 @@ using Unicast;
 
 partial class ReceiveComponent
 {
-    ReceiveComponent(Configuration configuration, IActivityFactory activityFactory, object endpointLogSlot)
+    ReceiveComponent(Configuration configuration, IActivityFactory activityFactory, LogSlot endpointLogSlot)
     {
         this.configuration = configuration;
         this.activityFactory = activityFactory;
@@ -265,7 +265,7 @@ partial class ReceiveComponent
         return Task.WhenAll(receiverStopTasks);
     }
 
-    static LogWrappedMessageReceiver CreateReceiver(ConsecutiveFailuresConfiguration consecutiveFailuresConfiguration, IMessageReceiver receiver, object endpointLogSlot)
+    static LogWrappedMessageReceiver CreateReceiver(ConsecutiveFailuresConfiguration consecutiveFailuresConfiguration, IMessageReceiver receiver, LogSlot endpointLogSlot)
     {
         var effectiveReceiver = consecutiveFailuresConfiguration.RateLimitSettings is not null
             ? new WrappedMessageReceiver(consecutiveFailuresConfiguration, receiver)
@@ -274,7 +274,7 @@ partial class ReceiveComponent
         return new LogWrappedMessageReceiver(effectiveReceiver, endpointLogSlot);
     }
 
-    static object CreateReceiverProcessingLogSlot(object endpointLogSlot, string receiverId)
+    static LogSlot CreateReceiverProcessingLogSlot(LogSlot endpointLogSlot, string receiverId)
     {
         if (endpointLogSlot is not EndpointLogSlot endpointSlot)
         {
@@ -284,11 +284,11 @@ partial class ReceiveComponent
         return receiverId == InstanceSpecificReceiverId ? new EndpointReceiverLogSlot(endpointSlot, receiverId) : endpointLogSlot;
     }
 
-    static object CreateSatelliteProcessingLogSlot(object endpointLogSlot, string satelliteName) => endpointLogSlot is not EndpointLogSlot endpointSlot ? endpointLogSlot : new EndpointSatelliteLogSlot(endpointSlot, satelliteName);
+    static LogSlot CreateSatelliteProcessingLogSlot(LogSlot endpointLogSlot, string satelliteName) => endpointLogSlot is not EndpointLogSlot endpointSlot ? endpointLogSlot : new EndpointSatelliteLogSlot(endpointSlot, satelliteName);
 
     readonly Configuration configuration;
     readonly IActivityFactory activityFactory;
-    readonly object endpointLogSlot;
+    readonly LogSlot endpointLogSlot;
     readonly List<IMessageReceiver> receivers = [];
 
     const string MainReceiverId = "Main";

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -18,7 +18,7 @@ class RunningEndpointInstance(SettingsHolder settings,
     CancellationTokenSource stoppingTokenSource,
     IAsyncDisposable serviceProviderLease,
 #pragma warning disable CS0618 // Type or member is obsolete -- Change the interface to IMessageSession in the next major
-    object endpointLogSlot) : IEndpointInstance, IAsyncDisposable
+    LogSlot endpointLogSlot) : IEndpointInstance, IAsyncDisposable
 #pragma warning restore CS0618 // Type or member is obsolete
 {
     // Stop is the legacy interface for shutting down the endpoint over the public API.


### PR DESCRIPTION
### Problem

When `BeginEndpointScope` was called before the endpoint started (e.g., between `host.Build()` and `host.StartAsync()`), MEL `ILogger` output had no scope enrichment — `Scopes:[]`. Legacy `ILog` calls were also affected: without a slot scope, logs went directly to the fallback factory instead of being deferred for later flush with scope metadata.

The root cause was that `BeginEndpointScope` only called `LogManager.BeginSlotScope`, which pushes MEL scope via the slot factory. Before startup, the slot factory is not registered yet, so no MEL scope gets pushed at all.

### Solution

`BeginEndpointScope` now distinguishes two phases:

- **Before endpoint start** (slot factory not registered): pushes both `SlotScope` (for legacy `ILog` deferral and async-local routing) and `logger.BeginScope` (for immediate MEL `ILogger` enrichment) via a composite disposable.
- **After endpoint start** (slot factory registered): `SlotScope` handles both concerns through `ISlotScopedLoggerFactory`, with dedup via the existing `alreadyInSameSlot` guard.

A `volatile bool IsFactoryRegistered` flag on `LogSlot` is set by `LogManager.RegisterSlotFactory` when the endpoint starts, allowing `BeginEndpointScope` to select the correct path without querying internal dictionaries.

As a cleanup, `LogManager.RegisterSlotFactory`, `UnregisterSlot`, and `BeginSlotScope` now take `LogSlot` instead of `object`, eliminating unnecessary boxing and runtime casts across all callers.