### PR TITLE
False positive NSB0033 for Handle methods implementing a derived IHandleMessages

### DIFF
--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
@@ -660,6 +660,31 @@ public class HandlerAttributeAnalyzerTests : AnalyzerTestFixture<HandlerAttribut
     }
 
     [Test]
+    public Task DoesNotReportConventionBasedHandlerImplementingUnrelatedInterfaceWithHandleMethod()
+    {
+        var source =
+            """
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            interface IUnrelatedHandler
+            {
+                Task Handle(MyMessage message, IMessageHandlerContext context);
+            }
+
+            [Handler]
+            class MyHandler : IUnrelatedHandler
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context) => Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage {}
+            """;
+
+        return Assert(source);
+    }
+
+    [Test]
     public Task ReportsMisplacedAttributeOnComplexBase()
     {
         var source =

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
@@ -591,6 +591,41 @@ public class HandlerAttributeAnalyzerTests : AnalyzerTestFixture<HandlerAttribut
     }
 
     [Test]
+    public Task DoesNotReportMixedStyleForDerivedHandlerInterfaceWithExtendedHandle()
+    {
+        // A custom interface deriving from IHandleMessages<T> that exposes an extended Handle
+        // signature (extra CancellationToken parameter) and forwards the two-parameter
+        // IHandleMessages<T>.Handle to it via a default interface method. The handler's extended
+        // Handle method is the implementation of that interface member, so it is interface-based,
+        // not a mixed style.
+        var source =
+            """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            interface IExtendedHandler<T> : IHandleMessages<T>
+            {
+                Task IHandleMessages<T>.Handle(T message, IMessageHandlerContext context) =>
+                    Handle(message, context, context.CancellationToken);
+
+                Task Handle(T message, IMessageHandlerContext context, CancellationToken cancellation = default);
+            }
+
+            [Handler]
+            class MyHandler : IExtendedHandler<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context, CancellationToken cancellation = default) =>
+                    Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage {}
+            """;
+
+        return Assert(source);
+    }
+
+    [Test]
     public Task ReportsMisplacedAttributeOnComplexBase()
     {
         var source =

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
@@ -626,6 +626,40 @@ public class HandlerAttributeAnalyzerTests : AnalyzerTestFixture<HandlerAttribut
     }
 
     [Test]
+    public Task DoesNotReportMixedStyleForDerivedHandlerInterfaceWithExtendedHandleImplementedByBaseClass()
+    {
+        var source =
+            """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            interface IExtendedHandler<T> : IHandleMessages<T>
+            {
+                Task IHandleMessages<T>.Handle(T message, IMessageHandlerContext context) =>
+                    Handle(message, context, context.CancellationToken);
+
+                Task Handle(T message, IMessageHandlerContext context, CancellationToken cancellation = default);
+            }
+
+            abstract class BaseHandler
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context, CancellationToken cancellation = default) =>
+                    Task.CompletedTask;
+            }
+
+            [Handler]
+            class MyHandler : BaseHandler, IExtendedHandler<MyMessage>
+            {
+            }
+
+            class MyMessage : IMessage {}
+            """;
+
+        return Assert(source);
+    }
+
+    [Test]
     public Task ReportsMisplacedAttributeOnComplexBase()
     {
         var source =

--- a/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
@@ -91,7 +91,41 @@ static class ConventionBasedHandlerHelper
         {
             return false;
         }
+
+        // If this Handle method is the implementation of an interface member, it is interface-based,
+        // not convention-based. This covers custom interfaces that derive from IHandleMessages<T> and
+        // expose an extended Handle signature (e.g. an additional CancellationToken parameter) backed
+        // by a default interface method that forwards to the two-parameter IHandleMessages<T>.Handle.
+        if (ImplementsInterfaceMember(method))
+        {
+            return false;
+        }
+
         return true;
+    }
+
+    static bool ImplementsInterfaceMember(IMethodSymbol method)
+    {
+        var containingType = method.ContainingType;
+        if (containingType is null)
+        {
+            return false;
+        }
+
+        foreach (var iface in containingType.AllInterfaces)
+        {
+            foreach (var interfaceMethod in iface.GetMembers(HandleMethodName).OfType<IMethodSymbol>())
+            {
+                var implementation = containingType.FindImplementationForInterfaceMember(interfaceMethod);
+                if (implementation is not null &&
+                    SymbolEqualityComparer.Default.Equals(implementation, method))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     public static bool IsConventionBasedHandlerWithBoundCancellationToken(IMethodSymbol method, Compilation compilation)

--- a/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
@@ -95,11 +95,11 @@ static class ConventionBasedHandlerHelper
             return false;
         }
 
-        // If this Handle method is the implementation of an interface member, it is interface-based,
-        // not convention-based. This covers custom interfaces that derive from IHandleMessages<T> and
-        // expose an extended Handle signature (e.g. an additional CancellationToken parameter) backed
-        // by a default interface method that forwards to the two-parameter IHandleMessages<T>.Handle.
-        if (ImplementsInterfaceMember(method, interfaceImplementationType))
+        // If this Handle method is the implementation of an interface member that belongs to a handler
+        // interface hierarchy (IHandleMessages<T>, IHandleTimeouts<T>, IAmStartedByMessages<T>, or an
+        // interface deriving from them), it is interface-based, not convention-based.
+        // Unrelated interfaces with a Handle-like method do NOT disqualify a convention-based handler.
+        if (ImplementsHandlerInterfaceMember(method, knownTypes, interfaceImplementationType))
         {
             return false;
         }
@@ -107,12 +107,21 @@ static class ConventionBasedHandlerHelper
         return true;
     }
 
-    static bool ImplementsInterfaceMember(IMethodSymbol method, INamedTypeSymbol? interfaceImplementationType)
+    static bool ImplementsHandlerInterfaceMember(IMethodSymbol method, HandlerKnownTypes knownTypes, INamedTypeSymbol? interfaceImplementationType)
     {
         // Fast path: check explicit interface implementations first (O(1))
         if (!method.ExplicitInterfaceImplementations.IsEmpty)
         {
-            return true;
+            // Only count as handler interface member if the explicit implementation targets a handler interface
+            foreach (var explicitImpl in method.ExplicitInterfaceImplementations)
+            {
+                if (IsHandlerInterfaceOrDerived(explicitImpl.ContainingType, knownTypes))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         interfaceImplementationType ??= method.ContainingType;
@@ -121,9 +130,14 @@ static class ConventionBasedHandlerHelper
             return false;
         }
 
-        // Check implicit interface implementations
+        // Check implicit interface implementations — only for handler interface hierarchies
         foreach (var iface in interfaceImplementationType.AllInterfaces)
         {
+            if (!IsHandlerInterfaceOrDerived(iface, knownTypes))
+            {
+                continue;
+            }
+
             foreach (var interfaceMethod in iface.GetMembers(method.Name).OfType<IMethodSymbol>())
             {
                 if (interfaceMethod.Parameters.Length != method.Parameters.Length)
@@ -136,6 +150,26 @@ static class ConventionBasedHandlerHelper
                 {
                     return true;
                 }
+            }
+        }
+
+        return false;
+    }
+
+    static bool IsHandlerInterfaceOrDerived(INamedTypeSymbol iface, HandlerKnownTypes knownTypes)
+    {
+        // Direct check: is this one of the known handler interface definitions?
+        if (iface.IsGenericType && HandlerConventions.IsHandlerInterface(iface.OriginalDefinition, knownTypes))
+        {
+            return true;
+        }
+
+        // Derived check: does this interface inherit from a handler interface?
+        foreach (var baseInterface in iface.AllInterfaces)
+        {
+            if (baseInterface.IsGenericType && HandlerConventions.IsHandlerInterface(baseInterface.OriginalDefinition, knownTypes))
+            {
+                return true;
             }
         }
 

--- a/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
@@ -14,7 +14,7 @@ static class ConventionBasedHandlerHelper
     {
         for (var current = classType; current is not null; current = current.BaseType)
         {
-            if (HasValidConventionBasedHandleMethods(current, knownTypes))
+            if (HasValidConventionBasedHandleMethods(current, knownTypes, classType))
             {
                 return true;
             }
@@ -23,10 +23,13 @@ static class ConventionBasedHandlerHelper
         return false;
     }
 
-    public static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes)
+    public static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes) =>
+        HasValidConventionBasedHandleMethods(classType, knownTypes, classType);
+
+    static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, INamedTypeSymbol interfaceImplementationType)
     {
         var interfaceMessageTypes = new HashSet<string>(System.StringComparer.Ordinal);
-        foreach (var iface in classType.AllInterfaces)
+        foreach (var iface in interfaceImplementationType.AllInterfaces)
         {
             if (iface.IsGenericType && HandlerConventions.IsHandlerInterface(iface.OriginalDefinition, knownTypes) &&
                 iface.TypeArguments[0] is INamedTypeSymbol msgType)
@@ -42,7 +45,7 @@ static class ConventionBasedHandlerHelper
                 continue;
             }
 
-            if (IsValidConventionBasedHandleMethod(method, knownTypes, interfaceMessageTypes))
+            if (IsValidConventionBasedHandleMethod(method, knownTypes, interfaceMessageTypes, interfaceImplementationType))
             {
                 return true;
             }
@@ -51,7 +54,7 @@ static class ConventionBasedHandlerHelper
         return false;
     }
 
-    public static bool IsValidConventionBasedHandleMethod(IMethodSymbol method, HandlerKnownTypes knownTypes, HashSet<string> interfaceMessageTypes)
+    public static bool IsValidConventionBasedHandleMethod(IMethodSymbol method, HandlerKnownTypes knownTypes, HashSet<string> interfaceMessageTypes, INamedTypeSymbol? interfaceImplementationType = null)
     {
         if (method.Name != HandleMethodName ||
             method.DeclaredAccessibility != Accessibility.Public ||
@@ -96,7 +99,7 @@ static class ConventionBasedHandlerHelper
         // not convention-based. This covers custom interfaces that derive from IHandleMessages<T> and
         // expose an extended Handle signature (e.g. an additional CancellationToken parameter) backed
         // by a default interface method that forwards to the two-parameter IHandleMessages<T>.Handle.
-        if (ImplementsInterfaceMember(method))
+        if (ImplementsInterfaceMember(method, interfaceImplementationType))
         {
             return false;
         }
@@ -104,21 +107,32 @@ static class ConventionBasedHandlerHelper
         return true;
     }
 
-    static bool ImplementsInterfaceMember(IMethodSymbol method)
+    static bool ImplementsInterfaceMember(IMethodSymbol method, INamedTypeSymbol? interfaceImplementationType)
     {
-        var containingType = method.ContainingType;
-        if (containingType is null)
+        // Fast path: check explicit interface implementations first (O(1))
+        if (!method.ExplicitInterfaceImplementations.IsEmpty)
+        {
+            return true;
+        }
+
+        interfaceImplementationType ??= method.ContainingType;
+        if (interfaceImplementationType is null)
         {
             return false;
         }
 
-        foreach (var iface in containingType.AllInterfaces)
+        // Check implicit interface implementations
+        foreach (var iface in interfaceImplementationType.AllInterfaces)
         {
-            foreach (var interfaceMethod in iface.GetMembers(HandleMethodName).OfType<IMethodSymbol>())
+            foreach (var interfaceMethod in iface.GetMembers(method.Name).OfType<IMethodSymbol>())
             {
-                var implementation = containingType.FindImplementationForInterfaceMember(interfaceMethod);
-                if (implementation is not null &&
-                    SymbolEqualityComparer.Default.Equals(implementation, method))
+                if (interfaceMethod.Parameters.Length != method.Parameters.Length)
+                {
+                    continue;
+                }
+
+                var implementation = interfaceImplementationType.FindImplementationForInterfaceMember(interfaceMethod);
+                if (SymbolEqualityComparer.Default.Equals(implementation, method))
                 {
                     return true;
                 }

--- a/src/NServiceBus.Core.Analyzer/Handlers/Handlers.Parser.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/Handlers.Parser.cs
@@ -152,7 +152,7 @@ public static partial class Handlers
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (!ConventionBasedHandlerHelper.IsValidConventionBasedHandleMethod(method, knownTypes, interfaceMessageTypes))
+                if (!ConventionBasedHandlerHelper.IsValidConventionBasedHandleMethod(method, knownTypes, interfaceMessageTypes, handlerType))
                 {
                     continue;
                 }


### PR DESCRIPTION
## Symptoms

The compiler reports a false positive NSB0033 diagnostic for Handle methods implementing implementing an interface derived from `IHandleMessages<T>`. 

## Who's affected

Users of NServiceBus 10.2.0 using an intermediate interface to identify handlers rather than using `IHandleMessages<T>` directly.`

## Root cause

The use case of an intermediate marker interface was not considered in the analyzer design.

## Original bug report

Fix NSB0033 false positive for Handle methods implementing a derived IHandleMessages<T> interface The mixed-style check treated any Handle(message, context, ...) method with more than two parameters as convention-based, even when that method is the implementation of an interface member. This produced a false positive for handlers that implement a custom interface deriving from IHandleMessages<T> which exposes an extended Handle signature (e.g. an extra CancellationToken) backed by a default interface method that forwards to the two-parameter IHandleMessages<T>.Handle.
IsValidConventionBasedHandleMethod now classifies a Handle method that implements any interface member as interface-based rather than convention-based, regardless of parameter count.