### PR TITLE
Support structured logging in downstream providers

### DIFF
--- a/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/EndpointLoggingScopeTests.cs
@@ -34,6 +34,26 @@ public class EndpointLoggingScopeTests
     }
 
     [Test]
+    public void Should_preserve_structured_state_when_logging_in_slot_scope()
+    {
+        var loggerFactory = new FakeLoggerLoggerFactory();
+        var slot = new EndpointLogSlot("Sales", "blue");
+        LogManager.RegisterSlotFactory(slot, new MicrosoftLoggerFactoryAdapter(loggerFactory));
+
+        var logger = LogManager.GetLogger($"{nameof(EndpointLoggingScopeTests)}-{Guid.NewGuid():N}");
+
+        using (LogManager.BeginSlotScope(slot))
+        {
+            logger.InfoFormat("message {0}", "value");
+        }
+
+        Assert.That(loggerFactory.CapturedStructuredState, Has.Some.Matches<IReadOnlyList<KeyValuePair<string, string?>>?>(state =>
+            state is not null &&
+            state.Any(kv => kv is { Key: "{OriginalFormat}", Value: "message {0}" }) &&
+            state.Any(kv => kv is { Key: "0", Value: "value" })));
+    }
+
+    [Test]
     public void Should_include_only_endpoint_name_when_identifier_is_not_provided()
     {
         var loggerFactory = new FakeLoggerLoggerFactory();
@@ -313,6 +333,8 @@ public class EndpointLoggingScopeTests
         readonly FakeLoggerProvider provider = new();
 
         public List<string> CapturedMessages => [.. provider.Collector.GetSnapshot().Select(r => r.Message)];
+
+        public List<IReadOnlyList<KeyValuePair<string, string?>>?> CapturedStructuredState => [.. provider.Collector.GetSnapshot().Select(r => r.StructuredState)];
 
         public List<IReadOnlyList<KeyValuePair<string, object>>> CapturedLogScopes =>
         [

--- a/src/NServiceBus.Core/Logging/MicrosoftLoggerAdapter.cs
+++ b/src/NServiceBus.Core/Logging/MicrosoftLoggerAdapter.cs
@@ -8,9 +8,6 @@ using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 sealed class MicrosoftLoggerAdapter(ILogger logger) : ILog
 {
-    static readonly Func<string?, Exception?, string> MessageFormatter = static (state, _) => state ?? string.Empty;
-    static readonly Func<(string format, object?[] args), Exception?, string> FormatMessageFormatter = static (state, _) => string.Format(state.format, state.args);
-
     public bool IsDebugEnabled => logger.IsEnabled(LogLevel.Debug);
     public bool IsInfoEnabled => logger.IsEnabled(LogLevel.Information);
     public bool IsWarnEnabled => logger.IsEnabled(LogLevel.Warning);
@@ -47,6 +44,7 @@ sealed class MicrosoftLoggerAdapter(ILogger logger) : ILog
 
     public void FatalFormat(string format, params object?[] args) => WriteFormat(LogLevel.Critical, format, args);
 
+#pragma warning disable CA2254 // Template should be a static expression -- this is infrastructure, not application code
     void Write(LogLevel level, string? message, Exception? exception = null)
     {
         if (!logger.IsEnabled(level))
@@ -54,7 +52,7 @@ sealed class MicrosoftLoggerAdapter(ILogger logger) : ILog
             return;
         }
 
-        logger.Log(level, default, message, exception, MessageFormatter);
+        logger.Log(level, default, exception, message);
     }
 
     void WriteFormat(LogLevel level, string format, object?[] args)
@@ -64,6 +62,7 @@ sealed class MicrosoftLoggerAdapter(ILogger logger) : ILog
             return;
         }
 
-        logger.Log(level, default, (format, args), null, FormatMessageFormatter);
+        logger.Log(level, default, null, format, args);
     }
+#pragma warning restore CA2254
 }


### PR DESCRIPTION
# Problem

NServiceBus 10.2 uses Microsoft Extensions Logging to write logs. The `MicrosoftLoggerAdapter` is responsible for adapting between NServiceBus' custom logging abstractions and MEL. This calls the `Write()` method accepting an opaque "state" object, which is passed onto the logging provider (e.g. Serilog, NLog, etc.)

The state object passed by the adapter will either be a `string` or a `(string, object?[])` tuple. Providers like Serilog and NLog expect the state to have a certain structure, specifically to implement `IEnumerable<KeyValuePair<string, object?>>`, to be properly interpreted as a structured log.

Because the logs written by NServiceBus don't fit this pattern, they are interpreted by the provider as a flat text log, removing the benefits of structured logging.

# Changes

Use Microsoft `ILogger` extension methods which internally construct a state object that's in the shape expected by downstream providers for structured logs.

# Result

## Before

```json
// Export of a log message written by Serilog
{
    "@t": "2026-06-04T23:47:43.7457810Z",
    "@mt": "{State:l}",
    "@m": "Use of TypeNameHandling.Auto is a potential security vulnerability and it is recommended to use TypeNameHandling.None if possible.",
    "@i": "41d88e58",
    "@l": "Warning",
    "ProcessId": 92380,
    "SourceContext": "NServiceBus.Newtonsoft.Json.JsonMessageSerializer",
    "State": "Use of TypeNameHandling.Auto is a potential security vulnerability and it is recommended to use TypeNameHandling.None if possible.",
    "ThreadId": 21,
    "ThreadName": ".NET TP Worker"
}
```

Note the message template (`@mt`) uses the generic "{State:l}" pattern, while the actual message is stored in the State property. All logs emitted by NServiceBus use the same template, making them impossible to differentiate by template, or to query based on properties.

## After

```json
// Export of a log message written by Serilog
{
    "@t": "2026-06-05T05:26:17.4353640Z",
    "@mt": "Use of TypeNameHandling.Auto is a potential security vulnerability and it is recommended to use TypeNameHandling.None if possible.",
    "@m": "Use of TypeNameHandling.Auto is a potential security vulnerability and it is recommended to use TypeNameHandling.None if possible.",
    "@i": "878e5019",
    "@l": "Warning",
    "ProcessId": 92380,
    "SourceContext": "NServiceBus.Newtonsoft.Json.JsonMessageSerializer",
    "ThreadId": 21,
    "ThreadName": ".NET TP Worker"
}
```

The message template is now the log message text. Properties within log messages are separated so they can be queried. They will use numerical indexing since names are not provided by NServiceBus. For example:

```json
{
    "0": "SqlPersistence",
    "1": "Subscriptions",
    "@t": "2026-06-05T08:53:24.6800280Z",
    "@mt": "Activating persistence '{0}' to provide storage for '{1}' storage.",
    "@m": "Activating persistence 'SqlPersistence' to provide storage for 'Subscriptions' storage.",
    "@i": "06b3ecd0",
    "@l": "Debug",
    "ProcessId": 96353,
    "SourceContext": "NServiceBus.PersistenceComponent",
    "ThreadId": 31,
    "ThreadName": ".NET TP Worker"
}
```