### PR TITLE
Regression test for null baggage value (#6983)

### DIFF
--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ContextPropagationTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ContextPropagationTests.cs
@@ -81,6 +81,22 @@ public class ContextPropagationTests
         Assert.That(activity.Id, Is.EqualTo(headers[Headers.DiagnosticsTraceParent]));
     }
 
+    [Test]
+    public void Should_not_throw_when_baggage_value_is_null()
+    {
+        // Reproduces https://github.com/Particular/NServiceBus/issues/6983
+        // A baggage item with a null value used to make the hand-written propagator call
+        // Uri.EscapeDataString(null), throwing ArgumentNullException while sending a message.
+        using var activity = new Activity(ActivityNames.OutgoingMessageActivityName);
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        activity.Start();
+        activity.AddBaggage("test", null);
+
+        var headers = new Dictionary<string, string>();
+
+        Assert.DoesNotThrow(() => ContextPropagation.PropagateContextToHeaders(activity, headers, new ContextBag()));
+    }
+
     [TestCaseSource(nameof(TestCases))]
     public void Can_propagate_baggage_from_header_to_activity(ContextPropagationTestCase testCase)
     {


### PR DESCRIPTION
Resolves: #6983

## Summary

Adds a regression test for [#6983](https://github.com/Particular/NServiceBus/issues/6983): `ContextPropagation` threw `ArgumentNullException` when `Activity.Current.Baggage` contained a key with a **null** value, because the old hand-written propagator called `Uri.EscapeDataString(item.Value)` on null.

The root cause is already fixed on the `otel` branch by the switch to `DistributedContextPropagator.Current.Inject` (commit bba80f7bd), which serializes baggage via the null-tolerant `WebUtility.UrlEncode`. A null value is now emitted as an empty string instead of throwing.

This PR only adds a test that pins that behavior so it can't silently regress.

## What it covers

`Should_not_throw_when_baggage_value_is_null` — adds `AddBaggage("test", null)` to an outgoing activity and asserts `PropagateContextToHeaders` does not throw.

## Verification

- New test passes against the `otel` branch.
- Verified standalone that `DistributedContextPropagator.Current.Inject` produces `baggage = "test = "` (empty value) for a null baggage value with no exception.

## Notes

- No production code change — `otel` already contains the fix.
- The originally reported 8.x release line still carries the vulnerable `Uri.EscapeDataString` code; a backport may be worth considering separately.

Targets the `otel` branch as requested.