### PR TITLE
Prefer strongly-typed StringBuilder overload in PipelineStepDiagnostics

### DIFF
--- a/src/NServiceBus.Core/Pipeline/PipelineStepDiagnostics.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineStepDiagnostics.cs
@@ -25,7 +25,7 @@ static class PipelineStepDiagnostics
             var nextContextName = $"context{i}";
 
             sb.AppendLine();
-            sb.Append(new string(' ', i * 4));
+            sb.Append(' ', i * 4);
             sb.Append($"({step.InputContextType.Name} {nextContextName}) => {step.BehaviorType.Name}.Invoke({nextContextName}{(i + 1 < steps.Count ? "," : string.Empty)}");
         }
 


### PR DESCRIPTION
This causes a warning when compiled using .NET 11 Preview 4.

```
warning CA1830: Prefer strongly-typed StringBuilder overload (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830)
```

Identified in https://github.com/Particular/NServiceBus/pull/7766/changes#r3307099146