### PR TITLE
    Send-only endpoints can incorrectly activate saga features when saga assemblies are scanned

### DIFF
--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -15,6 +15,7 @@ public sealed class Sagas : Feature
     {
         Enable<SynchronizedStorage>();
         DependsOn<SynchronizedStorage>();
+        Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Sagas are only relevant for endpoints receiving messages.");
         Prerequisite(s => s.Settings.Get<SagaMetadataCollection>().HasMetadata, "No sagas were found. Either enable assembly scanning or manually register sagas using AddSaga<TSaga>().");
     }
 


### PR DESCRIPTION
The feature prerequisite in https://github.com/Particular/NServiceBus/blob/release-10.0/src/NServiceBus.Core/Sagas/Sagas.cs#L25C9-L25C153 includes a check for send-only endpoints. As part of https://github.com/Particular/NServiceBus/pull/7609, we moved the send-only check into the saga component itself, assuming that send-only endpoints would never contain sagas and therefore the feature prerequisite would prevent the feature from being enabled.

The problem is that if a send-only endpoint has any assemblies containing sagas available during assembly scanning, saga metadata can still be discovered. This causes the saga feature to become active, along with any features depending on it.

In the case of the SagaAudit feature, this resulted in a crash because ReceiveAddresses are not available in send-only endpoints:
https://github.com/Particular/NServiceBus.SagaAudit/blob/master/src/NServiceBus.SagaAudit/SagaAuditFeature.cs#L25

Needs to be backported to [10.1.x](https://github.com/Particular/NServiceBus/pull/7785) and [10.2.x](https://github.com/Particular/NServiceBus/pull/7784)

## Symptoms

An error is raised at startup due to a missing service `ReceiveAddresses` in the dependency injection container. 

## Who's affected

Users are only affected when saga auditing is enabled on a send-only endpoint that also has saga code included (whether via assemblys canning or manually registered) which commonly through use of the NServiceBus.ServicePlatform.Connector plugin. This is a very uncommon configuration.

## Root cause

A regression in feature registration code starting in version 10.1.0.