### PR TITLE
    Send-only endpoints can incorrectly activate saga features when saga assemblies are scanned

### DIFF
--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -15,6 +15,7 @@ public sealed class Sagas : Feature
     {
         Enable<SynchronizedStorage>();
         DependsOn<SynchronizedStorage>();
+        Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Sagas are only relevant for endpoints receiving messages.");
         Prerequisite(s => s.Settings.Get<SagaMetadataCollection>().HasMetadata, "No sagas were found. Either enable assembly scanning or manually register sagas using AddSaga<TSaga>().");
     }
 


### PR DESCRIPTION
* Backport of #7783 to `release-10.1` to be released as `10.1.5`