### PR TITLE
Satellite and instance-specific receiver logs silently buffered and never delivered

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_instance_receiver_slot_registration.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_instance_receiver_slot_registration.cs
@@ -1,0 +1,61 @@
+#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
+
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+public class When_instance_receiver_slot_registration : NServiceBusAcceptanceTest
+{
+    static string ReceiverEndpoint => Conventions.EndpointNamingConvention(typeof(EndpointWithInstance));
+    const string InstanceDiscriminator = "XYZ";
+
+    [Test]
+    public async Task Should_enrich_instance_receiver_logs_with_receiver_scope()
+    {
+        var context = await Scenario.Define<Context>(ctx => ctx.IncludeLoggingScopes = true)
+            .WithEndpoint<EndpointWithInstance>(b => b
+                .CustomConfig(c =>
+                {
+                    c.ConfigureRouting().RouteToEndpoint(typeof(InstanceMessage), ReceiverEndpoint);
+                    c.MakeInstanceUniquelyAddressable(InstanceDiscriminator);
+                })
+                .When((session, _) =>
+                {
+                    var sendOptions = new SendOptions();
+                    sendOptions.RouteToSpecificInstance(InstanceDiscriminator);
+                    return session.Send(new InstanceMessage(), sendOptions);
+                }))
+            .Run();
+
+        Assert.That(context.Logs, Has.One.Matches<ScenarioContext.LogItem>(l =>
+            l.LoggerName.EndsWith("InstanceHandler") &&
+            (l.Message ?? string.Empty).Contains("Instance processed") &&
+            (l.Message ?? string.Empty).Contains("Endpoint = InstanceReceiverSlotRegistration.EndpointWithInstance, EndpointIdentifier = InstanceReceiverSlotRegistration.EndpointWithInstance0") &&
+            (l.Message ?? string.Empty).Contains($"EndpointDiscriminator = {InstanceDiscriminator}")));
+    }
+
+    public class Context : ScenarioContext;
+
+    public class EndpointWithInstance : EndpointConfigurationBuilder
+    {
+        public EndpointWithInstance() => EndpointSetup<DefaultServer>();
+
+        [Handler]
+        public class InstanceHandler(ILogger<InstanceHandler> logger, Context testContext) : IHandleMessages<InstanceMessage>
+        {
+            public Task Handle(InstanceMessage message, IMessageHandlerContext context)
+            {
+                logger.LogInformation("Instance processed");
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class InstanceMessage : IMessage;
+}

--- a/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_satellite_and_receiver_slot_registration.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LoggingIntegration/When_satellite_and_receiver_slot_registration.cs
@@ -1,0 +1,80 @@
+#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.LoggingIntegration;
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Transport;
+
+public class When_satellite_and_receiver_slot_registration : NServiceBusAcceptanceTest
+{
+    const string SateliteName = "MySatellite";
+
+    [Test]
+    public async Task Should_enrich_satellite_logs_with_satellite_scope()
+    {
+        var context = await Scenario.Define<Context>(ctx => ctx.IncludeLoggingScopes = true)
+            .WithEndpoint<EndpointWithSatellite>(b => b
+                .When((session, _) => session.Send(EndpointWithSatellite.SatelliteAddress!, new SatelliteMessage())))
+            .Run();
+
+        Assert.That(context.Logs, Has.One.Matches<ScenarioContext.LogItem>(l =>
+            l.LoggerName == "SatelliteHandler" &&
+            (l.Message ?? string.Empty).Contains("Satellite processed") &&
+            (l.Message ?? string.Empty).Contains("Endpoint = SatelliteAndReceiverSlotRegistration.EndpointWithSatellite, EndpointIdentifier = SatelliteAndReceiverSlotRegistration.EndpointWithSatellite0") &&
+            (l.Message ?? string.Empty).Contains($"Satellite = {SateliteName}")));
+    }
+
+    public class Context : ScenarioContext;
+
+    public class EndpointWithSatellite : EndpointConfigurationBuilder
+    {
+        public static string? SatelliteAddress { get; set; }
+
+        public EndpointWithSatellite() => EndpointSetup<DefaultServer>(c => c.EnableFeature<MySatelliteFeature>());
+
+        public class MySatelliteFeature : Feature
+        {
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                var endpointQueueName = context.Settings.EndpointQueueName();
+                var queueAddress = new QueueAddress(endpointQueueName, qualifier: SateliteName);
+
+                context.AddSatelliteReceiver(
+                    SateliteName,
+                    queueAddress,
+                    PushRuntimeSettings.Default,
+                    (c, ec) => RecoverabilityAction.MoveToError(c.Failed.ErrorQueue),
+                    (builder, messageContext, cancellationToken) =>
+                    {
+                        var logger = builder.GetRequiredService<ILoggerFactory>().CreateLogger("SatelliteHandler");
+                        logger.LogInformation("Satellite processed");
+                        builder.GetRequiredService<Context>().MarkAsCompleted();
+                        return Task.FromResult(true);
+                    });
+
+                context.RegisterStartupTask<SatelliteStartupTask>();
+            }
+
+            class SatelliteStartupTask(ReceiveAddresses receiveAddresses) : FeatureStartupTask
+            {
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
+                {
+                    SatelliteAddress = receiveAddresses.SatelliteReceiveAddresses.Single();
+                    return Task.CompletedTask;
+                }
+
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            }
+        }
+    }
+
+    public class SatelliteMessage : IMessage;
+}

--- a/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
@@ -5,7 +5,6 @@ namespace NServiceBus.Core.Tests.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NServiceBus.Logging;
@@ -73,16 +72,16 @@ public class EndpointLoggingScopeTests
     }
 
     [Test]
-    public void Should_include_receiver_name_for_instance_specific_receiver_scope()
+    public void Should_include_discriminator_for_instance_specific_receiver_scope()
     {
         var loggerFactory = new CollectingMicrosoftLoggerFactory();
         var endpointSlot = new EndpointLogSlot("Shipping", "green");
-        var receiverSlot = new EndpointReceiverLogSlot(endpointSlot, "InstanceSpecific");
-        LogManager.RegisterSlotFactory(receiverSlot, new MicrosoftLoggerFactoryAdapter(loggerFactory));
+        var discriminatorSlot = new EndpointDiscriminatorLogSlot(endpointSlot, "InstanceSpecific");
+        LogManager.RegisterSlotFactory(discriminatorSlot, new MicrosoftLoggerFactoryAdapter(loggerFactory));
 
         var logger = LogManager.GetLogger($"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}");
 
-        using (LogManager.BeginSlotScope(receiverSlot))
+        using (LogManager.BeginSlotScope(discriminatorSlot))
         {
             logger.Info("message");
         }
@@ -90,7 +89,7 @@ public class EndpointLoggingScopeTests
         AssertScopeWasUsed(loggerFactory.Logger.CapturedLogScopes,
             new KeyValuePair<string, object>("Endpoint", "Shipping"),
             new KeyValuePair<string, object>("EndpointIdentifier", "green"),
-            new KeyValuePair<string, object>("Receiver", "InstanceSpecific"));
+            new KeyValuePair<string, object>("EndpointDiscriminator", "InstanceSpecific"));
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Core.Tests.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NServiceBus.Logging;

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NuDoq" Version="2.0.1" NoWarn="NU1701" />
     <PackageReference Include="NUnit" Version="4.6.1" />

--- a/src/NServiceBus.Core.Tests/Receiving/LogWrappedMessageReceiverTests.cs
+++ b/src/NServiceBus.Core.Tests/Receiving/LogWrappedMessageReceiverTests.cs
@@ -3,9 +3,13 @@
 namespace NServiceBus.Core.Tests.Receiving;
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Extensibility;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using NServiceBus.Logging;
 using NServiceBus.Transport;
 using NUnit.Framework;
@@ -16,9 +20,11 @@ public class LogWrappedMessageReceiverTests
     [Test]
     public async Task Should_scope_on_message_callback()
     {
-        var slot = new EndpointLogSlot("Sales", endpointIdentifier: "blue");
+        var slot = new TestLogSlot();
+        var fakeFactory = new FakeLoggerLoggerFactory();
+        var slotFactory = new MicrosoftLoggerFactoryAdapter(fakeFactory);
         var receiver = new TestReceiver();
-        var wrapped = new LogWrappedMessageReceiver(receiver, slot);
+        var wrapped = new LogWrappedMessageReceiver(receiver, slot, slotFactory, manageSlotLifecycle: false);
 
         LogScopeState? scope = null;
 
@@ -38,22 +44,17 @@ public class LogWrappedMessageReceiverTests
 
         await receiver.InvokeMessage(CancellationToken.None);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(scope, Is.Not.Null);
-            Assert.That(scope![0].Key, Is.EqualTo("Endpoint"));
-            Assert.That(scope[0].Value, Is.EqualTo("Sales"));
-            Assert.That(scope[1].Key, Is.EqualTo("EndpointIdentifier"));
-            Assert.That(scope[1].Value, Is.EqualTo("blue"));
-        }
+        Assert.That(scope, Is.SameAs(slot.ScopeState));
     }
 
     [Test]
     public async Task Should_scope_on_error_callback()
     {
-        var slot = new EndpointLogSlot("Billing", endpointIdentifier: null);
+        var slot = new TestLogSlot();
+        var fakeFactory = new FakeLoggerLoggerFactory();
+        var slotFactory = new MicrosoftLoggerFactoryAdapter(fakeFactory);
         var receiver = new TestReceiver();
-        var wrapped = new LogWrappedMessageReceiver(receiver, slot);
+        var wrapped = new LogWrappedMessageReceiver(receiver, slot, slotFactory, manageSlotLifecycle: false);
 
         LogScopeState? scope = null;
 
@@ -71,15 +72,110 @@ public class LogWrappedMessageReceiverTests
             return Task.FromResult(ErrorHandleResult.Handled);
         });
 
-        var result = await receiver.InvokeError(CancellationToken.None);
+        await receiver.InvokeError(CancellationToken.None);
 
-        using (Assert.EnterMultipleScope())
+        Assert.That(scope, Is.SameAs(slot.ScopeState));
+    }
+
+    [Test]
+    public async Task Should_register_and_unregister_slot_when_managing_lifecycle()
+    {
+        var slot = new TestLogSlot();
+        var fakeFactory = new FakeLoggerLoggerFactory();
+        var slotFactory = new MicrosoftLoggerFactoryAdapter(fakeFactory);
+        var receiver = new TestReceiver();
+        var wrapped = new LogWrappedMessageReceiver(receiver, slot, slotFactory, manageSlotLifecycle: true);
+
+        await wrapped.Initialize(new PushRuntimeSettings(1), (messageContext, ct) =>
         {
-            Assert.That(result, Is.EqualTo(ErrorHandleResult.Handled));
-            Assert.That(scope, Is.Not.Null);
-            Assert.That(scope!.Count, Is.EqualTo(1));
-            Assert.That(scope[0].Key, Is.EqualTo("Endpoint"));
-            Assert.That(scope[0].Value, Is.EqualTo("Billing"));
+            _ = messageContext;
+            _ = ct;
+            return Task.CompletedTask;
+        }, (errorContext, ct) =>
+        {
+            _ = errorContext;
+            _ = ct;
+            return Task.FromResult(ErrorHandleResult.Handled);
+        });
+
+        Assert.That(slot.IsFactoryRegistered, Is.True, "Slot factory should be registered after Initialize");
+
+        await wrapped.StopReceive(CancellationToken.None);
+
+        Assert.That(slot.IsFactoryRegistered, Is.False, "Slot factory should be unregistered after StopReceive");
+    }
+
+    [Test]
+    public async Task Should_not_register_or_unregister_slot_when_not_managing_lifecycle()
+    {
+        var slot = new TestLogSlot();
+        var fakeFactory = new FakeLoggerLoggerFactory();
+        var slotFactory = new MicrosoftLoggerFactoryAdapter(fakeFactory);
+        LogManager.RegisterSlotFactory(slot, slotFactory);
+        var receiver = new TestReceiver();
+        var wrapped = new LogWrappedMessageReceiver(receiver, slot, slotFactory, manageSlotLifecycle: false);
+
+        await wrapped.Initialize(new PushRuntimeSettings(1), (messageContext, ct) =>
+        {
+            _ = messageContext;
+            _ = ct;
+            return Task.CompletedTask;
+        }, (errorContext, ct) =>
+        {
+            _ = errorContext;
+            _ = ct;
+            return Task.FromResult(ErrorHandleResult.Handled);
+        });
+
+        Assert.That(slot.IsFactoryRegistered, Is.True, "Slot should remain registered after Initialize");
+
+        await wrapped.StopReceive(CancellationToken.None);
+
+        Assert.That(slot.IsFactoryRegistered, Is.True, "Slot should remain registered after StopReceive");
+
+        LogManager.UnregisterSlot(slot);
+    }
+
+    [Test]
+    public async Task Should_route_logs_through_registered_slot_factory()
+    {
+        var slot = new TestLogSlot();
+        var fakeFactory = new FakeLoggerLoggerFactory();
+        var slotFactory = new MicrosoftLoggerFactoryAdapter(fakeFactory);
+        var receiver = new TestReceiver();
+        var wrapped = new LogWrappedMessageReceiver(receiver, slot, slotFactory, manageSlotLifecycle: true);
+
+        var loggerName = $"{nameof(LogWrappedMessageReceiverTests)}-{Guid.NewGuid():N}";
+        var logger = LogManager.GetLogger(loggerName);
+
+        await wrapped.Initialize(new PushRuntimeSettings(1), (messageContext, ct) =>
+        {
+            logger.Info("slot-processed-log");
+            return Task.CompletedTask;
+        }, (errorContext, ct) =>
+        {
+            _ = errorContext;
+            _ = ct;
+            return Task.FromResult(ErrorHandleResult.Handled);
+        });
+
+        await receiver.InvokeMessage(CancellationToken.None);
+
+        Assert.That(fakeFactory.CapturedMessages, Does.Contain("slot-processed-log"),
+            "Logs written during slot-scoped message processing must reach the registered slot factory.");
+
+        await wrapped.StopReceive(CancellationToken.None);
+    }
+
+    sealed class TestLogSlot : LogSlot
+    {
+        public override LogScopeState ScopeState { get; } = new TestLogScopeState();
+
+        sealed class TestLogScopeState : LogScopeState
+        {
+            public override KeyValuePair<string, object?> this[int index] => throw new IndexOutOfRangeException();
+            public override int Count => 0;
+            public override IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => Enumerable.Empty<KeyValuePair<string, object?>>().GetEnumerator();
         }
     }
 
@@ -143,5 +239,18 @@ public class LogWrappedMessageReceiverTests
                 immediateProcessingFailures: 1,
                 receiveAddress: "queue",
                 new ContextBag());
+    }
+
+    sealed class FakeLoggerLoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory
+    {
+        readonly FakeLoggerProvider provider = new();
+
+        public List<string> CapturedMessages => [.. provider.Collector.GetSnapshot().Select(r => r.Message)];
+
+        public void AddProvider(ILoggerProvider loggerProvider) => throw new NotSupportedException();
+
+        public ILogger CreateLogger(string categoryName) => provider.CreateLogger(categoryName);
+
+        public void Dispose() => provider.Dispose();
     }
 }

--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -168,6 +168,7 @@ public static class LogManager
             }
         }
 
+        slot.IsFactoryRegistered = false;
         slotContexts.TryRemove(slotKey, out _);
         slotLoggerFactories.TryRemove(slotKey, out _);
         scopedStartupLogsBySlot.TryRemove(slotKey, out _);

--- a/src/NServiceBus.Core/Logging/LogScopeStates.cs
+++ b/src/NServiceBus.Core/Logging/LogScopeStates.cs
@@ -85,7 +85,7 @@ sealed class EndpointSatelliteLogSlot(EndpointLogSlot endpointSlot, string satel
     public override LogScopeState ScopeState { get; } = new ExtendedLogScopeState(endpointSlot.ScopeState, "Satellite", satelliteName);
 }
 
-sealed class EndpointReceiverLogSlot(EndpointLogSlot endpointSlot, string receiverName) : LogSlot
+sealed class EndpointDiscriminatorLogSlot(EndpointLogSlot endpointSlot, string discriminator) : LogSlot
 {
-    public override LogScopeState ScopeState { get; } = new ExtendedLogScopeState(endpointSlot.ScopeState, "Receiver", receiverName);
+    public override LogScopeState ScopeState { get; } = new ExtendedLogScopeState(endpointSlot.ScopeState, "EndpointDiscriminator", discriminator);
 }

--- a/src/NServiceBus.Core/Receiving/LogWrappedMessageReceiver.cs
+++ b/src/NServiceBus.Core/Receiving/LogWrappedMessageReceiver.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using NServiceBus.Logging;
 using NServiceBus.Transport;
 
-class LogWrappedMessageReceiver(IMessageReceiver receiver, LogSlot endpointLogSlot) : IMessageReceiver
+class LogWrappedMessageReceiver(IMessageReceiver receiver, LogSlot logSlot, ILoggerFactory slotFactory, bool manageSlotLifecycle) : IMessageReceiver
 {
     public ISubscriptionManager Subscriptions => receiver.Subscriptions;
     public string Id => receiver.Id;
@@ -20,25 +20,42 @@ class LogWrappedMessageReceiver(IMessageReceiver receiver, LogSlot endpointLogSl
     public Task StartReceive(CancellationToken cancellationToken = default) =>
         receiver.StartReceive(cancellationToken);
 
-    public Task StopReceive(CancellationToken cancellationToken = default) =>
-        receiver.StopReceive(cancellationToken);
+    public async Task StopReceive(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await receiver.StopReceive(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (manageSlotLifecycle)
+            {
+                LogManager.UnregisterSlot(logSlot);
+            }
+        }
+    }
 
     public Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(onMessage);
         ArgumentNullException.ThrowIfNull(onError);
 
+        if (manageSlotLifecycle)
+        {
+            LogManager.RegisterSlotFactory(logSlot, slotFactory);
+        }
+
         return receiver.Initialize(limitations, ScopedOnMessage, ScopedOnError, cancellationToken);
 
         async Task ScopedOnMessage(MessageContext messageContext, CancellationToken ct)
         {
-            using var _ = LogManager.BeginSlotScope(endpointLogSlot);
+            using var _ = LogManager.BeginSlotScope(logSlot);
             await onMessage(messageContext, ct).ConfigureAwait(false);
         }
 
         async Task<ErrorHandleResult> ScopedOnError(ErrorContext errorContext, CancellationToken ct)
         {
-            using var _ = LogManager.BeginSlotScope(endpointLogSlot);
+            using var _ = LogManager.BeginSlotScope(logSlot);
             return await onError(errorContext, ct).ConfigureAwait(false);
         }
     }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Logging;
 using Microsoft.Extensions.DependencyInjection;
+using MicrosoftLoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 using Outbox;
 using Pipeline;
 using Transport;
@@ -16,7 +17,7 @@ using Unicast;
 
 partial class ReceiveComponent
 {
-    ReceiveComponent(Configuration configuration, IActivityFactory activityFactory, LogSlot endpointLogSlot)
+    ReceiveComponent(Configuration configuration, IActivityFactory activityFactory, EndpointLogSlot endpointLogSlot)
     {
         this.configuration = configuration;
         this.activityFactory = activityFactory;
@@ -147,6 +148,9 @@ partial class ReceiveComponent
             return;
         }
 
+        // It is fine to adapt multiple times since the deduplication happens inside the microsoft logger factory anyway.
+        var slotFactory = LogManager.Adapt(builder.GetRequiredService<MicrosoftLoggerFactory>());
+
         // Resolving the logger here with the LogManager for now since we want to do a consistent sweep of all LogManager usage
         // in the next minor when GetLogger might be deprecated. But we do it late when the service provider is available
         // to make sure the logger is already properly wired up.
@@ -164,8 +168,7 @@ partial class ReceiveComponent
             }
         }
 
-        var mainProcessingLogSlot = CreateReceiverProcessingLogSlot(endpointLogSlot, MainReceiverId);
-        var mainPump = CreateReceiver(consecutiveFailuresConfiguration, transportInfrastructure.Receivers[MainReceiverId], mainProcessingLogSlot);
+        var mainPump = CreateReceiver(consecutiveFailuresConfiguration, transportInfrastructure.Receivers[MainReceiverId], endpointLogSlot, slotFactory, manageSlotLifecycle: false);
 
         var receivePipeline = pipelineComponent.CreatePipeline<ITransportReceiveContext>(builder);
 
@@ -189,8 +192,9 @@ partial class ReceiveComponent
 
         if (transportInfrastructure.Receivers.TryGetValue(InstanceSpecificReceiverId, out var instanceSpecificPump))
         {
-            var instanceProcessingLogSlot = CreateReceiverProcessingLogSlot(endpointLogSlot, InstanceSpecificReceiverId);
-            var instancePump = CreateReceiver(consecutiveFailuresConfiguration, instanceSpecificPump, instanceProcessingLogSlot);
+            string discriminator = configuration.InstanceSpecificQueueAddress?.Discriminator ?? InstanceSpecificReceiverId;
+            var instanceProcessingLogSlot = new EndpointDiscriminatorLogSlot(endpointLogSlot, discriminator);
+            var instancePump = CreateReceiver(consecutiveFailuresConfiguration, instanceSpecificPump, instanceProcessingLogSlot, slotFactory, manageSlotLifecycle: true);
             var instancePipelineExecutor = new MainPipelineExecutor(builder, pipelineCache, messageOperations, configuration.PipelineCompletedSubscribers, receivePipeline, activityFactory, pipelineMetrics, envelopeUnwrapper);
 
             await instancePump.Initialize(
@@ -206,8 +210,8 @@ partial class ReceiveComponent
         {
             try
             {
-                var satelliteLogSlot = CreateSatelliteProcessingLogSlot(endpointLogSlot, satellite.Name);
-                var satellitePump = CreateReceiver(consecutiveFailuresConfiguration, transportInfrastructure.Receivers[satellite.Name], satelliteLogSlot);
+                var satelliteLogSlot = new EndpointSatelliteLogSlot(endpointLogSlot, satellite.Name);
+                var satellitePump = CreateReceiver(consecutiveFailuresConfiguration, transportInfrastructure.Receivers[satellite.Name], satelliteLogSlot, slotFactory, manageSlotLifecycle: true);
 
                 var satellitePipeline = new SatellitePipelineExecutor(builder, satellite);
                 var satelliteRecoverabilityExecutor = recoverabilityComponent.CreateSatelliteRecoverabilityExecutor(builder, satellite.RecoverabilityPolicy);
@@ -265,30 +269,18 @@ partial class ReceiveComponent
         return Task.WhenAll(receiverStopTasks);
     }
 
-    static LogWrappedMessageReceiver CreateReceiver(ConsecutiveFailuresConfiguration consecutiveFailuresConfiguration, IMessageReceiver receiver, LogSlot endpointLogSlot)
+    static LogWrappedMessageReceiver CreateReceiver(ConsecutiveFailuresConfiguration consecutiveFailuresConfiguration, IMessageReceiver receiver, LogSlot logSlot, ILoggerFactory slotFactory, bool manageSlotLifecycle)
     {
         var effectiveReceiver = consecutiveFailuresConfiguration.RateLimitSettings is not null
             ? new WrappedMessageReceiver(consecutiveFailuresConfiguration, receiver)
             : receiver;
 
-        return new LogWrappedMessageReceiver(effectiveReceiver, endpointLogSlot);
+        return new LogWrappedMessageReceiver(effectiveReceiver, logSlot, slotFactory, manageSlotLifecycle);
     }
-
-    static LogSlot CreateReceiverProcessingLogSlot(LogSlot endpointLogSlot, string receiverId)
-    {
-        if (endpointLogSlot is not EndpointLogSlot endpointSlot)
-        {
-            return endpointLogSlot;
-        }
-
-        return receiverId == InstanceSpecificReceiverId ? new EndpointReceiverLogSlot(endpointSlot, receiverId) : endpointLogSlot;
-    }
-
-    static LogSlot CreateSatelliteProcessingLogSlot(LogSlot endpointLogSlot, string satelliteName) => endpointLogSlot is not EndpointLogSlot endpointSlot ? endpointLogSlot : new EndpointSatelliteLogSlot(endpointSlot, satelliteName);
 
     readonly Configuration configuration;
     readonly IActivityFactory activityFactory;
-    readonly LogSlot endpointLogSlot;
+    readonly EndpointLogSlot endpointLogSlot;
     readonly List<IMessageReceiver> receivers = [];
 
     const string MainReceiverId = "Main";


### PR DESCRIPTION
* Backport of https://github.com/Particular/NServiceBus/pull/7787 to fix https://github.com/Particular/NServiceBus/issues/7790 on `release-10.2` for release in 10.2.4