### PR TITLE
Ensure RunningEndpointInstance.DisposeAsync completes when host is disposed without StopAsync

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehavior.cs
@@ -44,6 +44,14 @@ public class EndpointBehavior : IComponentBehavior
                 return async token => await endpointLifecycle.Stop(token).ConfigureAwait(false);
             });
 
+            // For some super advanced scenarios require
+            // disposing the endpoint, and this backdoor allows that without having to expose the lifecycle in Core
+            collectionAdapter.AddKeyedSingleton<Func<ValueTask>>("Disposer", (provider, key) =>
+            {
+                var endpointLifecycle = provider.GetRequiredKeyedService<IEndpointLifecycle>(serviceKey);
+                return async () => await endpointLifecycle.DisposeAsync().ConfigureAwait(false);
+            });
+
             return Task.FromResult(new StartableEndpointInstance(serviceKey));
         }, static (startableEndpoint, provider, cancellationToken) => startableEndpoint.Start(provider, cancellationToken));
     }

--- a/src/NServiceBus.AcceptanceTests/Core/Stopping/When_disposing_without_stopping.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Stopping/When_disposing_without_stopping.cs
@@ -1,0 +1,58 @@
+namespace NServiceBus.AcceptanceTests.Core.Stopping;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+public class When_disposing_without_stopping : NServiceBusAcceptanceTest
+{
+    [Test]
+    [CancelAfter(30000)]
+    public async Task Should_initiate_immediate_handler_cancellation(CancellationToken cancellationToken = default) =>
+        await Scenario.Define<Context>()
+            .WithEndpoint<EndpointThatGetsRugPulled>(b =>
+                b.ServiceResolve(static async (provider, context, token) =>
+                {
+                    var session = provider.GetRequiredService<IMessageSession>();
+                    await session.SendLocal(new MessageThatTakesALongTime(), token);
+
+                    await context.MessageReceived.Task.WaitAsync(token);
+
+                    var disposer = provider.GetRequiredKeyedService<Func<ValueTask>>("Disposer");
+                    await disposer();
+                }, true))
+            .Run(cancellationToken);
+
+    public class Context : ScenarioContext
+    {
+        public TaskCompletionSource MessageReceived { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public class EndpointThatGetsRugPulled : EndpointConfigurationBuilder
+    {
+        public EndpointThatGetsRugPulled() => EndpointSetup<DefaultServer>();
+
+        [Handler]
+        public class InfiniteHandler(Context testContext) : IHandleMessages<MessageThatTakesALongTime>
+        {
+            public async Task Handle(MessageThatTakesALongTime message, IMessageHandlerContext context)
+            {
+                try
+                {
+                    testContext.MessageReceived.SetResult();
+                    await Task.Delay(Timeout.InfiniteTimeSpan, context.CancellationToken);
+                }
+                catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+                {
+                    testContext.MarkAsCompleted();
+                }
+            }
+        }
+    }
+
+    public class MessageThatTakesALongTime : IMessage;
+}

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -18,10 +18,10 @@ public class RunningEndpointInstanceTest
 
         var testInstance = new RunningEndpointInstance(
             settings,
-            null,
+            null!,
             new FeatureComponent(new FeatureComponent.Settings()),
             new TestableMessageSession(),
-            null,
+            null!,
             new CancellationTokenSource(),
             NoOpAsyncDisposable.Instance,
             new EndpointLogSlot("RunningEndpointInstanceTest", endpointIdentifier: null));
@@ -92,34 +92,26 @@ public class RunningEndpointInstanceTest
         // and hangs forever, disposal still hangs. Confirm the timeout actually fires and
         // disposal proceeds past a stuck transport.Shutdown.
 
-        var originalTimeout = RunningEndpointInstance.DisposeShutdownTimeout;
-        RunningEndpointInstance.DisposeShutdownTimeout = TimeSpan.FromMilliseconds(250);
-        try
-        {
-            var hangingTransport = new HangingTransportInfrastructure();
+        var hangingTransport = new HangingTransportInfrastructure();
 
-            var testInstance = new RunningEndpointInstance(
-                new SettingsHolder(),
-                CreateEmptyReceiveComponent(),
-                new FeatureComponent(new FeatureComponent.Settings()),
-                new TestableMessageSession(),
-                hangingTransport,
-                new CancellationTokenSource(),
-                NoOpAsyncDisposable.Instance,
-                new EndpointLogSlot("RunningEndpointInstanceTest", endpointIdentifier: null));
+        var testInstance = new RunningEndpointInstance(
+            new SettingsHolder(),
+            CreateEmptyReceiveComponent(),
+            new FeatureComponent(new FeatureComponent.Settings()),
+            new TestableMessageSession(),
+            hangingTransport,
+            new CancellationTokenSource(),
+            NoOpAsyncDisposable.Instance,
+            new EndpointLogSlot("RunningEndpointInstanceTest", endpointIdentifier: null),
+            disposeShutdownTimeout: TimeSpan.FromMilliseconds(250));
 
-            var dispose = testInstance.DisposeAsync().AsTask();
-            var winner = await Task.WhenAny(dispose, Task.Delay(TimeSpan.FromSeconds(5)));
+        var dispose = testInstance.DisposeAsync().AsTask();
+        var winner = await Task.WhenAny(dispose, Task.Delay(TimeSpan.FromSeconds(5)));
 
-            Assert.That(winner, Is.SameAs(dispose),
-                "DisposeAsync did not complete within 5s of a 250ms internal timeout — " +
-                "DisposeShutdownTimeout must fire and let disposal proceed past a stuck transport.Shutdown.");
-            await dispose;
-        }
-        finally
-        {
-            RunningEndpointInstance.DisposeShutdownTimeout = originalTimeout;
-        }
+        Assert.That(winner, Is.SameAs(dispose),
+            "DisposeAsync did not complete within 5s of a 250ms internal timeout — " +
+            "the disposeShutdownTimeout must fire and let disposal proceed past a stuck transport.Shutdown.");
+        await dispose;
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Unicast.Tests;
 
 using System;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Features;
@@ -101,17 +100,10 @@ public class RunningEndpointInstanceTest
         Assert.Throws<InvalidOperationException>(() => testInstance.Unsubscribe(typeof(object), new UnsubscribeOptions()), "Invoking messaging operations on the endpoint instance after it has been triggered to stop is not supported.");
     }
 
-    // ReceiveComponent has a private constructor; reflection is the lightest way to
-    // get a real instance for tests. An empty `receivers` list (the field default)
-    // makes Stop a no-op, so we can reach transport.Shutdown without standing up
-    // the full receive pipeline.
+    // Empty ReceiveComponent (no receivers) so Stop is a no-op and StopCore reaches
+    // transport.Shutdown without us having to stand up the full receive pipeline.
     static ReceiveComponent CreateEmptyReceiveComponent() =>
-        (ReceiveComponent)Activator.CreateInstance(
-            typeof(ReceiveComponent),
-            BindingFlags.Instance | BindingFlags.NonPublic,
-            binder: null,
-            args: [null, null, null],
-            culture: null)!;
+        new(configuration: null!, activityFactory: null!, endpointLogSlot: null!);
 
     sealed class TokenCapturingTransportInfrastructure : TransportInfrastructure
     {

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -51,17 +51,6 @@ public class RunningEndpointInstanceTest
     [Test]
     public async Task DisposeAsync_should_pass_a_bounded_cancellation_token_to_transport_Shutdown()
     {
-        // DisposeAsync is the cleanup path taken when an IHost is disposed without an
-        // explicit StopAsync (e.g. `using var host = ...` or `await using var host = ...`
-        // with no prior host.StopAsync()). It calls StopCore internally, which awaits
-        // transport.Shutdown. If StopCore is invoked with CancellationToken.None then
-        // the transport's shutdown wait is unbounded — a slow or stuck transport hangs
-        // disposal forever instead of being aborted by the host's shutdown timeout.
-        //
-        // Repro from the field: NServiceBus.SqlServerTransport receive loop in flight
-        // at the moment the test host is disposed; 5+ minute hang until the hangdump
-        // timeout fires.
-
         var capturingTransport = new TokenCapturingTransportInfrastructure();
 
         var testInstance = new RunningEndpointInstance(
@@ -76,22 +65,21 @@ public class RunningEndpointInstanceTest
 
         await testInstance.DisposeAsync();
 
-        Assert.That(capturingTransport.ShutdownWasCalled, Is.True,
-            "transport.Shutdown was not called during DisposeAsync.");
-        Assert.That(capturingTransport.ObservedToken.CanBeCanceled, Is.True,
-            "DisposeAsync passed CancellationToken.None to StopCore (which then passes it to " +
-            "transport.Shutdown). Disposal must be bounded by an internal cancellation token so " +
-            "a stuck transport cannot hang shutdown indefinitely. " +
-            "See RunningEndpointInstance.DisposeAsync — `await StopCore()` is missing a token.");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(capturingTransport.ShutdownWasCalled, Is.True,
+                    "transport.Shutdown was not called during DisposeAsync.");
+            Assert.That(capturingTransport.ObservedToken.CanBeCanceled, Is.True,
+                "DisposeAsync passed CancellationToken.None to StopCore (which then passes it to " +
+                "transport.Shutdown). Disposal must be bounded by an internal cancellation token so " +
+                "a stuck transport cannot hang shutdown indefinitely. " +
+                "See RunningEndpointInstance.DisposeAsync — `await StopCore()` is missing a token.");
+        }
     }
 
     [Test]
     public async Task DisposeAsync_should_complete_even_when_transport_Shutdown_hangs()
     {
-        // The bounded token alone is not enough — if transport.Shutdown ignores the token
-        // and hangs forever, disposal still hangs. Confirm the timeout actually fires and
-        // disposal proceeds past a stuck transport.Shutdown.
-
         var hangingTransport = new HangingTransportInfrastructure();
 
         var testInstance = new RunningEndpointInstance(
@@ -102,8 +90,7 @@ public class RunningEndpointInstanceTest
             hangingTransport,
             new CancellationTokenSource(),
             NoOpAsyncDisposable.Instance,
-            new EndpointLogSlot("RunningEndpointInstanceTest", endpointIdentifier: null),
-            disposeShutdownTimeout: TimeSpan.FromMilliseconds(250));
+            new EndpointLogSlot("RunningEndpointInstanceTest", endpointIdentifier: null));
 
         var dispose = testInstance.DisposeAsync().AsTask();
         var winner = await Task.WhenAny(dispose, Task.Delay(TimeSpan.FromSeconds(5)));
@@ -111,7 +98,7 @@ public class RunningEndpointInstanceTest
         Assert.That(winner, Is.SameAs(dispose),
             "DisposeAsync did not complete within 5s of a 250ms internal timeout — " +
             "the disposeShutdownTimeout must fire and let disposal proceed past a stuck transport.Shutdown.");
-        await dispose;
+        Assert.DoesNotThrowAsync(() => dispose, "DisposeAsync threw an exception when transport.Shutdown hung. DisposeAsync should complete successfully even if transport.Shutdown does not.");
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -86,6 +86,43 @@ public class RunningEndpointInstanceTest
     }
 
     [Test]
+    public async Task DisposeAsync_should_complete_even_when_transport_Shutdown_hangs()
+    {
+        // The bounded token alone is not enough — if transport.Shutdown ignores the token
+        // and hangs forever, disposal still hangs. Confirm the timeout actually fires and
+        // disposal proceeds past a stuck transport.Shutdown.
+
+        var originalTimeout = RunningEndpointInstance.DisposeShutdownTimeout;
+        RunningEndpointInstance.DisposeShutdownTimeout = TimeSpan.FromMilliseconds(250);
+        try
+        {
+            var hangingTransport = new HangingTransportInfrastructure();
+
+            var testInstance = new RunningEndpointInstance(
+                new SettingsHolder(),
+                CreateEmptyReceiveComponent(),
+                new FeatureComponent(new FeatureComponent.Settings()),
+                new TestableMessageSession(),
+                hangingTransport,
+                new CancellationTokenSource(),
+                NoOpAsyncDisposable.Instance,
+                new EndpointLogSlot("RunningEndpointInstanceTest", endpointIdentifier: null));
+
+            var dispose = testInstance.DisposeAsync().AsTask();
+            var winner = await Task.WhenAny(dispose, Task.Delay(TimeSpan.FromSeconds(5)));
+
+            Assert.That(winner, Is.SameAs(dispose),
+                "DisposeAsync did not complete within 5s of a 250ms internal timeout — " +
+                "DisposeShutdownTimeout must fire and let disposal proceed past a stuck transport.Shutdown.");
+            await dispose;
+        }
+        finally
+        {
+            RunningEndpointInstance.DisposeShutdownTimeout = originalTimeout;
+        }
+    }
+
+    [Test]
     public async Task ShouldThrowExceptionAfterInvokingStop()
     {
         var testInstance = Create();
@@ -116,6 +153,14 @@ public class RunningEndpointInstanceTest
             ObservedToken = cancellationToken;
             return Task.CompletedTask;
         }
+
+        public override string ToTransportAddress(QueueAddress address) => address.BaseAddress;
+    }
+
+    sealed class HangingTransportInfrastructure : TransportInfrastructure
+    {
+        public override Task Shutdown(CancellationToken cancellationToken = default) =>
+            Task.Delay(Timeout.Infinite, cancellationToken);
 
         public override string ToTransportAddress(QueueAddress address) => address.BaseAddress;
     }

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -1,12 +1,14 @@
 ﻿namespace NServiceBus.Unicast.Tests;
 
 using System;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Features;
 using NUnit.Framework;
 using Settings;
 using Testing;
+using NServiceBus.Transport;
 
 [TestFixture]
 public class RunningEndpointInstanceTest
@@ -48,6 +50,43 @@ public class RunningEndpointInstanceTest
     }
 
     [Test]
+    public async Task DisposeAsync_should_pass_a_bounded_cancellation_token_to_transport_Shutdown()
+    {
+        // DisposeAsync is the cleanup path taken when an IHost is disposed without an
+        // explicit StopAsync (e.g. `using var host = ...` or `await using var host = ...`
+        // with no prior host.StopAsync()). It calls StopCore internally, which awaits
+        // transport.Shutdown. If StopCore is invoked with CancellationToken.None then
+        // the transport's shutdown wait is unbounded — a slow or stuck transport hangs
+        // disposal forever instead of being aborted by the host's shutdown timeout.
+        //
+        // Repro from the field: NServiceBus.SqlServerTransport receive loop in flight
+        // at the moment the test host is disposed; 5+ minute hang until the hangdump
+        // timeout fires.
+
+        var capturingTransport = new TokenCapturingTransportInfrastructure();
+
+        var testInstance = new RunningEndpointInstance(
+            new SettingsHolder(),
+            CreateEmptyReceiveComponent(),
+            new FeatureComponent(new FeatureComponent.Settings()),
+            new TestableMessageSession(),
+            capturingTransport,
+            new CancellationTokenSource(),
+            NoOpAsyncDisposable.Instance,
+            new EndpointLogSlot("RunningEndpointInstanceTest", endpointIdentifier: null));
+
+        await testInstance.DisposeAsync();
+
+        Assert.That(capturingTransport.ShutdownWasCalled, Is.True,
+            "transport.Shutdown was not called during DisposeAsync.");
+        Assert.That(capturingTransport.ObservedToken.CanBeCanceled, Is.True,
+            "DisposeAsync passed CancellationToken.None to StopCore (which then passes it to " +
+            "transport.Shutdown). Disposal must be bounded by an internal cancellation token so " +
+            "a stuck transport cannot hang shutdown indefinitely. " +
+            "See RunningEndpointInstance.DisposeAsync — `await StopCore()` is missing a token.");
+    }
+
+    [Test]
     public async Task ShouldThrowExceptionAfterInvokingStop()
     {
         var testInstance = Create();
@@ -60,5 +99,32 @@ public class RunningEndpointInstanceTest
         Assert.Throws<InvalidOperationException>(() => testInstance.Publish<object>(_ => { }, new PublishOptions()), "Invoking messaging operations on the endpoint instance after it has been triggered to stop is not supported.");
         Assert.Throws<InvalidOperationException>(() => testInstance.Subscribe(typeof(object), new SubscribeOptions()), "Invoking messaging operations on the endpoint instance after it has been triggered to stop is not supported.");
         Assert.Throws<InvalidOperationException>(() => testInstance.Unsubscribe(typeof(object), new UnsubscribeOptions()), "Invoking messaging operations on the endpoint instance after it has been triggered to stop is not supported.");
+    }
+
+    // ReceiveComponent has a private constructor; reflection is the lightest way to
+    // get a real instance for tests. An empty `receivers` list (the field default)
+    // makes Stop a no-op, so we can reach transport.Shutdown without standing up
+    // the full receive pipeline.
+    static ReceiveComponent CreateEmptyReceiveComponent() =>
+        (ReceiveComponent)Activator.CreateInstance(
+            typeof(ReceiveComponent),
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            args: [null, null, null],
+            culture: null)!;
+
+    sealed class TokenCapturingTransportInfrastructure : TransportInfrastructure
+    {
+        public bool ShutdownWasCalled { get; private set; }
+        public CancellationToken ObservedToken { get; private set; }
+
+        public override Task Shutdown(CancellationToken cancellationToken = default)
+        {
+            ShutdownWasCalled = true;
+            ObservedToken = cancellationToken;
+            return Task.CompletedTask;
+        }
+
+        public override string ToTransportAddress(QueueAddress address) => address.BaseAddress;
     }
 }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -17,7 +17,7 @@ using Unicast;
 
 partial class ReceiveComponent
 {
-    ReceiveComponent(Configuration configuration, IActivityFactory activityFactory, EndpointLogSlot endpointLogSlot)
+    internal ReceiveComponent(Configuration configuration, IActivityFactory activityFactory, EndpointLogSlot endpointLogSlot)
     {
         this.configuration = configuration;
         this.activityFactory = activityFactory;

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -7,6 +7,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Features;
 using Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Settings;
 using Transport;
 
@@ -82,7 +85,15 @@ class StartableEndpoint(
 
             await hostingComponent.WriteDiagnosticsFile(cancellationToken).ConfigureAwait(false);
 
-            var runningInstance = new RunningEndpointInstance(settings, receiveComponent, featureComponent, messageSession, transportInfrastructure, stoppingTokenSource, serviceProviderLease, hostingComponent.Config.EndpointLogSlot);
+            // Honour HostOptions.ShutdownTimeout when running under Microsoft.Extensions.Hosting
+            // so DisposeAsync uses the same budget the host applies during a graceful StopAsync.
+            // When IOptions<HostOptions> isn't registered (legacy self-hosted Endpoint.Start),
+            // RunningEndpointInstance falls back to its own default.
+            var disposeShutdownTimeout = serviceProvider
+                .GetService<IOptions<HostOptions>>()
+                ?.Value.ShutdownTimeout;
+
+            var runningInstance = new RunningEndpointInstance(settings, receiveComponent, featureComponent, messageSession, transportInfrastructure, stoppingTokenSource, serviceProviderLease, hostingComponent.Config.EndpointLogSlot, disposeShutdownTimeout);
 
             hostingComponent.SetupCriticalErrors(runningInstance, cancellationToken);
 

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -7,9 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Features;
 using Logging;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 using Settings;
 using Transport;
 
@@ -85,15 +82,7 @@ class StartableEndpoint(
 
             await hostingComponent.WriteDiagnosticsFile(cancellationToken).ConfigureAwait(false);
 
-            // Honour HostOptions.ShutdownTimeout when running under Microsoft.Extensions.Hosting
-            // so DisposeAsync uses the same budget the host applies during a graceful StopAsync.
-            // When IOptions<HostOptions> isn't registered (legacy self-hosted Endpoint.Start),
-            // RunningEndpointInstance falls back to its own default.
-            var disposeShutdownTimeout = serviceProvider
-                .GetService<IOptions<HostOptions>>()
-                ?.Value.ShutdownTimeout;
-
-            var runningInstance = new RunningEndpointInstance(settings, receiveComponent, featureComponent, messageSession, transportInfrastructure, stoppingTokenSource, serviceProviderLease, hostingComponent.Config.EndpointLogSlot, disposeShutdownTimeout);
+            var runningInstance = new RunningEndpointInstance(settings, receiveComponent, featureComponent, messageSession, transportInfrastructure, stoppingTokenSource, serviceProviderLease, hostingComponent.Config.EndpointLogSlot);
 
             hostingComponent.SetupCriticalErrors(runningInstance, cancellationToken);
 

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -106,11 +106,12 @@ class RunningEndpointInstance(SettingsHolder settings,
         }
 
         using var disposeCancelSource = new CancellationTokenSource(disposeShutdownTimeout);
+        var disposeCancellationToken = disposeCancelSource.Token;
         try
         {
-            await StopCore(disposeCancelSource.Token).ConfigureAwait(false);
+            await StopCore(disposeCancellationToken).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (disposeCancelSource.IsCancellationRequested)
+        catch (OperationCanceledException) when (disposeCancellationToken.IsCancellationRequested)
         {
             Log.Warn($"Graceful shutdown timed out after {disposeShutdownTimeout} during DisposeAsync; continuing with resource cleanup.");
         }

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -18,9 +18,15 @@ class RunningEndpointInstance(SettingsHolder settings,
     CancellationTokenSource stoppingTokenSource,
     IAsyncDisposable serviceProviderLease,
 #pragma warning disable CS0618 // Type or member is obsolete -- Change the interface to IMessageSession in the next major
-    LogSlot endpointLogSlot) : IEndpointInstance, IAsyncDisposable
+    LogSlot endpointLogSlot,
+    TimeSpan? disposeShutdownTimeout = null) : IEndpointInstance, IAsyncDisposable
 #pragma warning restore CS0618 // Type or member is obsolete
 {
+    // Bound the shutdown wait inside DisposeAsync. DisposeAsync is reached when an IHost
+    // is disposed without an explicit StopAsync (e.g. `using var host` / `await using var
+    // host` followed by scope exit), so no host shutdown token reaches us. Mirrors
+    // HostOptions.ShutdownTimeout's default of 30s.
+    readonly TimeSpan disposeShutdownTimeout = disposeShutdownTimeout ?? TimeSpan.FromSeconds(30);
     // Stop is the legacy interface for shutting down the endpoint over the public API.
     // The modern hosted variant has Stop and DisposeAsync as separate steps:
     // BaseEndpointLifecycle.Stop calls StopCore (shutdown only), then DisposeAsync (cleanup).
@@ -99,28 +105,20 @@ class RunningEndpointInstance(SettingsHolder settings,
             return;
         }
 
-        // Bound the shutdown wait. DisposeAsync is reached when an IHost is disposed
-        // without an explicit StopAsync (e.g. `using var host` or `await using var host`
-        // followed by scope exit), so no host shutdown token reaches us here. Without a
-        // bound, a slow or stuck transport.Shutdown blocks disposal indefinitely.
-        // Mirrors HostOptions.ShutdownTimeout default.
-        using var disposeCts = new CancellationTokenSource(DisposeShutdownTimeout);
+        using var disposeCancelSource = new CancellationTokenSource(disposeShutdownTimeout);
         try
         {
-            await StopCore(disposeCts.Token).ConfigureAwait(false);
+            await StopCore(disposeCancelSource.Token).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (disposeCts.IsCancellationRequested)
+        catch (OperationCanceledException) when (disposeCancelSource.IsCancellationRequested)
         {
-            Log.Warn($"Graceful shutdown timed out after {DisposeShutdownTimeout} during DisposeAsync; continuing with resource cleanup.");
+            Log.Warn($"Graceful shutdown timed out after {disposeShutdownTimeout} during DisposeAsync; continuing with resource cleanup.");
         }
 
         settings.Clear();
         stoppingTokenSource.Dispose();
         await serviceProviderLease.DisposeAsync().ConfigureAwait(false);
     }
-
-    // Mutable for tests. Defaults to HostOptions.ShutdownTimeout's default of 30s.
-    internal static TimeSpan DisposeShutdownTimeout = TimeSpan.FromSeconds(30);
 
     public Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)
     {

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -111,7 +111,7 @@ class RunningEndpointInstance(SettingsHolder settings,
         }
         catch (OperationCanceledException) when (disposeCts.IsCancellationRequested)
         {
-            Log.Warn($"Graceful shutdown timed out after {DisposeShutdownTimeout.TotalSeconds:F0}s during DisposeAsync; continuing with resource cleanup.");
+            Log.Warn($"Graceful shutdown timed out after {DisposeShutdownTimeout} during DisposeAsync; continuing with resource cleanup.");
         }
 
         settings.Clear();
@@ -119,7 +119,8 @@ class RunningEndpointInstance(SettingsHolder settings,
         await serviceProviderLease.DisposeAsync().ConfigureAwait(false);
     }
 
-    static readonly TimeSpan DisposeShutdownTimeout = TimeSpan.FromSeconds(30);
+    // Mutable for tests. Defaults to HostOptions.ShutdownTimeout's default of 30s.
+    internal static TimeSpan DisposeShutdownTimeout = TimeSpan.FromSeconds(30);
 
     public Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)
     {

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -18,15 +18,9 @@ class RunningEndpointInstance(SettingsHolder settings,
     CancellationTokenSource stoppingTokenSource,
     IAsyncDisposable serviceProviderLease,
 #pragma warning disable CS0618 // Type or member is obsolete -- Change the interface to IMessageSession in the next major
-    LogSlot endpointLogSlot,
-    TimeSpan? disposeShutdownTimeout = null) : IEndpointInstance, IAsyncDisposable
+    LogSlot endpointLogSlot) : IEndpointInstance, IAsyncDisposable
 #pragma warning restore CS0618 // Type or member is obsolete
 {
-    // Bound the shutdown wait inside DisposeAsync. DisposeAsync is reached when an IHost
-    // is disposed without an explicit StopAsync (e.g. `using var host` / `await using var
-    // host` followed by scope exit), so no host shutdown token reaches us. Mirrors
-    // HostOptions.ShutdownTimeout's default of 30s.
-    readonly TimeSpan disposeShutdownTimeout = disposeShutdownTimeout ?? TimeSpan.FromSeconds(30);
     // Stop is the legacy interface for shutting down the endpoint over the public API.
     // The modern hosted variant has Stop and DisposeAsync as separate steps:
     // BaseEndpointLifecycle.Stop calls StopCore (shutdown only), then DisposeAsync (cleanup).
@@ -105,20 +99,25 @@ class RunningEndpointInstance(SettingsHolder settings,
             return;
         }
 
-        using var disposeCancelSource = new CancellationTokenSource(disposeShutdownTimeout);
-        var disposeCancellationToken = disposeCancelSource.Token;
+        // In case Stop was not called, we need to trigger shutdown before cleaning up resources.
+        // Since we're already disposing, we want to bypass any waits and just trigger shutdown with a canceled token.
+        // We are effectively indicating the graceful shutdown period has already elapsed and any ongoing operations should
+        // be aborted immediately if they participate in the cooperative cancellation.
+        var cancellationToken = new CancellationToken(true);
+
         try
         {
-            await StopCore(disposeCancellationToken).ConfigureAwait(false);
+            await StopCore(cancellationToken).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (disposeCancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            Log.Warn($"Graceful shutdown timed out after {disposeShutdownTimeout} during DisposeAsync; continuing with resource cleanup.");
         }
-
-        settings.Clear();
-        stoppingTokenSource.Dispose();
-        await serviceProviderLease.DisposeAsync().ConfigureAwait(false);
+        finally
+        {
+            settings.Clear();
+            stoppingTokenSource.Dispose();
+            await serviceProviderLease.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     public Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -99,12 +99,27 @@ class RunningEndpointInstance(SettingsHolder settings,
             return;
         }
 
-        await StopCore().ConfigureAwait(false);
+        // Bound the shutdown wait. DisposeAsync is reached when an IHost is disposed
+        // without an explicit StopAsync (e.g. `using var host` or `await using var host`
+        // followed by scope exit), so no host shutdown token reaches us here. Without a
+        // bound, a slow or stuck transport.Shutdown blocks disposal indefinitely.
+        // Mirrors HostOptions.ShutdownTimeout default.
+        using var disposeCts = new CancellationTokenSource(DisposeShutdownTimeout);
+        try
+        {
+            await StopCore(disposeCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (disposeCts.IsCancellationRequested)
+        {
+            Log.Warn($"Graceful shutdown timed out after {DisposeShutdownTimeout.TotalSeconds:F0}s during DisposeAsync; continuing with resource cleanup.");
+        }
 
         settings.Clear();
         stoppingTokenSource.Dispose();
         await serviceProviderLease.DisposeAsync().ConfigureAwait(false);
     }
+
+    static readonly TimeSpan DisposeShutdownTimeout = TimeSpan.FromSeconds(30);
 
     public Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)
     {

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -109,8 +109,11 @@ class RunningEndpointInstance(SettingsHolder settings,
         {
             await StopCore(cancellationToken).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+#pragma warning disable PS0019
+        catch (Exception)
+#pragma warning restore PS0019
         {
+            // ignored because we're already disposing and we don't want to throw from DisposeAsync. Any exceptions from StopCore are already logged, so we can safely ignore them here.
         }
         finally
         {


### PR DESCRIPTION
## Problem

`RunningEndpointInstance.DisposeAsync()` calls `StopCore()` without a `CancellationToken`. `StopCore` forwards `CancellationToken.None` to `receiveComponent.Stop`, `featureComponent.StopFeatures`, and `transportInfrastructure.Shutdown`. If any of those does not return on its own, disposal hangs forever.

This manifests when an `IHost` is disposed without a prior `StopAsync` call, for example via `using var host = ...` followed by scope exit. The generic host's `DisposeAsync` only tears down the service provider and does not call `StopAsync` on hosted services. The normal lifecycle path (`EndpointHostedService.StopAsync` through `BaseEndpointLifecycle.Stop`) is unaffected because it properly threads the host's shutdown-timeout token.

The pattern that hits this is most common in integration tests, where a test spins up an `IHost` per test, exercises the endpoint, and lets the using scope tear it down without calling `StopAsync` first.

## Design consideration

An earlier iteration of this PR attempted to apply a shutdown timeout within `DisposeAsync`, effectively emulating `StopAsync` semantics during disposal. This was reconsidered because it would introduce a second shutdown path that behaves differently depending on how the endpoint is hosted. The cancellation token in the stop path is part of the graceful shutdown contract: transports stop accepting new messages first and then allow in-flight processing to complete. Only when the token is cancelled does cooperative cancellation kick in. Making `DisposeAsync` mimic that process with its own timeout would blur the distinction between stopping and disposing.

The correct usage when manually controlling the host lifecycle remains:

```csharp
await host.StartAsync();
try
{
    // ...
}
finally
{
    await host.StopAsync();
    await host.DisposeAsync();
}
```

## Fix

Given the above, `DisposeAsync` now passes an already-canceled token to `StopCore`. This does not attempt graceful shutdown. Instead, it signals that the graceful shutdown period has elapsed and any ongoing operations should abort immediately if they participate in cooperative cancellation. This prevents `DisposeAsync` from hanging while avoiding a competing shutdown path with its own timeout semantics.

Exceptions from `StopCore` are caught and ignored since they are already logged and `DisposeAsync` should not throw. Resource cleanup (`settings.Clear`, `stoppingTokenSource.Dispose`, `serviceProviderLease.DisposeAsync`) runs in a `finally` block to ensure it always executes.

`ReceiveComponent`'s constructor was promoted from private to `internal` so the new unit tests can build minimal instances directly. No public API surface is affected; `RunningEndpointInstance`, `StartableEndpoint`, and `ReceiveComponent` are all internal types.

## Tests

- Unit tests verify `DisposeAsync` passes a cancelable token to `transport.Shutdown`
- Unit tests verify `DisposeAsync` completes even when `transport.Shutdown` hangs
- Acceptance test verifies that disposing without stopping initiates immediate handler cancellation