### PR TITLE
Fix NSB0033 incorrectly reporting mixed handler style when helper overloads are called from interface Handle

### DIFF
--- a/src/NServiceBus.Core.Analyzer.Fixes/Handlers/HandlerAttributeFixer.cs
+++ b/src/NServiceBus.Core.Analyzer.Fixes/Handlers/HandlerAttributeFixer.cs
@@ -164,7 +164,7 @@ public class HandlerAttributeFixer : CodeFixProvider
             }
 
             var isInterfaceBasedHandler = type.ImplementsGenericInterface(knownTypes.IHandleMessages);
-            var isConventionBasedHandler = !isInterfaceBasedHandler && ConventionBasedHandlerHelper.HasValidConventionBasedHandleMethods(type, knownTypes);
+            var isConventionBasedHandler = !isInterfaceBasedHandler && ConventionBasedHandlerHelper.HasValidConventionBasedHandleMethods(type, knownTypes, cancellationToken: cancellationToken);
 
             if (!isInterfaceBasedHandler && !isConventionBasedHandler)
             {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
@@ -663,9 +663,8 @@ public class HandlerAttributeAnalyzerTests : AnalyzerTestFixture<HandlerAttribut
     public Task DoesNotReportMixedStyleForHelperMethodNamedHandleWithNonMessageFirstParameter()
     {
         // A pure interface-based handler with an unrelated public helper overload that happens to be
-        // named Handle and takes IMessageHandlerContext, but whose first parameter is a framework type
-        // (string) that can never be a message. The helper is not a convention-based handler, so this
-        // is not a mixed style.
+        // named Handle and takes IMessageHandlerContext. The helper is called from the interface Handle
+        // method, so it is not a convention-based handler — this is not a mixed style.
         var source =
             """
             using System.Threading;
@@ -682,6 +681,113 @@ public class HandlerAttributeAnalyzerTests : AnalyzerTestFixture<HandlerAttribut
             }
 
             class MyMessage : IMessage {}
+            """;
+
+        return Assert(source);
+    }
+
+    [Test]
+    public Task DoesNotReportMixedStyleForHelperWithUserDefinedTypeCalledFromInterfaceHandle()
+    {
+        // A helper with a user-defined DTO as first param that is called from the interface Handle method.
+        // The call-site analysis detects the invocation, so this is not a mixed style.
+        var source =
+            """
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            class MyDto {}
+
+            [Handler]
+            class MyHandler : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context) => Handle(new MyDto(), context);
+
+                public Task Handle(MyDto dto, IMessageHandlerContext context) => Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage {}
+            """;
+
+        return Assert(source);
+    }
+
+    [Test]
+    public Task DoesNotReportMixedStyleForHelperCalledFromBlockBodiedInterfaceHandle()
+    {
+        // Same pattern but with a block-bodied interface Handle method.
+        var source =
+            """
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            [Handler]
+            class MyHandler : IHandleMessages<MyMessage>
+            {
+                public async Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    await Handle("text", context);
+                }
+
+                public Task Handle(string text, IMessageHandlerContext context) => Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage {}
+            """;
+
+        return Assert(source);
+    }
+
+    [Test]
+    public Task ReportsMixedStyleWhenConventionBasedMethodNotCalledFromInterfaceHandle()
+    {
+        // A convention-based Handle method that is NOT called from the interface Handle method
+        // should still be reported as mixed style.
+        var source =
+            """
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            [Handler]
+            class [|MyHandler|] : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context) => Task.CompletedTask;
+
+                public Task Handle(OtherMessage message, IMessageHandlerContext context) => Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage {}
+            class OtherMessage : IMessage {}
+            """;
+
+        return Assert(source, DiagnosticIds.ConventionBasedHandlerMixedStyle);
+    }
+
+    [Test]
+    public Task DoesNotReportMixedStyleForHelperPassingMessageProperties()
+    {
+        // A helper that receives individual properties extracted from the message.
+        // The call-site analysis detects it is called from the interface Handle method.
+        var source =
+            """
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            [Handler]
+            class MyHandler : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context) =>
+                    Handle(message.Id, message.Name, context);
+
+                public Task Handle(string id, string name, IMessageHandlerContext context) =>
+                    Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage
+            {
+                public string Id { get; set; }
+                public string Name { get; set; }
+            }
             """;
 
         return Assert(source);

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
@@ -660,6 +660,34 @@ public class HandlerAttributeAnalyzerTests : AnalyzerTestFixture<HandlerAttribut
     }
 
     [Test]
+    public Task DoesNotReportMixedStyleForHelperMethodNamedHandleWithNonMessageFirstParameter()
+    {
+        // A pure interface-based handler with an unrelated public helper overload that happens to be
+        // named Handle and takes IMessageHandlerContext, but whose first parameter is a framework type
+        // (string) that can never be a message. The helper is not a convention-based handler, so this
+        // is not a mixed style.
+        var source =
+            """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            [Handler]
+            class MyHandler : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context) => Handle("text", context);
+
+                public Task Handle(string text, IMessageHandlerContext context, CancellationToken cancellation = default) =>
+                    Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage {}
+            """;
+
+        return Assert(source);
+    }
+
+    [Test]
     public Task DoesNotReportConventionBasedHandlerImplementingUnrelatedInterfaceWithHandleMethod()
     {
         var source =

--- a/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Core.Analyzer.Handlers;
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -11,11 +12,16 @@ static class ConventionBasedHandlerHelper
 {
     public const string HandleMethodName = "Handle";
 
-    public static bool IsConventionBasedHandlerType(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, Compilation? compilation = null)
+    public static bool IsConventionBasedHandlerType(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, Compilation? compilation = null, CancellationToken cancellationToken = default)
     {
+        var interfaceMessageTypes = CollectInterfaceMessageTypes(classType, knownTypes);
+        var interfaceHandleCallees = compilation is null
+            ? null
+            : CollectInterfaceHandleCallees(classType, knownTypes, compilation, cancellationToken);
+
         for (var current = classType; current is not null; current = current.BaseType)
         {
-            if (HasValidConventionBasedHandleMethods(current, knownTypes, classType, compilation))
+            if (HasValidConventionBasedHandleMethods(current, knownTypes, interfaceMessageTypes, interfaceHandleCallees))
             {
                 return true;
             }
@@ -24,28 +30,13 @@ static class ConventionBasedHandlerHelper
         return false;
     }
 
-    public static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, Compilation? compilation = null) =>
-        HasValidConventionBasedHandleMethods(classType, knownTypes, classType, compilation);
+    public static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, Compilation? compilation = null, CancellationToken cancellationToken = default) =>
+        HasValidConventionBasedHandleMethods(classType, knownTypes,
+            CollectInterfaceMessageTypes(classType, knownTypes),
+            compilation is null ? null : CollectInterfaceHandleCallees(classType, knownTypes, compilation, cancellationToken));
 
-    static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, INamedTypeSymbol interfaceImplementationType, Compilation? compilation = null)
+    static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, HashSet<ITypeSymbol> interfaceMessageTypes, HashSet<IMethodSymbol>? interfaceHandleCallees)
     {
-        var interfaceMessageTypes = new HashSet<string>(System.StringComparer.Ordinal);
-        foreach (var iface in interfaceImplementationType.AllInterfaces)
-        {
-            if (iface.IsGenericType && HandlerConventions.IsHandlerInterface(iface.OriginalDefinition, knownTypes) &&
-                iface.TypeArguments[0] is INamedTypeSymbol msgType)
-            {
-                interfaceMessageTypes.Add(msgType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
-            }
-        }
-
-        // Single pass: find all interface Handle implementations and the methods they call
-        HashSet<IMethodSymbol>? interfaceHandleCallees = null;
-        if (compilation is not null)
-        {
-            interfaceHandleCallees = CollectInterfaceHandleCallees(interfaceImplementationType, knownTypes, compilation);
-        }
-
         foreach (var member in classType.GetMembers())
         {
             if (member is not IMethodSymbol method)
@@ -53,13 +44,14 @@ static class ConventionBasedHandlerHelper
                 continue;
             }
 
-            if (!IsValidConventionBasedHandleMethod(method, knownTypes, interfaceMessageTypes, interfaceImplementationType))
+            if (!IsValidConventionBasedHandleMethod(method, knownTypes, interfaceMessageTypes))
             {
                 continue;
             }
 
             // Exclude methods that are helpers called from within an interface Handle implementation
-            if (interfaceHandleCallees is not null && interfaceHandleCallees.Contains(method))
+            if (interfaceHandleCallees is not null &&
+                (interfaceHandleCallees.Contains(method) || interfaceHandleCallees.Contains(method.OriginalDefinition)))
             {
                 continue;
             }
@@ -70,7 +62,7 @@ static class ConventionBasedHandlerHelper
         return false;
     }
 
-    public static bool IsValidConventionBasedHandleMethod(IMethodSymbol method, HandlerKnownTypes knownTypes, HashSet<string> interfaceMessageTypes, INamedTypeSymbol? interfaceImplementationType = null)
+    public static bool IsValidConventionBasedHandleMethod(IMethodSymbol method, HandlerKnownTypes knownTypes, HashSet<ITypeSymbol> interfaceMessageTypes, INamedTypeSymbol? interfaceImplementationType = null)
     {
         if (method.Name != HandleMethodName ||
             method.DeclaredAccessibility != Accessibility.Public ||
@@ -104,12 +96,12 @@ static class ConventionBasedHandlerHelper
         }
 
         // If the class implements IHandleMessages<T> for this exact message type with exactly 2 params,
-        // this Handle method is the interface implementation — not a convention-based method.
-        var messageTypeFqn = messageType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        if (method.Parameters.Length == 2 && interfaceMessageTypes.Contains(messageTypeFqn))
+        // this Handle method is the interface implementation, not a convention-based method.
+        if (method.Parameters.Length == 2 && interfaceMessageTypes.Contains(messageType))
         {
             return false;
         }
+
 
         // If this Handle method is the implementation of an interface member that belongs to a handler
         // interface hierarchy (IHandleMessages<T>, IHandleTimeouts<T>, IAmStartedByMessages<T>, or an
@@ -123,12 +115,28 @@ static class ConventionBasedHandlerHelper
         return true;
     }
 
+    static HashSet<ITypeSymbol> CollectInterfaceMessageTypes(INamedTypeSymbol classType, HandlerKnownTypes knownTypes)
+    {
+        var messageTypes = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
+        foreach (var iface in classType.AllInterfaces)
+        {
+            if (iface.IsGenericType && HandlerConventions.IsHandlerInterface(iface.OriginalDefinition, knownTypes) &&
+                iface.TypeArguments[0] is INamedTypeSymbol msgType)
+            {
+                messageTypes.Add(msgType);
+            }
+        }
+
+        return messageTypes;
+    }
+
     // Collects all methods that are called from within interface Handle method implementations.
     // These are helper methods, not convention-based handlers.
     static HashSet<IMethodSymbol> CollectInterfaceHandleCallees(
         INamedTypeSymbol classType,
         HandlerKnownTypes knownTypes,
-        Compilation compilation)
+        Compilation compilation,
+        CancellationToken cancellationToken)
     {
         var visitedImplementations = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
         var callees = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
@@ -147,19 +155,28 @@ static class ConventionBasedHandlerHelper
                 continue;
             }
 
-            foreach (var ifaceMethod in iface.GetMembers(HandleMethodName).OfType<IMethodSymbol>())
+            foreach (var member in iface.GetMembers(HandleMethodName))
             {
-                if (classType.FindImplementationForInterfaceMember(ifaceMethod) is not IMethodSymbol impl ||
-                    !visitedImplementations.Add(impl))
+                if (member is not IMethodSymbol ifaceMethod)
+                {
+                    continue;
+                }
+
+                if (classType.FindImplementationForInterfaceMember(ifaceMethod) is not IMethodSymbol impl)
+                {
+                    continue;
+                }
+
+                if (!visitedImplementations.Add(impl))
                 {
                     continue;
                 }
 
                 foreach (var syntaxRef in impl.DeclaringSyntaxReferences)
                 {
-                    var syntax = syntaxRef.GetSyntax();
+                    var syntax = syntaxRef.GetSyntax(cancellationToken);
 
-                    if (syntax.SyntaxTree != cachedTree)
+                    if (!ReferenceEquals(syntax.SyntaxTree, cachedTree))
                     {
                         cachedTree = syntax.SyntaxTree;
                         cachedModel = compilation.GetSemanticModel(cachedTree);
@@ -167,16 +184,18 @@ static class ConventionBasedHandlerHelper
 
                     foreach (var invocation in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
                     {
-                        var symbolInfo = cachedModel!.GetSymbolInfo(invocation);
-
-                        if (symbolInfo.Symbol is IMethodSymbol invokedMethod)
+                        if (cachedModel!.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol invokedMethod)
                         {
-                            callees.Add(invokedMethod);
+                            continue;
+                        }
 
-                            if (invokedMethod.ReducedFrom is { } reduced)
-                            {
-                                callees.Add(reduced);
-                            }
+                        callees.Add(invokedMethod);
+                        callees.Add(invokedMethod.OriginalDefinition);
+
+                        if (invokedMethod.ReducedFrom is { } reduced)
+                        {
+                            callees.Add(reduced);
+                            callees.Add(reduced.OriginalDefinition);
                         }
                     }
                 }
@@ -217,8 +236,13 @@ static class ConventionBasedHandlerHelper
                 continue;
             }
 
-            foreach (var interfaceMethod in iface.GetMembers(method.Name).OfType<IMethodSymbol>())
+            foreach (var member in iface.GetMembers(method.Name))
             {
+                if (member is not IMethodSymbol interfaceMethod)
+                {
+                    continue;
+                }
+
                 if (interfaceMethod.Parameters.Length != method.Parameters.Length)
                 {
                     continue;

--- a/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
@@ -5,16 +5,17 @@ namespace NServiceBus.Core.Analyzer.Handlers;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 static class ConventionBasedHandlerHelper
 {
     public const string HandleMethodName = "Handle";
 
-    public static bool IsConventionBasedHandlerType(INamedTypeSymbol classType, HandlerKnownTypes knownTypes)
+    public static bool IsConventionBasedHandlerType(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, Compilation? compilation = null)
     {
         for (var current = classType; current is not null; current = current.BaseType)
         {
-            if (HasValidConventionBasedHandleMethods(current, knownTypes, classType))
+            if (HasValidConventionBasedHandleMethods(current, knownTypes, classType, compilation))
             {
                 return true;
             }
@@ -23,10 +24,10 @@ static class ConventionBasedHandlerHelper
         return false;
     }
 
-    public static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes) =>
-        HasValidConventionBasedHandleMethods(classType, knownTypes, classType);
+    public static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, Compilation? compilation = null) =>
+        HasValidConventionBasedHandleMethods(classType, knownTypes, classType, compilation);
 
-    static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, INamedTypeSymbol interfaceImplementationType)
+    static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, INamedTypeSymbol interfaceImplementationType, Compilation? compilation = null)
     {
         var interfaceMessageTypes = new HashSet<string>(System.StringComparer.Ordinal);
         foreach (var iface in interfaceImplementationType.AllInterfaces)
@@ -45,7 +46,7 @@ static class ConventionBasedHandlerHelper
                 continue;
             }
 
-            if (IsValidConventionBasedHandleMethod(method, knownTypes, interfaceMessageTypes, interfaceImplementationType))
+            if (IsValidConventionBasedHandleMethod(method, knownTypes, interfaceMessageTypes, interfaceImplementationType, compilation))
             {
                 return true;
             }
@@ -54,7 +55,7 @@ static class ConventionBasedHandlerHelper
         return false;
     }
 
-    public static bool IsValidConventionBasedHandleMethod(IMethodSymbol method, HandlerKnownTypes knownTypes, HashSet<string> interfaceMessageTypes, INamedTypeSymbol? interfaceImplementationType = null)
+    public static bool IsValidConventionBasedHandleMethod(IMethodSymbol method, HandlerKnownTypes knownTypes, HashSet<string> interfaceMessageTypes, INamedTypeSymbol? interfaceImplementationType = null, Compilation? compilation = null)
     {
         if (method.Name != HandleMethodName ||
             method.DeclaredAccessibility != Accessibility.Public ||
@@ -69,8 +70,7 @@ static class ConventionBasedHandlerHelper
             return false;
         }
 
-        if (method.Parameters[0].Type is not INamedTypeSymbol messageType ||
-            !IsPlausibleMessageType(messageType))
+        if (method.Parameters[0].Type is not INamedTypeSymbol messageType)
         {
             return false;
         }
@@ -105,34 +105,66 @@ static class ConventionBasedHandlerHelper
             return false;
         }
 
+        // If this Handle method is called from within an interface-implementing Handle method
+        // on the same class, it is a helper, not a convention-based handler.
+        if (compilation is not null && interfaceImplementationType is not null &&
+            IsCalledFromInterfaceHandlerMethod(method, interfaceImplementationType, knownTypes, compilation))
+        {
+            return false;
+        }
+
         return true;
     }
 
-    // NServiceBus messages are user-defined types. Framework/system types (string, primitives,
-    // object, Guid, Uri, etc.) and value types can never be messages, so a Handle method whose
-    // first parameter is such a type is an unrelated helper overload, not a convention-based handler.
-    static bool IsPlausibleMessageType(INamedTypeSymbol type)
+    // If a Handle method is invoked from within any IHandleMessages<T>.Handle implementation
+    // on the same class, it is an internal helper, not a convention-based handler.
+    static bool IsCalledFromInterfaceHandlerMethod(
+        IMethodSymbol suspectMethod,
+        INamedTypeSymbol classType,
+        HandlerKnownTypes knownTypes,
+        Compilation compilation)
     {
-        if (type.SpecialType != SpecialType.None)
+        foreach (var iface in classType.AllInterfaces)
         {
-            return false;
-        }
-
-        if (type.TypeKind is not (TypeKind.Class or TypeKind.Interface))
-        {
-            return false;
-        }
-
-        return !IsInSystemNamespace(type);
-    }
-
-    static bool IsInSystemNamespace(ITypeSymbol type)
-    {
-        for (var ns = type.ContainingNamespace; ns is { IsGlobalNamespace: false }; ns = ns.ContainingNamespace)
-        {
-            if (ns.ContainingNamespace is { IsGlobalNamespace: true })
+            if (!iface.IsGenericType)
             {
-                return ns.Name == "System";
+                continue;
+            }
+
+            if (!HandlerConventions.IsHandlerInterface(iface.OriginalDefinition, knownTypes))
+            {
+                continue;
+            }
+
+            foreach (var ifaceMethod in iface.GetMembers("Handle").OfType<IMethodSymbol>())
+            {
+                var impl = classType.FindImplementationForInterfaceMember(ifaceMethod);
+                if (impl is null || SymbolEqualityComparer.Default.Equals(impl, suspectMethod))
+                {
+                    continue;
+                }
+
+                foreach (var syntaxRef in impl.DeclaringSyntaxReferences)
+                {
+                    var syntax = syntaxRef.GetSyntax();
+                    var semanticModel = compilation.GetSemanticModel(syntax.SyntaxTree);
+
+                    foreach (var invocation in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
+                    {
+                        var symbolInfo = semanticModel.GetSymbolInfo(invocation);
+                        if (symbolInfo.Symbol is IMethodSymbol invokedMethod &&
+                            SymbolEqualityComparer.Default.Equals(invokedMethod, suspectMethod))
+                        {
+                            return true;
+                        }
+
+                        if (symbolInfo.Symbol is IMethodSymbol { ReducedFrom: { } reduced } &&
+                            SymbolEqualityComparer.Default.Equals(reduced, suspectMethod))
+                        {
+                            return true;
+                        }
+                    }
+                }
             }
         }
 

--- a/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
@@ -69,7 +69,8 @@ static class ConventionBasedHandlerHelper
             return false;
         }
 
-        if (method.Parameters[0].Type is not INamedTypeSymbol messageType)
+        if (method.Parameters[0].Type is not INamedTypeSymbol messageType ||
+            !IsPlausibleMessageType(messageType))
         {
             return false;
         }
@@ -105,6 +106,37 @@ static class ConventionBasedHandlerHelper
         }
 
         return true;
+    }
+
+    // NServiceBus messages are user-defined types. Framework/system types (string, primitives,
+    // object, Guid, Uri, etc.) and value types can never be messages, so a Handle method whose
+    // first parameter is such a type is an unrelated helper overload, not a convention-based handler.
+    static bool IsPlausibleMessageType(INamedTypeSymbol type)
+    {
+        if (type.SpecialType != SpecialType.None)
+        {
+            return false;
+        }
+
+        if (type.TypeKind is not (TypeKind.Class or TypeKind.Interface))
+        {
+            return false;
+        }
+
+        return !IsInSystemNamespace(type);
+    }
+
+    static bool IsInSystemNamespace(ITypeSymbol type)
+    {
+        for (var ns = type.ContainingNamespace; ns is { IsGlobalNamespace: false }; ns = ns.ContainingNamespace)
+        {
+            if (ns.ContainingNamespace is { IsGlobalNamespace: true })
+            {
+                return ns.Name == "System";
+            }
+        }
+
+        return false;
     }
 
     static bool ImplementsHandlerInterfaceMember(IMethodSymbol method, HandlerKnownTypes knownTypes, INamedTypeSymbol? interfaceImplementationType)

--- a/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
@@ -39,6 +39,13 @@ static class ConventionBasedHandlerHelper
             }
         }
 
+        // Single pass: find all interface Handle implementations and the methods they call
+        HashSet<IMethodSymbol>? interfaceHandleCallees = null;
+        if (compilation is not null)
+        {
+            interfaceHandleCallees = CollectInterfaceHandleCallees(interfaceImplementationType, knownTypes, compilation);
+        }
+
         foreach (var member in classType.GetMembers())
         {
             if (member is not IMethodSymbol method)
@@ -46,16 +53,24 @@ static class ConventionBasedHandlerHelper
                 continue;
             }
 
-            if (IsValidConventionBasedHandleMethod(method, knownTypes, interfaceMessageTypes, interfaceImplementationType, compilation))
+            if (!IsValidConventionBasedHandleMethod(method, knownTypes, interfaceMessageTypes, interfaceImplementationType))
             {
-                return true;
+                continue;
             }
+
+            // Exclude methods that are helpers called from within an interface Handle implementation
+            if (interfaceHandleCallees is not null && interfaceHandleCallees.Contains(method))
+            {
+                continue;
+            }
+
+            return true;
         }
 
         return false;
     }
 
-    public static bool IsValidConventionBasedHandleMethod(IMethodSymbol method, HandlerKnownTypes knownTypes, HashSet<string> interfaceMessageTypes, INamedTypeSymbol? interfaceImplementationType = null, Compilation? compilation = null)
+    public static bool IsValidConventionBasedHandleMethod(IMethodSymbol method, HandlerKnownTypes knownTypes, HashSet<string> interfaceMessageTypes, INamedTypeSymbol? interfaceImplementationType = null)
     {
         if (method.Name != HandleMethodName ||
             method.DeclaredAccessibility != Accessibility.Public ||
@@ -105,25 +120,21 @@ static class ConventionBasedHandlerHelper
             return false;
         }
 
-        // If this Handle method is called from within an interface-implementing Handle method
-        // on the same class, it is a helper, not a convention-based handler.
-        if (compilation is not null && interfaceImplementationType is not null &&
-            IsCalledFromInterfaceHandlerMethod(method, interfaceImplementationType, knownTypes, compilation))
-        {
-            return false;
-        }
-
         return true;
     }
 
-    // If a Handle method is invoked from within any IHandleMessages<T>.Handle implementation
-    // on the same class, it is an internal helper, not a convention-based handler.
-    static bool IsCalledFromInterfaceHandlerMethod(
-        IMethodSymbol suspectMethod,
+    // Collects all methods that are called from within interface Handle method implementations.
+    // These are helper methods, not convention-based handlers.
+    static HashSet<IMethodSymbol> CollectInterfaceHandleCallees(
         INamedTypeSymbol classType,
         HandlerKnownTypes knownTypes,
         Compilation compilation)
     {
+        var visitedImplementations = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        var callees = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        SyntaxTree? cachedTree = null;
+        SemanticModel? cachedModel = null;
+
         foreach (var iface in classType.AllInterfaces)
         {
             if (!iface.IsGenericType)
@@ -136,10 +147,10 @@ static class ConventionBasedHandlerHelper
                 continue;
             }
 
-            foreach (var ifaceMethod in iface.GetMembers("Handle").OfType<IMethodSymbol>())
+            foreach (var ifaceMethod in iface.GetMembers(HandleMethodName).OfType<IMethodSymbol>())
             {
-                var impl = classType.FindImplementationForInterfaceMember(ifaceMethod);
-                if (impl is null || SymbolEqualityComparer.Default.Equals(impl, suspectMethod))
+                if (classType.FindImplementationForInterfaceMember(ifaceMethod) is not IMethodSymbol impl ||
+                    !visitedImplementations.Add(impl))
                 {
                     continue;
                 }
@@ -147,28 +158,32 @@ static class ConventionBasedHandlerHelper
                 foreach (var syntaxRef in impl.DeclaringSyntaxReferences)
                 {
                     var syntax = syntaxRef.GetSyntax();
-                    var semanticModel = compilation.GetSemanticModel(syntax.SyntaxTree);
+
+                    if (syntax.SyntaxTree != cachedTree)
+                    {
+                        cachedTree = syntax.SyntaxTree;
+                        cachedModel = compilation.GetSemanticModel(cachedTree);
+                    }
 
                     foreach (var invocation in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
                     {
-                        var symbolInfo = semanticModel.GetSymbolInfo(invocation);
-                        if (symbolInfo.Symbol is IMethodSymbol invokedMethod &&
-                            SymbolEqualityComparer.Default.Equals(invokedMethod, suspectMethod))
-                        {
-                            return true;
-                        }
+                        var symbolInfo = cachedModel!.GetSymbolInfo(invocation);
 
-                        if (symbolInfo.Symbol is IMethodSymbol { ReducedFrom: { } reduced } &&
-                            SymbolEqualityComparer.Default.Equals(reduced, suspectMethod))
+                        if (symbolInfo.Symbol is IMethodSymbol invokedMethod)
                         {
-                            return true;
+                            callees.Add(invokedMethod);
+
+                            if (invokedMethod.ReducedFrom is { } reduced)
+                            {
+                                callees.Add(reduced);
+                            }
                         }
                     }
                 }
             }
         }
 
-        return false;
+        return callees;
     }
 
     static bool ImplementsHandlerInterfaceMember(IMethodSymbol method, HandlerKnownTypes knownTypes, INamedTypeSymbol? interfaceImplementationType)

--- a/src/NServiceBus.Core.Analyzer/Handlers/HandlerAttributeAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/HandlerAttributeAnalyzer.cs
@@ -37,7 +37,7 @@ public class HandlerAttributeAnalyzer : DiagnosticAnalyzer
 
                 var isInterfaceBasedHandler = classType.ImplementsGenericInterface(knownTypes.IHandleMessages);
                 var isSaga = classType.ImplementsGenericType(knownTypes.SagaBase);
-                var isConventionBasedHandler = !isSaga && ConventionBasedHandlerHelper.IsConventionBasedHandlerType(classType, knownTypes);
+                var isConventionBasedHandler = !isSaga && ConventionBasedHandlerHelper.IsConventionBasedHandlerType(classType, knownTypes, context.Compilation);
 
                 if (!isInterfaceBasedHandler || isSaga)
                 {
@@ -150,7 +150,7 @@ public class HandlerAttributeAnalyzer : DiagnosticAnalyzer
                 }
 
                 // Interface-based handler: check for mixed-style (also has convention-based Handle methods)
-                if (ConventionBasedHandlerHelper.HasValidConventionBasedHandleMethods(classType, knownTypes))
+                if (ConventionBasedHandlerHelper.HasValidConventionBasedHandleMethods(classType, knownTypes, context.Compilation))
                 {
                     var classLocation = classType.GetClassIdentifierLocation(context.CancellationToken);
                     if (classLocation is not null)

--- a/src/NServiceBus.Core.Analyzer/Handlers/HandlerAttributeAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/HandlerAttributeAnalyzer.cs
@@ -37,7 +37,7 @@ public class HandlerAttributeAnalyzer : DiagnosticAnalyzer
 
                 var isInterfaceBasedHandler = classType.ImplementsGenericInterface(knownTypes.IHandleMessages);
                 var isSaga = classType.ImplementsGenericType(knownTypes.SagaBase);
-                var isConventionBasedHandler = !isSaga && ConventionBasedHandlerHelper.IsConventionBasedHandlerType(classType, knownTypes, context.Compilation);
+                var isConventionBasedHandler = !isSaga && ConventionBasedHandlerHelper.IsConventionBasedHandlerType(classType, knownTypes, context.Compilation, context.CancellationToken);
 
                 if (!isInterfaceBasedHandler || isSaga)
                 {
@@ -150,7 +150,7 @@ public class HandlerAttributeAnalyzer : DiagnosticAnalyzer
                 }
 
                 // Interface-based handler: check for mixed-style (also has convention-based Handle methods)
-                if (ConventionBasedHandlerHelper.HasValidConventionBasedHandleMethods(classType, knownTypes, context.Compilation))
+                if (ConventionBasedHandlerHelper.HasValidConventionBasedHandleMethods(classType, knownTypes, context.Compilation, context.CancellationToken))
                 {
                     var classLocation = classType.GetClassIdentifierLocation(context.CancellationToken);
                     if (classLocation is not null)

--- a/src/NServiceBus.Core.Analyzer/Handlers/Handlers.Parser.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/Handlers.Parser.cs
@@ -109,12 +109,12 @@ public static partial class Handlers
                 .ToList();
 
             // Collect message types already handled by IHandleMessages<T> interface implementations
-            var interfaceMessageTypes = new HashSet<string>(StringComparer.Ordinal);
+            var interfaceMessageTypes = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
             foreach (var @interface in handlerType.AllInterfaces.Where(IsHandlerInterface))
             {
                 if (@interface.TypeArguments[0] is INamedTypeSymbol msgType)
                 {
-                    interfaceMessageTypes.Add(msgType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+                    interfaceMessageTypes.Add(msgType);
                 }
             }
 
@@ -137,7 +137,7 @@ public static partial class Handlers
         static List<ConventionBasedMethodSpec> ParseConventionBasedMethods(
             INamedTypeSymbol handlerType,
             HandlerKnownTypes knownTypes,
-            HashSet<string> interfaceMessageTypes,
+            HashSet<ITypeSymbol> interfaceMessageTypes,
             bool includeInheritedMethods,
             CancellationToken cancellationToken)
         {


### PR DESCRIPTION
## Problem

When a class implements `IHandleMessages<T>` and also has a public helper method named `Handle` that accepts `IMessageHandlerContext`, the analyzer incorrectly flagged NSB0033 (mixed interface and convention-based handler style). Helper overloads called from within the interface Handle method implementation are not convention-based handlers.

## Fix

The analyzer now inspects the body of interface Handle method implementations and collects all methods invoked from them. Any `Handle` overload that is called from an interface Handle method is treated as a helper, not as a convention-based handler. This correctly handles block-bodied and expression-bodied interface implementations, including helpers that receive individual message properties.

The interface message type collection was also switched from string-based comparison to `SymbolEqualityComparer.Default` for robustness.

This complements #7770, which excluded methods implementing a handler-derived interface member. Standalone helper overloads implement no interface and slipped through that check.