### PR TITLE
Update licensing sources

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Fody" Version="6.8.1" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.9.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="6.1.1" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="6.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="4.2.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
* Backport of https://github.com/Particular/NServiceBus/pull/7810 to support license validation running in more secure environments, targeting `release-9.2` to be released in version 9.2.12