### PR TITLE
Update licensing sources

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup Label="Private dependencies">
     <PackageReference Include="FastExpressionCompiler.Internal.src" Version="5.3.3" PrivateAssets="All" GeneratePathProperty="true" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="7.0.1" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="7.1.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Obsoletes" Version="1.0.0" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
* Backport of https://github.com/Particular/NServiceBus/pull/7810 to support license validation running in more secure environments, targeting `release-10.1` to be released in version 10.1.7