### PR TITLE
Mark source-generated handler adapters with CompilerGeneratedAttribute

### DIFF
--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerCtorAndMethodInjectionWithSameParameterName.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerCtorAndMethodInjectionWithSameParameterName.approved.txt
@@ -36,6 +36,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_84ed469652f1dfdc : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerCtorAndMethodInjectionWithSameParameterName.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerCtorAndMethodInjectionWithSameParameterName.approved.txt
@@ -37,6 +37,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_84ed469652f1dfdc : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerCtorAndMethodInjectionWithSameParameterName.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerCtorAndMethodInjectionWithSameParameterName.approved.txt
@@ -36,9 +36,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_84ed469652f1dfdc : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceFromCtor;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerHidingBaseClassMethodWithNew.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerHidingBaseClassMethodWithNew.approved.txt
@@ -36,6 +36,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerHidingBaseClassMethodWithNew.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerHidingBaseClassMethodWithNew.approved.txt
@@ -37,6 +37,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerHidingBaseClassMethodWithNew.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerHidingBaseClassMethodWithNew.approved.txt
@@ -36,9 +36,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerInheritedFromBaseClass.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerInheritedFromBaseClass.approved.txt
@@ -36,9 +36,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerInheritedFromBaseClass.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerInheritedFromBaseClass.approved.txt
@@ -37,6 +37,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerInheritedFromBaseClass.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerInheritedFromBaseClass.approved.txt
@@ -36,6 +36,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithActivatorUtilitiesConstructorAttributeUsesMarkedConstructor.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithActivatorUtilitiesConstructorAttributeUsesMarkedConstructor.approved.txt
@@ -37,6 +37,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_fa2b89e238cf7fd6 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithActivatorUtilitiesConstructorAttributeUsesMarkedConstructor.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithActivatorUtilitiesConstructorAttributeUsesMarkedConstructor.approved.txt
@@ -36,9 +36,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_fa2b89e238cf7fd6 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceC _serviceCFromCtor;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithActivatorUtilitiesConstructorAttributeUsesMarkedConstructor.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithActivatorUtilitiesConstructorAttributeUsesMarkedConstructor.approved.txt
@@ -36,6 +36,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_fa2b89e238cf7fd6 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithConflictingCtorParameterName.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithConflictingCtorParameterName.approved.txt
@@ -36,9 +36,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceFromCtor;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithConflictingCtorParameterName.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithConflictingCtorParameterName.approved.txt
@@ -37,6 +37,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithConflictingCtorParameterName.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithConflictingCtorParameterName.approved.txt
@@ -36,6 +36,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithMultipleConstructorsUsesMostGreedyConstructor.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithMultipleConstructorsUsesMostGreedyConstructor.approved.txt
@@ -36,9 +36,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_40f827e6c30cb1cb : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceAFromCtor;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithMultipleConstructorsUsesMostGreedyConstructor.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithMultipleConstructorsUsesMostGreedyConstructor.approved.txt
@@ -37,6 +37,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_40f827e6c30cb1cb : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithMultipleConstructorsUsesMostGreedyConstructor.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithMultipleConstructorsUsesMostGreedyConstructor.approved.txt
@@ -36,6 +36,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_40f827e6c30cb1cb : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithMultipleHandleMethodsSameMessageType.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithMultipleHandleMethodsSameMessageType.approved.txt
@@ -40,9 +40,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
 
@@ -53,9 +53,9 @@ sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NService
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_f018c527f72a5f56 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceAFromMethod;
@@ -72,9 +72,9 @@ sealed file class OrderHandler__Handle__Cmd1_f018c527f72a5f56 : global::NService
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_8f0c4c684fd6fad3 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceAFromMethod;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithMultipleHandleMethodsSameMessageType.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithMultipleHandleMethodsSameMessageType.approved.txt
@@ -40,6 +40,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -52,6 +53,7 @@ sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NService
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderHandler__Handle__Cmd1_f018c527f72a5f56 : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -70,6 +72,7 @@ sealed file class OrderHandler__Handle__Cmd1_f018c527f72a5f56 : global::NService
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderHandler__Handle__Cmd1_8f0c4c684fd6fad3 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithMultipleHandleMethodsSameMessageType.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithMultipleHandleMethodsSameMessageType.approved.txt
@@ -41,6 +41,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -54,6 +55,7 @@ sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NService
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_f018c527f72a5f56 : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -73,6 +75,7 @@ sealed file class OrderHandler__Handle__Cmd1_f018c527f72a5f56 : global::NService
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_8f0c4c684fd6fad3 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithSuffixCollision.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithSuffixCollision.approved.txt
@@ -36,9 +36,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceFromCtor;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithSuffixCollision.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithSuffixCollision.approved.txt
@@ -37,6 +37,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithSuffixCollision.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlerWithSuffixCollision.approved.txt
@@ -36,6 +36,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlers.approved.txt
@@ -64,6 +64,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_abf6ab59fa4378ea : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -84,6 +85,7 @@ sealed file class OrderShippedHandler__Handle__Cmd1_abf6ab59fa4378ea : global::N
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderPlacedHandler__Handle__Cmd2_bced5e5e9570a48a : global::NServiceBus.IHandleMessages<global::Cmd2>
@@ -95,6 +97,7 @@ sealed file class OrderPlacedHandler__Handle__Cmd2_bced5e5e9570a48a : global::NS
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderAcceptedHandler__Handle__Cmd1_da7a5fd2452aa3d8 : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -112,6 +115,7 @@ sealed file class OrderAcceptedHandler__Handle__Cmd1_da7a5fd2452aa3d8 : global::
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderAcceptedHandler__Handle__Cmd2_5a8c95a05fa2edc7 : global::NServiceBus.IHandleMessages<global::Cmd2>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlers.approved.txt
@@ -64,9 +64,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_abf6ab59fa4378ea : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IMyService _serviceFromCtor;
@@ -85,9 +85,9 @@ sealed file class OrderShippedHandler__Handle__Cmd1_abf6ab59fa4378ea : global::N
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderPlacedHandler__Handle__Cmd2_bced5e5e9570a48a : global::NServiceBus.IHandleMessages<global::Cmd2>
 {
 
@@ -97,9 +97,9 @@ sealed file class OrderPlacedHandler__Handle__Cmd2_bced5e5e9570a48a : global::NS
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderAcceptedHandler__Handle__Cmd1_da7a5fd2452aa3d8 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IMyService _serviceFromMethod;
@@ -115,9 +115,9 @@ sealed file class OrderAcceptedHandler__Handle__Cmd1_da7a5fd2452aa3d8 : global::
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderAcceptedHandler__Handle__Cmd2_5a8c95a05fa2edc7 : global::NServiceBus.IHandleMessages<global::Cmd2>
 {
     readonly global::IMyService _serviceFromMethod;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlers.approved.txt
@@ -65,6 +65,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_abf6ab59fa4378ea : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -86,6 +87,7 @@ sealed file class OrderShippedHandler__Handle__Cmd1_abf6ab59fa4378ea : global::N
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderPlacedHandler__Handle__Cmd2_bced5e5e9570a48a : global::NServiceBus.IHandleMessages<global::Cmd2>
@@ -98,6 +100,7 @@ sealed file class OrderPlacedHandler__Handle__Cmd2_bced5e5e9570a48a : global::NS
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderAcceptedHandler__Handle__Cmd1_da7a5fd2452aa3d8 : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -116,6 +119,7 @@ sealed file class OrderAcceptedHandler__Handle__Cmd1_da7a5fd2452aa3d8 : global::
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderAcceptedHandler__Handle__Cmd2_5a8c95a05fa2edc7 : global::NServiceBus.IHandleMessages<global::Cmd2>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlersCtorAndParameterInjection.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlersCtorAndParameterInjection.approved.txt
@@ -36,6 +36,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_84ed469652f1dfdc : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlersCtorAndParameterInjection.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlersCtorAndParameterInjection.approved.txt
@@ -37,6 +37,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_84ed469652f1dfdc : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlersCtorAndParameterInjection.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerGeneratorTests.ConventionBasedHandlersCtorAndParameterInjection.approved.txt
@@ -36,9 +36,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_84ed469652f1dfdc : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceAFromCtor;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandler.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandler.approved.txt
@@ -42,9 +42,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_a47fdeab1cad48d6 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandler.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandler.approved.txt
@@ -42,6 +42,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_a47fdeab1cad48d6 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandler.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandler.approved.txt
@@ -43,6 +43,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_a47fdeab1cad48d6 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerCtorAndMethodInjectionWithSameParameterName.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerCtorAndMethodInjectionWithSameParameterName.approved.txt
@@ -42,6 +42,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_84ed469652f1dfdc : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerCtorAndMethodInjectionWithSameParameterName.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerCtorAndMethodInjectionWithSameParameterName.approved.txt
@@ -43,6 +43,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_84ed469652f1dfdc : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerCtorAndMethodInjectionWithSameParameterName.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerCtorAndMethodInjectionWithSameParameterName.approved.txt
@@ -42,9 +42,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_84ed469652f1dfdc : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceFromCtor;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerHidingBaseClassMethodWithNew.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerHidingBaseClassMethodWithNew.approved.txt
@@ -42,9 +42,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerHidingBaseClassMethodWithNew.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerHidingBaseClassMethodWithNew.approved.txt
@@ -43,6 +43,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerHidingBaseClassMethodWithNew.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerHidingBaseClassMethodWithNew.approved.txt
@@ -42,6 +42,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerInheritedFromBaseClass.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerInheritedFromBaseClass.approved.txt
@@ -42,6 +42,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerInheritedFromBaseClass.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerInheritedFromBaseClass.approved.txt
@@ -43,6 +43,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerInheritedFromBaseClass.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerInheritedFromBaseClass.approved.txt
@@ -42,9 +42,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithActivatorUtilitiesConstructorAttributeUsesMarkedConstructor.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithActivatorUtilitiesConstructorAttributeUsesMarkedConstructor.approved.txt
@@ -42,9 +42,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_fa2b89e238cf7fd6 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceC _serviceCFromCtor;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithActivatorUtilitiesConstructorAttributeUsesMarkedConstructor.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithActivatorUtilitiesConstructorAttributeUsesMarkedConstructor.approved.txt
@@ -43,6 +43,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_fa2b89e238cf7fd6 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithActivatorUtilitiesConstructorAttributeUsesMarkedConstructor.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithActivatorUtilitiesConstructorAttributeUsesMarkedConstructor.approved.txt
@@ -42,6 +42,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_fa2b89e238cf7fd6 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithMultipleConstructorsUsesMostGreedyConstructor.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithMultipleConstructorsUsesMostGreedyConstructor.approved.txt
@@ -42,6 +42,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_40f827e6c30cb1cb : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithMultipleConstructorsUsesMostGreedyConstructor.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithMultipleConstructorsUsesMostGreedyConstructor.approved.txt
@@ -43,6 +43,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_40f827e6c30cb1cb : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithMultipleConstructorsUsesMostGreedyConstructor.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithMultipleConstructorsUsesMostGreedyConstructor.approved.txt
@@ -42,9 +42,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_40f827e6c30cb1cb : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceAFromCtor;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithMultipleHandleMethodsSameMessageType.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithMultipleHandleMethodsSameMessageType.approved.txt
@@ -46,9 +46,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
 
@@ -59,9 +59,9 @@ sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NService
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_f018c527f72a5f56 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceAFromMethod;
@@ -78,9 +78,9 @@ sealed file class OrderHandler__Handle__Cmd1_f018c527f72a5f56 : global::NService
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_8f0c4c684fd6fad3 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceAFromMethod;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithMultipleHandleMethodsSameMessageType.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithMultipleHandleMethodsSameMessageType.approved.txt
@@ -47,6 +47,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -60,6 +61,7 @@ sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NService
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_f018c527f72a5f56 : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -79,6 +81,7 @@ sealed file class OrderHandler__Handle__Cmd1_f018c527f72a5f56 : global::NService
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderHandler__Handle__Cmd1_8f0c4c684fd6fad3 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithMultipleHandleMethodsSameMessageType.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithMultipleHandleMethodsSameMessageType.approved.txt
@@ -46,6 +46,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -58,6 +59,7 @@ sealed file class OrderHandler__Handle__Cmd1_6d4631ee145fdd52 : global::NService
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderHandler__Handle__Cmd1_f018c527f72a5f56 : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -76,6 +78,7 @@ sealed file class OrderHandler__Handle__Cmd1_f018c527f72a5f56 : global::NService
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderHandler__Handle__Cmd1_8f0c4c684fd6fad3 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithSuffixCollision.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithSuffixCollision.approved.txt
@@ -42,6 +42,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithSuffixCollision.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithSuffixCollision.approved.txt
@@ -43,6 +43,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithSuffixCollision.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlerWithSuffixCollision.approved.txt
@@ -42,9 +42,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_df918940d9a78851 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceFromCtor;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlers.approved.txt
@@ -66,9 +66,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_abf6ab59fa4378ea : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IMyService _serviceFromCtor;
@@ -88,9 +88,9 @@ sealed file class OrderShippedHandler__Handle__Cmd1_abf6ab59fa4378ea : global::N
 }
 
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderPlacedHandler__Handle__Cmd2_bced5e5e9570a48a : global::NServiceBus.IHandleMessages<global::Cmd2>
 {
 
@@ -101,9 +101,9 @@ sealed file class OrderPlacedHandler__Handle__Cmd2_bced5e5e9570a48a : global::NS
 }
 
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderAcceptedHandler__Handle__Cmd1_da7a5fd2452aa3d8 : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IMyService _serviceFromMethod;
@@ -119,9 +119,9 @@ sealed file class OrderAcceptedHandler__Handle__Cmd1_da7a5fd2452aa3d8 : global::
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderAcceptedHandler__Handle__Cmd2_5a8c95a05fa2edc7 : global::NServiceBus.IHandleMessages<global::Cmd2>
 {
     readonly global::IMyService _serviceFromMethod;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlers.approved.txt
@@ -66,6 +66,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_abf6ab59fa4378ea : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -87,6 +88,7 @@ sealed file class OrderShippedHandler__Handle__Cmd1_abf6ab59fa4378ea : global::N
 }
 
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderPlacedHandler__Handle__Cmd2_bced5e5e9570a48a : global::NServiceBus.IHandleMessages<global::Cmd2>
@@ -99,6 +101,7 @@ sealed file class OrderPlacedHandler__Handle__Cmd2_bced5e5e9570a48a : global::NS
 }
 
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderAcceptedHandler__Handle__Cmd1_da7a5fd2452aa3d8 : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -116,6 +119,7 @@ sealed file class OrderAcceptedHandler__Handle__Cmd1_da7a5fd2452aa3d8 : global::
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderAcceptedHandler__Handle__Cmd2_5a8c95a05fa2edc7 : global::NServiceBus.IHandleMessages<global::Cmd2>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlers.approved.txt
@@ -67,6 +67,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_abf6ab59fa4378ea : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -89,6 +90,7 @@ sealed file class OrderShippedHandler__Handle__Cmd1_abf6ab59fa4378ea : global::N
 
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderPlacedHandler__Handle__Cmd2_bced5e5e9570a48a : global::NServiceBus.IHandleMessages<global::Cmd2>
@@ -102,6 +104,7 @@ sealed file class OrderPlacedHandler__Handle__Cmd2_bced5e5e9570a48a : global::NS
 
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderAcceptedHandler__Handle__Cmd1_da7a5fd2452aa3d8 : global::NServiceBus.IHandleMessages<global::Cmd1>
@@ -120,6 +123,7 @@ sealed file class OrderAcceptedHandler__Handle__Cmd1_da7a5fd2452aa3d8 : global::
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderAcceptedHandler__Handle__Cmd2_5a8c95a05fa2edc7 : global::NServiceBus.IHandleMessages<global::Cmd2>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlersCtorAndParameterInjection.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlersCtorAndParameterInjection.approved.txt
@@ -42,6 +42,7 @@ namespace NServiceBus
     }
 }
 
+[global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.StackTraceHidden]
 [global::System.Diagnostics.DebuggerNonUserCode]
 sealed file class OrderShippedHandler__Handle__Cmd1_84ed469652f1dfdc : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlersCtorAndParameterInjection.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlersCtorAndParameterInjection.approved.txt
@@ -43,6 +43,7 @@ namespace NServiceBus
 }
 
 [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
 [global::System.Diagnostics.StackTraceHiddenAttribute]
 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_84ed469652f1dfdc : global::NServiceBus.IHandleMessages<global::Cmd1>

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlersCtorAndParameterInjection.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddHandlerInterceptorTests.ConventionBasedHandlersCtorAndParameterInjection.approved.txt
@@ -42,9 +42,9 @@ namespace NServiceBus
     }
 }
 
-[global::System.Runtime.CompilerServices.CompilerGenerated]
-[global::System.Diagnostics.StackTraceHidden]
-[global::System.Diagnostics.DebuggerNonUserCode]
+[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+[global::System.Diagnostics.StackTraceHiddenAttribute]
+[global::System.Diagnostics.DebuggerNonUserCodeAttribute]
 sealed file class OrderShippedHandler__Handle__Cmd1_84ed469652f1dfdc : global::NServiceBus.IHandleMessages<global::Cmd1>
 {
     readonly global::IServiceA _serviceAFromCtor;

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.BasicSagas.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.BasicSagas.approved.txt
@@ -130,6 +130,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_f7dc3394c771851e : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.Billing.OrderBilled>
     {
@@ -143,6 +144,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_f7dc3394c771851e();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_ae6ad694572b9fcb : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.Billing.OrderPlaced>
     {
@@ -156,6 +158,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_ae6ad694572b9fcb();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_08b7b00354e1d041 : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.Shipping.OrderBilled>
     {
@@ -169,6 +172,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_08b7b00354e1d041();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_13dea9c2dc628538 : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.Shipping.OrderPlaced>
     {
@@ -182,6 +186,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_13dea9c2dc628538();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_2fd27f5436ef20b9 : NServiceBus.Sagas.MessagePropertyAccessor<global::Payments.OrderBilled>
     {
@@ -195,6 +200,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_2fd27f5436ef20b9();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_c561311f0fcc5cf0 : NServiceBus.Sagas.MessagePropertyAccessor<global::Payments.OrderPlaced>
     {
@@ -208,6 +214,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_c561311f0fcc5cf0();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.CastSyntaxWrappers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.CastSyntaxWrappers.approved.txt
@@ -44,6 +44,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -57,6 +58,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.DuplicatePropertyDefinitionsWithCompilationErrors.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.DuplicatePropertyDefinitionsWithCompilationErrors.approved.txt
@@ -48,6 +48,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -61,6 +62,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.ExpressionBodiedConfigureHowToFindSaga.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.ExpressionBodiedConfigureHowToFindSaga.approved.txt
@@ -44,6 +44,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -57,6 +58,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.InheritedMessageProperty.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.InheritedMessageProperty.approved.txt
@@ -48,6 +48,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_b1eaacebc632acfc : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderBilled>
     {
@@ -61,6 +62,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_b1eaacebc632acfc();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -74,6 +76,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.InvalidMappingWithCompilationErrors.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.InvalidMappingWithCompilationErrors.approved.txt
@@ -51,6 +51,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -64,6 +65,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.NestedSagas.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.NestedSagas.approved.txt
@@ -89,6 +89,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_b1eaacebc632acfc : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderBilled>
     {
@@ -102,6 +103,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_b1eaacebc632acfc();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -115,6 +117,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.NullableReferenceTypeMappings.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.NullableReferenceTypeMappings.approved.txt
@@ -44,6 +44,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -57,6 +58,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.NullableReferenceTypeMixedMappings.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.NullableReferenceTypeMixedMappings.approved.txt
@@ -69,6 +69,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class NonNullableMessageOrderIdAccessor_e023774f080a36b1 : NServiceBus.Sagas.MessagePropertyAccessor<global::NonNullableMessage>
     {
@@ -82,6 +83,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new NonNullableMessageOrderIdAccessor_e023774f080a36b1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class NullableMessageOrderIdAccessor_9894122651576960 : NServiceBus.Sagas.MessagePropertyAccessor<global::NullableMessage>
     {
@@ -95,6 +97,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new NullableMessageOrderIdAccessor_9894122651576960();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.PrimaryConstructorAndSyntaxWrappers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.PrimaryConstructorAndSyntaxWrappers.approved.txt
@@ -50,6 +50,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class StartPartitionSagaCommandCorrelationIdAccessor_64596642731407e6 : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.Shipping.StartPartitionSagaCommand>
     {
@@ -63,6 +64,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new StartPartitionSagaCommandCorrelationIdAccessor_64596642731407e6();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class CorrelationIdAsStringAccessor_566e8fad769818c2 : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.RegistrationMethodNamePatterns.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.RegistrationMethodNamePatterns.approved.txt
@@ -54,6 +54,7 @@ namespace CustomRegistrations
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_6b40737e550b4237 : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.OrderBilled>
     {
@@ -67,6 +68,7 @@ namespace CustomRegistrations
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_6b40737e550b4237();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_92819afdda929c86 : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.OrderPlaced>
     {
@@ -80,6 +82,7 @@ namespace CustomRegistrations
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_92819afdda929c86();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.RootClassEntryPointName.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.RootClassEntryPointName.approved.txt
@@ -54,6 +54,7 @@ namespace CustomRegistrations
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_6b40737e550b4237 : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.OrderBilled>
     {
@@ -67,6 +68,7 @@ namespace CustomRegistrations
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_6b40737e550b4237();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_92819afdda929c86 : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.OrderPlaced>
     {
@@ -80,6 +82,7 @@ namespace CustomRegistrations
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_92819afdda929c86();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.RootClassVisibilityAndNamespace.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.RootClassVisibilityAndNamespace.approved.txt
@@ -54,6 +54,7 @@ namespace CustomRegistrations
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_6b40737e550b4237 : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.OrderBilled>
     {
@@ -67,6 +68,7 @@ namespace CustomRegistrations
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_6b40737e550b4237();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_92819afdda929c86 : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.OrderPlaced>
     {
@@ -80,6 +82,7 @@ namespace CustomRegistrations
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_92819afdda929c86();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.UnrelatedCompilationError.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.UnrelatedCompilationError.approved.txt
@@ -54,6 +54,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_13dea9c2dc628538 : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.Shipping.OrderPlaced>
     {
@@ -67,6 +68,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_13dea9c2dc628538();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.UnrelatedCompilationErrorInDifferentFile.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.UnrelatedCompilationErrorInDifferentFile.approved.txt
@@ -47,6 +47,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -60,6 +61,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.BasicSagas.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.BasicSagas.approved.txt
@@ -112,6 +112,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_f7dc3394c771851e : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.Billing.OrderBilled>
     {
@@ -125,6 +126,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_f7dc3394c771851e();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_ae6ad694572b9fcb : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.Billing.OrderPlaced>
     {
@@ -138,6 +140,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_ae6ad694572b9fcb();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_08b7b00354e1d041 : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.Shipping.OrderBilled>
     {
@@ -151,6 +154,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_08b7b00354e1d041();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_13dea9c2dc628538 : NServiceBus.Sagas.MessagePropertyAccessor<global::Orders.Shipping.OrderPlaced>
     {
@@ -164,6 +168,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_13dea9c2dc628538();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_2fd27f5436ef20b9 : NServiceBus.Sagas.MessagePropertyAccessor<global::Payments.OrderBilled>
     {
@@ -177,6 +182,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_2fd27f5436ef20b9();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_c561311f0fcc5cf0 : NServiceBus.Sagas.MessagePropertyAccessor<global::Payments.OrderPlaced>
     {
@@ -190,6 +196,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_c561311f0fcc5cf0();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.CastSyntaxWrappers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.CastSyntaxWrappers.approved.txt
@@ -53,6 +53,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -66,6 +67,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.DuplicatePropertyDefinitionsWithCompilationErrors.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.DuplicatePropertyDefinitionsWithCompilationErrors.approved.txt
@@ -57,6 +57,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -70,6 +71,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.ExpressionBodiedConfigureHowToFindSaga.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.ExpressionBodiedConfigureHowToFindSaga.approved.txt
@@ -53,6 +53,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -66,6 +67,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.InheritedMessageProperty.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.InheritedMessageProperty.approved.txt
@@ -57,6 +57,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_b1eaacebc632acfc : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderBilled>
     {
@@ -70,6 +71,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_b1eaacebc632acfc();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -83,6 +85,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.InvalidMappingWithCompilationErrors.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.InvalidMappingWithCompilationErrors.approved.txt
@@ -60,6 +60,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -73,6 +74,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.NestedSagas.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.NestedSagas.approved.txt
@@ -85,6 +85,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderBilledOrderIdAccessor_b1eaacebc632acfc : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderBilled>
     {
@@ -98,6 +99,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderBilledOrderIdAccessor_b1eaacebc632acfc();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -111,6 +113,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.NullableReferenceTypeMappings.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.NullableReferenceTypeMappings.approved.txt
@@ -53,6 +53,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -66,6 +67,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.NullableReferenceTypeMixedMappings.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.NullableReferenceTypeMixedMappings.approved.txt
@@ -76,6 +76,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class NonNullableMessageOrderIdAccessor_e023774f080a36b1 : NServiceBus.Sagas.MessagePropertyAccessor<global::NonNullableMessage>
     {
@@ -89,6 +90,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new NonNullableMessageOrderIdAccessor_e023774f080a36b1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class NullableMessageOrderIdAccessor_9894122651576960 : NServiceBus.Sagas.MessagePropertyAccessor<global::NullableMessage>
     {
@@ -102,6 +104,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new NullableMessageOrderIdAccessor_9894122651576960();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.PrimaryConstructorAndSyntaxWrappers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.PrimaryConstructorAndSyntaxWrappers.approved.txt
@@ -53,6 +53,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class StartPartitionSagaCommandCorrelationIdAccessor_82483382109e24ab : NServiceBus.Sagas.MessagePropertyAccessor<global::StartPartitionSagaCommand>
     {
@@ -66,6 +67,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new StartPartitionSagaCommandCorrelationIdAccessor_82483382109e24ab();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class CorrelationIdAsStringAccessor_566e8fad769818c2 : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.UnrelatedCompilationError.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.UnrelatedCompilationError.approved.txt
@@ -56,6 +56,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -69,6 +70,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.UnrelatedCompilationErrorInDifferentFile.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.UnrelatedCompilationErrorInDifferentFile.approved.txt
@@ -56,6 +56,7 @@ namespace NServiceBus
         }
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderPlacedOrderIdAccessor_5f69124e5a7de2e1 : NServiceBus.Sagas.MessagePropertyAccessor<global::OrderPlaced>
     {
@@ -69,6 +70,7 @@ namespace NServiceBus
         public static readonly NServiceBus.Sagas.MessagePropertyAccessor Instance = new OrderPlacedOrderIdAccessor_5f69124e5a7de2e1();
     }
 
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
     file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
     {

--- a/src/NServiceBus.Core.Analyzer/Handlers/Handlers.Emitter.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/Handlers.Emitter.cs
@@ -57,8 +57,8 @@ public static partial class Handlers
         static void EmitAdapterType(SourceWriter sourceWriter, ConventionBasedMethodSpec method)
         {
             sourceWriter.WithCompilerGeneratedAttribute();
-            sourceWriter.WriteLine("[global::System.Diagnostics.StackTraceHidden]");
-            sourceWriter.WriteLine("[global::System.Diagnostics.DebuggerNonUserCode]");
+            sourceWriter.WriteLine("[global::System.Diagnostics.StackTraceHiddenAttribute]");
+            sourceWriter.WriteLine("[global::System.Diagnostics.DebuggerNonUserCodeAttribute]");
             sourceWriter.WriteLine($"sealed file class {method.AdapterName} : global::NServiceBus.IHandleMessages<{method.MessageType}>");
             sourceWriter.WriteLine("{");
             sourceWriter.Indentation++;

--- a/src/NServiceBus.Core.Analyzer/Handlers/Handlers.Emitter.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/Handlers.Emitter.cs
@@ -56,6 +56,7 @@ public static partial class Handlers
 
         static void EmitAdapterType(SourceWriter sourceWriter, ConventionBasedMethodSpec method)
         {
+            sourceWriter.WithCompilerGeneratedAttribute();
             sourceWriter.WriteLine("[global::System.Diagnostics.StackTraceHidden]");
             sourceWriter.WriteLine("[global::System.Diagnostics.DebuggerNonUserCode]");
             sourceWriter.WriteLine($"sealed file class {method.AdapterName} : global::NServiceBus.IHandleMessages<{method.MessageType}>");

--- a/src/NServiceBus.Core.Analyzer/Handlers/Handlers.Emitter.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/Handlers.Emitter.cs
@@ -56,7 +56,8 @@ public static partial class Handlers
 
         static void EmitAdapterType(SourceWriter sourceWriter, ConventionBasedMethodSpec method)
         {
-            sourceWriter.WithCompilerGeneratedAttribute();
+            sourceWriter.WithCompilerGeneratedAttribute()
+                .WithGeneratedCodeAttribute();
             sourceWriter.WriteLine("[global::System.Diagnostics.StackTraceHiddenAttribute]");
             sourceWriter.WriteLine("[global::System.Diagnostics.DebuggerNonUserCodeAttribute]");
             sourceWriter.WriteLine($"sealed file class {method.AdapterName} : global::NServiceBus.IHandleMessages<{method.MessageType}>");

--- a/src/NServiceBus.Core.Analyzer/Sagas/Sagas.Emitter.cs
+++ b/src/NServiceBus.Core.Analyzer/Sagas/Sagas.Emitter.cs
@@ -98,7 +98,8 @@ public static partial class Sagas
             {
                 var mapping = allPropertyMappings[index];
                 var accessorClassName = MessagePropertyAccessorName(mapping);
-                _ = sourceWriter.WithGeneratedCodeAttribute();
+                _ = sourceWriter.WithCompilerGeneratedAttribute()
+                    .WithGeneratedCodeAttribute();
                 sourceWriter.WriteLine($"file sealed class {accessorClassName} : NServiceBus.Sagas.MessagePropertyAccessor<{mapping.MessageType}>");
                 sourceWriter.WriteLine("{");
 
@@ -159,7 +160,8 @@ public static partial class Sagas
             {
                 var mapping = allPropertyMappings[index];
                 var accessorClassName = CorrelationPropertyAccessorName(mapping);
-                _ = sourceWriter.WithGeneratedCodeAttribute();
+                _ = sourceWriter.WithCompilerGeneratedAttribute()
+                    .WithGeneratedCodeAttribute();
                 sourceWriter.WriteLine($"file sealed class {accessorClassName} : NServiceBus.Sagas.CorrelationPropertyAccessor");
                 sourceWriter.WriteLine("{");
 

--- a/src/NServiceBus.Core.Analyzer/Utility/SourceWriterExtensions.cs
+++ b/src/NServiceBus.Core.Analyzer/Utility/SourceWriterExtensions.cs
@@ -50,6 +50,12 @@ static class SourceWriterExtensions
             return writer.WithOpenNamespace("NServiceBus");
         }
 
+        public SourceWriter WithCompilerGeneratedAttribute()
+        {
+            writer.WriteLine("[global::System.Runtime.CompilerServices.CompilerGenerated]");
+            return writer;
+        }
+
         public SourceWriter WithGeneratedCodeAttribute() => writer.WithGeneratedCodeAttribute(AssemblyName);
 
         public SourceWriter WithGeneratedCodeAttribute(AssemblyName assemblyName)

--- a/src/NServiceBus.Core.Analyzer/Utility/SourceWriterExtensions.cs
+++ b/src/NServiceBus.Core.Analyzer/Utility/SourceWriterExtensions.cs
@@ -52,7 +52,7 @@ static class SourceWriterExtensions
 
         public SourceWriter WithCompilerGeneratedAttribute()
         {
-            writer.WriteLine("[global::System.Runtime.CompilerServices.CompilerGenerated]");
+            writer.WriteLine("[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]");
             return writer;
         }
 

--- a/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
@@ -107,6 +107,7 @@ public class MessageHandlerRegistry
     /// <summary>
     /// Add a handler for a specific message type. Should only be called by a source generator.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void AddMessageHandlerForMessage<[DynamicallyAccessedMembers(DynamicMemberTypeAccess.Handler)] THandler, TMessage>() where THandler : class, IHandleMessages<TMessage>
         => AddMessageHandlerForMessage<THandler, TMessage, THandler>();
 
@@ -130,6 +131,7 @@ public class MessageHandlerRegistry
     /// <summary>
     /// Add a handler for a specific timeout type. Should only be called by a source generator.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void AddTimeoutHandlerForMessage<[DynamicallyAccessedMembers(DynamicMemberTypeAccess.Handler)] THandler, TMessage>() where THandler : class, IHandleTimeouts<TMessage>
     {
         // We are keeping a small deduplication set to avoid registering the same handler+message combination multiple times


### PR DESCRIPTION
Closes https://github.com/Particular/NServiceBus/issues/7777

## Problem

Convention-based handlers with `[Handler]` and assembly scanning enabled via `Handlers.ConventionBasedAssembly.AddAll()` could cause the source-generated adapter types to be discovered twice: once through the generated registration code and once through assembly scanning.

The adapter types implement `IHandleMessages<TMessage>` so they show up as handlers during reflection-based scanning. The assembly scanner already filters types with `[CompilerGeneratedAttribute]`, but the generated adapters didn't have it.

## What changed

- Handler adapter types now emit `[CompilerGenerated]` and `[GeneratedCode]`
- Saga property/correlation accessor types now emit `[CompilerGenerated]` alongside the existing `[GeneratedCode]`
- Registry and interceptor infrastructure types emit `[GeneratedCode]` only (they don't implement handler interfaces, so scanning won't pick them up)

## Why CompilerGeneratedAttribute

Strictly speaking, `CompilerGeneratedAttribute` is meant for compiler-produced types like closures and async state machines, not source generators. The correct attribute for tool-generated code is `GeneratedCodeAttribute`. However, the assembly scanner has always filtered on `CompilerGeneratedAttribute`, and we can't switch to filtering `GeneratedCodeAttribute` instead because that would break third-party handler generators that use it legitimately. So emitting `CompilerGeneratedAttribute` on our own generated types is the pragmatic way to keep things consistent without introducing a breaking change.