### PR TITLE
Test .NET 11 Preview 4 on release9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5.1.0
         with:
-          global-json-file: global.json
+          dotnet-version: |
+            8.0.x
+            11.0.x
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-dotnet@v5.1.0
         with:
           global-json-file: global.json
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,8 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5.1.0
         with:
-          dotnet-version: |
-            8.0.x
-            11.0.x
+          global-json-file: global.json
+          dotnet-version: 8.0.x
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.0",
-    "rollForward": "latestFeature"
+    "version": "11.0.100-preview.4.26230.115",
+    "allowPrerelease": true,
+    "rollForward": "latestPatch"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.4.26230.115",
+    "version": "11.0.0",
     "allowPrerelease": true,
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFramework>net11.0</TargetFramework>
+   <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+   <TargetFramework>net11.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
+++ b/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFramework>net11.0</TargetFramework>
+   <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
+++ b/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+   <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn4/NServiceBus.Core.Analyzer.Tests.Roslyn4.csproj
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn4/NServiceBus.Core.Analyzer.Tests.Roslyn4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFramework>net11.0</TargetFramework>
+   <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn4/NServiceBus.Core.Analyzer.Tests.Roslyn4.csproj
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn4/NServiceBus.Core.Analyzer.Tests.Roslyn4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+   <TargetFramework>net11.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFramework>net11.0</TargetFramework>
+   <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+   <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Learning.AcceptanceTests/NServiceBus.Learning.AcceptanceTests.csproj
+++ b/src/NServiceBus.Learning.AcceptanceTests/NServiceBus.Learning.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFramework>net11.0</TargetFramework>
+   <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Learning.AcceptanceTests/NServiceBus.Learning.AcceptanceTests.csproj
+++ b/src/NServiceBus.Learning.AcceptanceTests/NServiceBus.Learning.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+   <TargetFramework>net11.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
+++ b/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFramework>net11.0</TargetFramework>
+   <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
+++ b/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+   <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
+++ b/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
     <RootNamespace>NServiceBus.Testing</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFramework>net11.0</TargetFramework>
+   <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+   <TargetFramework>net11.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update `global.json` to target the .NET 11 Preview 4 SDK and enable prerelease versions. Adjust CI workflow to install the 11.0.x SDK alongside 8.0.x to support the new preview.