### PR TITLE
Persistence tests leave saga storage directories around in temp directory

### DIFF
--- a/src/NServiceBus.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -33,8 +33,10 @@ public partial class PersistenceTestsConfiguration
     {
         SagaIdGenerator = new LearningSagaIdGenerator();
 
+        storageLocation = Path.Combine(Path.GetTempPath(), ".sagas", TestContext.CurrentContext.Test.ID);
+
         var sagaManifests = new SagaManifestCollection(SagaMetadataCollection,
-            Path.Combine(Path.GetTempPath(), ".sagas", TestContext.CurrentContext.Test.ID),
+            storageLocation,
             name => DeterministicGuid.Create(name).ToString());
 
         SagaStorage = new LearningSagaPersister(sagaManifests);
@@ -44,5 +46,15 @@ public partial class PersistenceTestsConfiguration
         return Task.CompletedTask;
     }
 
-    public Task Cleanup(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task Cleanup(CancellationToken cancellationToken = default)
+    {
+        if (storageLocation != null && Directory.Exists(storageLocation))
+        {
+            Directory.Delete(storageLocation, true);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    string storageLocation;
 }

--- a/src/NServiceBus.PersistenceTests/PersistenceTestsConfigurationTests.cs
+++ b/src/NServiceBus.PersistenceTests/PersistenceTestsConfigurationTests.cs
@@ -1,0 +1,37 @@
+namespace NServiceBus.PersistenceTesting;
+
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+[TestFixture]
+public class PersistenceTestsConfigurationTests
+{
+    [Test]
+    public async Task Cleanup_should_remove_the_saga_storage_directory()
+    {
+        var configuration = new PersistenceTestsConfiguration(new TestVariant("default"));
+
+        await configuration.Configure();
+
+        var storageLocation = Path.Combine(Path.GetTempPath(), ".sagas", TestContext.CurrentContext.Test.ID);
+        Assert.That(Directory.Exists(storageLocation), Is.True, "Configure should create the saga storage directory");
+
+        await configuration.Cleanup();
+
+        Assert.That(Directory.Exists(storageLocation), Is.False, "Cleanup should remove the saga storage directory");
+    }
+
+    [Test]
+    public async Task Cleanup_should_not_throw_when_storage_directory_is_missing()
+    {
+        var configuration = new PersistenceTestsConfiguration(new TestVariant("default"));
+
+        await configuration.Configure();
+
+        var storageLocation = Path.Combine(Path.GetTempPath(), ".sagas", TestContext.CurrentContext.Test.ID);
+        Directory.Delete(storageLocation, true);
+
+        Assert.DoesNotThrowAsync(() => configuration.Cleanup());
+    }
+}


### PR DESCRIPTION
Delete saga storage directory in persistence tests Cleanup PersistenceTestsConfiguration.Configure created saga storage under %TEMP%\.sagas\<TestID> but Cleanup was a no-op, so every persistence test run leaked its directory and they accumulated indefinitely. Track the storage location and recursively delete it in Cleanup