### PR TITLE
NSB0033 incorrectly reports mixed handler style when helper overloads are called from interface Handle method

### DIFF
--- a/src/NServiceBus.Core.Analyzer.Fixes/Handlers/HandlerAttributeFixer.cs
+++ b/src/NServiceBus.Core.Analyzer.Fixes/Handlers/HandlerAttributeFixer.cs
@@ -164,7 +164,7 @@ public class HandlerAttributeFixer : CodeFixProvider
             }
 
             var isInterfaceBasedHandler = type.ImplementsGenericInterface(knownTypes.IHandleMessages);
-            var isConventionBasedHandler = !isInterfaceBasedHandler && ConventionBasedHandlerHelper.HasValidConventionBasedHandleMethods(type, knownTypes);
+            var isConventionBasedHandler = !isInterfaceBasedHandler && ConventionBasedHandlerHelper.HasValidConventionBasedHandleMethods(type, knownTypes, cancellationToken: cancellationToken);
 
             if (!isInterfaceBasedHandler && !isConventionBasedHandler)
             {

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Handlers/HandlerAttributeAnalyzerTests.cs
@@ -660,6 +660,140 @@ public class HandlerAttributeAnalyzerTests : AnalyzerTestFixture<HandlerAttribut
     }
 
     [Test]
+    public Task DoesNotReportMixedStyleForHelperMethodNamedHandleWithNonMessageFirstParameter()
+    {
+        // A pure interface-based handler with an unrelated public helper overload that happens to be
+        // named Handle and takes IMessageHandlerContext. The helper is called from the interface Handle
+        // method, so it is not a convention-based handler — this is not a mixed style.
+        var source =
+            """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            [Handler]
+            class MyHandler : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context) => Handle("text", context);
+
+                public Task Handle(string text, IMessageHandlerContext context, CancellationToken cancellation = default) =>
+                    Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage {}
+            """;
+
+        return Assert(source);
+    }
+
+    [Test]
+    public Task DoesNotReportMixedStyleForHelperWithUserDefinedTypeCalledFromInterfaceHandle()
+    {
+        // A helper with a user-defined DTO as first param that is called from the interface Handle method.
+        // The call-site analysis detects the invocation, so this is not a mixed style.
+        var source =
+            """
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            class MyDto {}
+
+            [Handler]
+            class MyHandler : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context) => Handle(new MyDto(), context);
+
+                public Task Handle(MyDto dto, IMessageHandlerContext context) => Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage {}
+            """;
+
+        return Assert(source);
+    }
+
+    [Test]
+    public Task DoesNotReportMixedStyleForHelperCalledFromBlockBodiedInterfaceHandle()
+    {
+        // Same pattern but with a block-bodied interface Handle method.
+        var source =
+            """
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            [Handler]
+            class MyHandler : IHandleMessages<MyMessage>
+            {
+                public async Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    await Handle("text", context);
+                }
+
+                public Task Handle(string text, IMessageHandlerContext context) => Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage {}
+            """;
+
+        return Assert(source);
+    }
+
+    [Test]
+    public Task ReportsMixedStyleWhenConventionBasedMethodNotCalledFromInterfaceHandle()
+    {
+        // A convention-based Handle method that is NOT called from the interface Handle method
+        // should still be reported as mixed style.
+        var source =
+            """
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            [Handler]
+            class [|MyHandler|] : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context) => Task.CompletedTask;
+
+                public Task Handle(OtherMessage message, IMessageHandlerContext context) => Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage {}
+            class OtherMessage : IMessage {}
+            """;
+
+        return Assert(source, DiagnosticIds.ConventionBasedHandlerMixedStyle);
+    }
+
+    [Test]
+    public Task DoesNotReportMixedStyleForHelperPassingMessageProperties()
+    {
+        // A helper that receives individual properties extracted from the message.
+        // The call-site analysis detects it is called from the interface Handle method.
+        var source =
+            """
+            using System.Threading.Tasks;
+            using NServiceBus;
+
+            [Handler]
+            class MyHandler : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context) =>
+                    Handle(message.Id, message.Name, context);
+
+                public Task Handle(string id, string name, IMessageHandlerContext context) =>
+                    Task.CompletedTask;
+            }
+
+            class MyMessage : IMessage
+            {
+                public string Id { get; set; }
+                public string Name { get; set; }
+            }
+            """;
+
+        return Assert(source);
+    }
+
+    [Test]
     public Task DoesNotReportConventionBasedHandlerImplementingUnrelatedInterfaceWithHandleMethod()
     {
         var source =

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/NServiceBus.Core.Analyzer.Tests.Roslyn5.csproj
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/NServiceBus.Core.Analyzer.Tests.Roslyn5.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="Particular.AnalyzerTesting" Version="2.0.0" />
+    <PackageReference Include="Particular.AnalyzerTesting" Version="2.1.0" />
     <PackageReference Include="Particular.Approvals" Version="2.0.1" />
   </ItemGroup>
 

--- a/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/ConventionBasedHandlerHelper.cs
@@ -4,17 +4,24 @@ namespace NServiceBus.Core.Analyzer.Handlers;
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 static class ConventionBasedHandlerHelper
 {
     public const string HandleMethodName = "Handle";
 
-    public static bool IsConventionBasedHandlerType(INamedTypeSymbol classType, HandlerKnownTypes knownTypes)
+    public static bool IsConventionBasedHandlerType(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, Compilation? compilation = null, CancellationToken cancellationToken = default)
     {
+        var interfaceMessageTypes = CollectInterfaceMessageTypes(classType, knownTypes);
+        var interfaceHandleCallees = compilation is null
+            ? null
+            : CollectInterfaceHandleCallees(classType, knownTypes, compilation, cancellationToken);
+
         for (var current = classType; current is not null; current = current.BaseType)
         {
-            if (HasValidConventionBasedHandleMethods(current, knownTypes, classType))
+            if (HasValidConventionBasedHandleMethods(current, knownTypes, interfaceMessageTypes, interfaceHandleCallees))
             {
                 return true;
             }
@@ -23,21 +30,13 @@ static class ConventionBasedHandlerHelper
         return false;
     }
 
-    public static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes) =>
-        HasValidConventionBasedHandleMethods(classType, knownTypes, classType);
+    public static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, Compilation? compilation = null, CancellationToken cancellationToken = default) =>
+        HasValidConventionBasedHandleMethods(classType, knownTypes,
+            CollectInterfaceMessageTypes(classType, knownTypes),
+            compilation is null ? null : CollectInterfaceHandleCallees(classType, knownTypes, compilation, cancellationToken));
 
-    static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, INamedTypeSymbol interfaceImplementationType)
+    static bool HasValidConventionBasedHandleMethods(INamedTypeSymbol classType, HandlerKnownTypes knownTypes, HashSet<ITypeSymbol> interfaceMessageTypes, HashSet<IMethodSymbol>? interfaceHandleCallees)
     {
-        var interfaceMessageTypes = new HashSet<string>(System.StringComparer.Ordinal);
-        foreach (var iface in interfaceImplementationType.AllInterfaces)
-        {
-            if (iface.IsGenericType && HandlerConventions.IsHandlerInterface(iface.OriginalDefinition, knownTypes) &&
-                iface.TypeArguments[0] is INamedTypeSymbol msgType)
-            {
-                interfaceMessageTypes.Add(msgType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
-            }
-        }
-
         foreach (var member in classType.GetMembers())
         {
             if (member is not IMethodSymbol method)
@@ -45,16 +44,25 @@ static class ConventionBasedHandlerHelper
                 continue;
             }
 
-            if (IsValidConventionBasedHandleMethod(method, knownTypes, interfaceMessageTypes, interfaceImplementationType))
+            if (!IsValidConventionBasedHandleMethod(method, knownTypes, interfaceMessageTypes))
             {
-                return true;
+                continue;
             }
+
+            // Exclude methods that are helpers called from within an interface Handle implementation
+            if (interfaceHandleCallees is not null &&
+                (interfaceHandleCallees.Contains(method) || interfaceHandleCallees.Contains(method.OriginalDefinition)))
+            {
+                continue;
+            }
+
+            return true;
         }
 
         return false;
     }
 
-    public static bool IsValidConventionBasedHandleMethod(IMethodSymbol method, HandlerKnownTypes knownTypes, HashSet<string> interfaceMessageTypes, INamedTypeSymbol? interfaceImplementationType = null)
+    public static bool IsValidConventionBasedHandleMethod(IMethodSymbol method, HandlerKnownTypes knownTypes, HashSet<ITypeSymbol> interfaceMessageTypes, INamedTypeSymbol? interfaceImplementationType = null)
     {
         if (method.Name != HandleMethodName ||
             method.DeclaredAccessibility != Accessibility.Public ||
@@ -88,12 +96,12 @@ static class ConventionBasedHandlerHelper
         }
 
         // If the class implements IHandleMessages<T> for this exact message type with exactly 2 params,
-        // this Handle method is the interface implementation — not a convention-based method.
-        var messageTypeFqn = messageType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        if (method.Parameters.Length == 2 && interfaceMessageTypes.Contains(messageTypeFqn))
+        // this Handle method is the interface implementation, not a convention-based method.
+        if (method.Parameters.Length == 2 && interfaceMessageTypes.Contains(messageType))
         {
             return false;
         }
+
 
         // If this Handle method is the implementation of an interface member that belongs to a handler
         // interface hierarchy (IHandleMessages<T>, IHandleTimeouts<T>, IAmStartedByMessages<T>, or an
@@ -105,6 +113,96 @@ static class ConventionBasedHandlerHelper
         }
 
         return true;
+    }
+
+    static HashSet<ITypeSymbol> CollectInterfaceMessageTypes(INamedTypeSymbol classType, HandlerKnownTypes knownTypes)
+    {
+        var messageTypes = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
+        foreach (var iface in classType.AllInterfaces)
+        {
+            if (iface.IsGenericType && HandlerConventions.IsHandlerInterface(iface.OriginalDefinition, knownTypes) &&
+                iface.TypeArguments[0] is INamedTypeSymbol msgType)
+            {
+                messageTypes.Add(msgType);
+            }
+        }
+
+        return messageTypes;
+    }
+
+    // Collects all methods that are called from within interface Handle method implementations.
+    // These are helper methods, not convention-based handlers.
+    static HashSet<IMethodSymbol> CollectInterfaceHandleCallees(
+        INamedTypeSymbol classType,
+        HandlerKnownTypes knownTypes,
+        Compilation compilation,
+        CancellationToken cancellationToken)
+    {
+        var visitedImplementations = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        var callees = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        SyntaxTree? cachedTree = null;
+        SemanticModel? cachedModel = null;
+
+        foreach (var iface in classType.AllInterfaces)
+        {
+            if (!iface.IsGenericType)
+            {
+                continue;
+            }
+
+            if (!HandlerConventions.IsHandlerInterface(iface.OriginalDefinition, knownTypes))
+            {
+                continue;
+            }
+
+            foreach (var member in iface.GetMembers(HandleMethodName))
+            {
+                if (member is not IMethodSymbol ifaceMethod)
+                {
+                    continue;
+                }
+
+                if (classType.FindImplementationForInterfaceMember(ifaceMethod) is not IMethodSymbol impl)
+                {
+                    continue;
+                }
+
+                if (!visitedImplementations.Add(impl))
+                {
+                    continue;
+                }
+
+                foreach (var syntaxRef in impl.DeclaringSyntaxReferences)
+                {
+                    var syntax = syntaxRef.GetSyntax(cancellationToken);
+
+                    if (!ReferenceEquals(syntax.SyntaxTree, cachedTree))
+                    {
+                        cachedTree = syntax.SyntaxTree;
+                        cachedModel = compilation.GetSemanticModel(cachedTree);
+                    }
+
+                    foreach (var invocation in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
+                    {
+                        if (cachedModel!.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol invokedMethod)
+                        {
+                            continue;
+                        }
+
+                        callees.Add(invokedMethod);
+                        callees.Add(invokedMethod.OriginalDefinition);
+
+                        if (invokedMethod.ReducedFrom is { } reduced)
+                        {
+                            callees.Add(reduced);
+                            callees.Add(reduced.OriginalDefinition);
+                        }
+                    }
+                }
+            }
+        }
+
+        return callees;
     }
 
     static bool ImplementsHandlerInterfaceMember(IMethodSymbol method, HandlerKnownTypes knownTypes, INamedTypeSymbol? interfaceImplementationType)
@@ -138,8 +236,13 @@ static class ConventionBasedHandlerHelper
                 continue;
             }
 
-            foreach (var interfaceMethod in iface.GetMembers(method.Name).OfType<IMethodSymbol>())
+            foreach (var member in iface.GetMembers(method.Name))
             {
+                if (member is not IMethodSymbol interfaceMethod)
+                {
+                    continue;
+                }
+
                 if (interfaceMethod.Parameters.Length != method.Parameters.Length)
                 {
                     continue;

--- a/src/NServiceBus.Core.Analyzer/Handlers/HandlerAttributeAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/HandlerAttributeAnalyzer.cs
@@ -37,7 +37,7 @@ public class HandlerAttributeAnalyzer : DiagnosticAnalyzer
 
                 var isInterfaceBasedHandler = classType.ImplementsGenericInterface(knownTypes.IHandleMessages);
                 var isSaga = classType.ImplementsGenericType(knownTypes.SagaBase);
-                var isConventionBasedHandler = !isSaga && ConventionBasedHandlerHelper.IsConventionBasedHandlerType(classType, knownTypes);
+                var isConventionBasedHandler = !isSaga && ConventionBasedHandlerHelper.IsConventionBasedHandlerType(classType, knownTypes, context.Compilation, context.CancellationToken);
 
                 if (!isInterfaceBasedHandler || isSaga)
                 {
@@ -150,7 +150,7 @@ public class HandlerAttributeAnalyzer : DiagnosticAnalyzer
                 }
 
                 // Interface-based handler: check for mixed-style (also has convention-based Handle methods)
-                if (ConventionBasedHandlerHelper.HasValidConventionBasedHandleMethods(classType, knownTypes))
+                if (ConventionBasedHandlerHelper.HasValidConventionBasedHandleMethods(classType, knownTypes, context.Compilation, context.CancellationToken))
                 {
                     var classLocation = classType.GetClassIdentifierLocation(context.CancellationToken);
                     if (classLocation is not null)

--- a/src/NServiceBus.Core.Analyzer/Handlers/Handlers.Parser.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/Handlers.Parser.cs
@@ -109,12 +109,12 @@ public static partial class Handlers
                 .ToList();
 
             // Collect message types already handled by IHandleMessages<T> interface implementations
-            var interfaceMessageTypes = new HashSet<string>(StringComparer.Ordinal);
+            var interfaceMessageTypes = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
             foreach (var @interface in handlerType.AllInterfaces.Where(IsHandlerInterface))
             {
                 if (@interface.TypeArguments[0] is INamedTypeSymbol msgType)
                 {
-                    interfaceMessageTypes.Add(msgType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+                    interfaceMessageTypes.Add(msgType);
                 }
             }
 
@@ -137,7 +137,7 @@ public static partial class Handlers
         static List<ConventionBasedMethodSpec> ParseConventionBasedMethods(
             INamedTypeSymbol handlerType,
             HandlerKnownTypes knownTypes,
-            HashSet<string> interfaceMessageTypes,
+            HashSet<ITypeSymbol> interfaceMessageTypes,
             bool includeInheritedMethods,
             CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus/pull/7807 to `release-10.2`

Also brings in https://github.com/Particular/NServiceBus/pull/7808