### PR TITLE
Support AOT and trimming compliance in SystemJson serializer and Learning Saga Persister

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -645,6 +645,7 @@ namespace NServiceBus
     public class LearningPersistence : NServiceBus.Persistence.PersistenceDefinition, NServiceBus.Persistence.IPersistenceDefinitionFactory<NServiceBus.LearningPersistence> { }
     public static class LearningSagaPersisterConfigurationExtensions
     {
+        public static void SagaSerializerOptions(this NServiceBus.PersistenceExtensions<NServiceBus.LearningPersistence> persistenceExtensions, System.Text.Json.JsonSerializerOptions options) { }
         public static void SagaStorageDirectory(this NServiceBus.PersistenceExtensions<NServiceBus.LearningPersistence> persistenceExtensions, string path) { }
     }
     public class LearningTransport : NServiceBus.Transport.TransportDefinition

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/TrimmabilityWarnings.ApproveTrimmabilityWarnings.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/TrimmabilityWarnings.ApproveTrimmabilityWarnings.approved.txt
@@ -45,10 +45,6 @@ src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/NamespacePublisherSource
 src/NServiceBus.Core/Routing/NamespaceRouteSource.cs
   IL2026: Using member 'System.Reflection.Assembly.GetTypes()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types might be removed.
 
-src/NServiceBus.Core/Serializers/SystemJson/JsonMessageSerializer.cs
-  IL2026: Using member 'System.Text.Json.JsonSerializer.Deserialize(Stream, Type, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
-  IL2026: Using member 'System.Text.Json.JsonSerializer.Serialize<TValue>(Stream, TValue, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
-
 src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
   IL2070: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'. The parameter 'messageType' of method 'NServiceBus.LearningTransportDispatcher.GetPotentialEventTypes(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/TrimmabilityWarnings.ApproveTrimmabilityWarnings.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/TrimmabilityWarnings.ApproveTrimmabilityWarnings.approved.txt
@@ -19,10 +19,6 @@ src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriter.cs
 src/NServiceBus.Core/Hosting/StartupDiagnostics/JsonPrettyPrinter.cs
   IL2026: Using member 'System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
 
-src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
-  IL2026: Using member 'System.Text.Json.JsonSerializer.DeserializeAsync<TValue>(Stream, JsonSerializerOptions, CancellationToken)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
-  IL2026: Using member 'System.Text.Json.JsonSerializer.SerializeAsync(Stream, Object, Type, JsonSerializerOptions, CancellationToken)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
-
 src/NServiceBus.Core/Pipeline/RegisterStep.cs
   IL2072: 'instanceType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(IServiceProvider, Type, params Object[])'. The return value of method 'NServiceBus.Pipeline.RegisterStep.BehaviorType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
 

--- a/src/NServiceBus.Core.Tests/StandardsTests.cs
+++ b/src/NServiceBus.Core.Tests/StandardsTests.cs
@@ -51,15 +51,12 @@ public class StandardsTests
         }
     }
 
-    static bool IsCompilerGenerated(Type x)
-    {
-        return Attribute.IsDefined(x, typeof(CompilerGeneratedAttribute), false);
-    }
+    static bool IsCompilerGenerated(Type x) => Attribute.IsDefined(x, typeof(CompilerGeneratedAttribute), false);
 
     [Test]
     public void LoggersShouldBeStaticField()
     {
-        foreach (var type in typeof(EndpointCreator).Assembly.GetTypes())
+        foreach (var type in typeof(EndpointCreator).Assembly.GetTypes().Where(t => !IsCompilerGenerated(t)))
         {
             // Logging namespace contains special adapter types that are not expected to have static loggers
             if (type.Namespace == "NServiceBus.Logging")
@@ -100,20 +97,15 @@ public class StandardsTests
         }
     }
 
-    static IEnumerable<Type> GetBehaviors()
-    {
-        return typeof(EndpointCreator).Assembly.GetTypes()
+    static IEnumerable<Type> GetBehaviors() =>
+        typeof(EndpointCreator).Assembly.GetTypes()
             .Where(type => type.GetInterfaces().Any(face => face.Name == nameof(NServiceBus.Pipeline.IBehavior)) && !type.IsAbstract && !type.IsGenericType);
-    }
-    static IEnumerable<Type> GetFeatures()
-    {
-        return typeof(EndpointCreator).Assembly.GetTypes()
-            .Where(type => typeof(Feature).IsAssignableFrom(type) && type.IsPublic && !type.IsAbstract);
-    }
 
-    static IEnumerable<Type> GetAttributeTypes()
-    {
-        return typeof(EndpointCreator).Assembly.GetTypes()
+    static IEnumerable<Type> GetFeatures() =>
+        typeof(EndpointCreator).Assembly.GetTypes()
+            .Where(type => typeof(Feature).IsAssignableFrom(type) && type.IsPublic && !type.IsAbstract);
+
+    static IEnumerable<Type> GetAttributeTypes() =>
+        typeof(EndpointCreator).Assembly.GetTypes()
             .Where(type => typeof(Attribute).IsAssignableFrom(type));
-    }
 }

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/LearningSagaPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/LearningSagaPersistence.cs
@@ -3,6 +3,7 @@
 namespace NServiceBus.Features;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -36,10 +37,21 @@ sealed class LearningSagaPersistence : Feature
         context.Services.AddSingleton<ISagaPersister, LearningSagaPersister>();
     }
 
-    static JsonSerializerOptions GetDefaultOptions() => new()
+    static JsonSerializerOptions GetDefaultOptions()
     {
-        Converters = { new JsonStringEnumConverter() }
-    };
+        var options = new JsonSerializerOptions();
+        if (JsonSerializer.IsReflectionEnabledByDefault)
+        {
+            options.Converters.Add(CreateDefaultConverter());
+        }
+        return options;
+    }
+
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Only used when System.Text.Json reflection is enabled.")]
+    static JsonStringEnumConverter CreateDefaultConverter() => new();
 
     internal static readonly string StorageLocationKey = "LearningSagaPersistence.StorageLocation";
     internal static readonly string SerializerOptionsKey = "LearningSagaPersistence.SerializerOptions";

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/LearningSagaPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/LearningSagaPersistence.cs
@@ -4,6 +4,8 @@ namespace NServiceBus.Features;
 
 using System;
 using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using NServiceBus.Sagas;
 
@@ -26,12 +28,19 @@ sealed class LearningSagaPersistence : Feature
     protected override void Setup(FeatureConfigurationContext context)
     {
         var storageLocation = context.Settings.Get<string>(StorageLocationKey);
+        var serializerOptions = context.Settings.GetOrDefault<JsonSerializerOptions>(SerializerOptionsKey) ?? GetDefaultOptions();
 
         var allSagas = context.Settings.Get<SagaMetadataCollection>();
 
-        context.Services.AddSingleton(new SagaManifestCollection(allSagas, storageLocation, sagaName => sagaName.Replace("+", "")));
+        context.Services.AddSingleton(new SagaManifestCollection(allSagas, storageLocation, sagaName => sagaName.Replace("+", ""), serializerOptions));
         context.Services.AddSingleton<ISagaPersister, LearningSagaPersister>();
     }
 
+    static JsonSerializerOptions GetDefaultOptions() => new()
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
     internal static readonly string StorageLocationKey = "LearningSagaPersistence.StorageLocation";
+    internal static readonly string SerializerOptionsKey = "LearningSagaPersistence.SerializerOptions";
 }

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/LearningSagaPersisterConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/LearningSagaPersisterConfigurationExtensions.cs
@@ -3,6 +3,7 @@
 namespace NServiceBus;
 
 using System;
+using System.Text.Json;
 using Features;
 
 /// <summary>
@@ -21,5 +22,18 @@ public static class LearningSagaPersisterConfigurationExtensions
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
         persistenceExtensions.Settings.Set(LearningSagaPersistence.StorageLocationKey, path);
+    }
+
+    /// <summary>
+    /// Configures the <see cref="JsonSerializerOptions" /> to use for serializing saga data.
+    /// </summary>
+    /// <param name="persistenceExtensions">The persistence extensions to extend.</param>
+    /// <param name="options">The <see cref="JsonSerializerOptions" /> to use.</param>
+    public static void SagaSerializerOptions(this PersistenceExtensions<LearningPersistence> persistenceExtensions, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(persistenceExtensions);
+        ArgumentNullException.ThrowIfNull(options);
+
+        persistenceExtensions.Settings.Set(LearningSagaPersistence.SerializerOptionsKey, options);
     }
 }

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaManifest.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaManifest.cs
@@ -4,11 +4,13 @@ namespace NServiceBus;
 
 using System;
 using System.IO;
+using System.Text.Json;
 
 class SagaManifest
 {
     public required string StorageDirectory { get; init; }
     public required Type SagaEntityType { get; init; }
+    public required JsonSerializerOptions SerializerOptions { get; init; }
 
     public string GetFilePath(Guid sagaId) => Path.Combine(StorageDirectory, sagaId + ".json");
 }

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaManifestCollection.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaManifestCollection.cs
@@ -5,11 +5,12 @@ namespace NServiceBus;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
 using Sagas;
 
 class SagaManifestCollection
 {
-    public SagaManifestCollection(SagaMetadataCollection sagas, string storageLocation, Func<string, string> sagaNameConverter)
+    public SagaManifestCollection(SagaMetadataCollection sagas, string storageLocation, Func<string, string> sagaNameConverter, JsonSerializerOptions serializerOptions)
     {
         foreach (var metadata in sagas)
         {
@@ -23,7 +24,8 @@ class SagaManifestCollection
             var manifest = new SagaManifest
             {
                 StorageDirectory = sagaStorageDir,
-                SagaEntityType = metadata.SagaEntityType
+                SagaEntityType = metadata.SagaEntityType,
+                SerializerOptions = serializerOptions
             };
 
             sagaManifests[metadata.SagaEntityType] = manifest;

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaManifestCollection.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaManifestCollection.cs
@@ -12,6 +12,7 @@ class SagaManifestCollection
 {
     public SagaManifestCollection(SagaMetadataCollection sagas, string storageLocation, Func<string, string> sagaNameConverter, JsonSerializerOptions? serializerOptions = null)
     {
+        serializerOptions ??= new JsonSerializerOptions();
         foreach (var metadata in sagas)
         {
             var sagaStorageDir = Path.Combine(storageLocation, sagaNameConverter(metadata.SagaType.FullName!));
@@ -25,7 +26,7 @@ class SagaManifestCollection
             {
                 StorageDirectory = sagaStorageDir,
                 SagaEntityType = metadata.SagaEntityType,
-                SerializerOptions = serializerOptions ?? JsonSerializerOptions.Default
+                SerializerOptions = serializerOptions
             };
 
             sagaManifests[metadata.SagaEntityType] = manifest;

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaManifestCollection.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaManifestCollection.cs
@@ -10,7 +10,7 @@ using Sagas;
 
 class SagaManifestCollection
 {
-    public SagaManifestCollection(SagaMetadataCollection sagas, string storageLocation, Func<string, string> sagaNameConverter, JsonSerializerOptions serializerOptions)
+    public SagaManifestCollection(SagaMetadataCollection sagas, string storageLocation, Func<string, string> sagaNameConverter, JsonSerializerOptions? serializerOptions = null)
     {
         foreach (var metadata in sagas)
         {
@@ -25,7 +25,7 @@ class SagaManifestCollection
             {
                 StorageDirectory = sagaStorageDir,
                 SagaEntityType = metadata.SagaEntityType,
-                SerializerOptions = serializerOptions
+                SerializerOptions = serializerOptions ?? JsonSerializerOptions.Default
             };
 
             sagaManifests[metadata.SagaEntityType] = manifest;

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
@@ -3,15 +3,20 @@
 namespace NServiceBus;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
-using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 
 class SagaStorageFile : IDisposable, IAsyncDisposable
 {
-    SagaStorageFile(FileStream fileStream) => this.fileStream = fileStream;
+    SagaStorageFile(FileStream fileStream, JsonSerializerOptions options)
+    {
+        this.fileStream = fileStream;
+        this.options = options;
+    }
 
     public void Dispose()
     {
@@ -58,17 +63,17 @@ class SagaStorageFile : IDisposable, IAsyncDisposable
             return noSagaFoundResult;
         }
 
-        return OpenWithRetryOnConcurrency(filePath, FileMode.Open, cancellationToken)!;
+        return OpenWithRetryOnConcurrency(filePath, FileMode.Open, manifest.SerializerOptions, cancellationToken)!;
     }
 
     public static Task<SagaStorageFile> Create(Guid sagaId, SagaManifest manifest, CancellationToken cancellationToken = default)
     {
         var filePath = manifest.GetFilePath(sagaId);
 
-        return OpenWithRetryOnConcurrency(filePath, FileMode.CreateNew, cancellationToken);
+        return OpenWithRetryOnConcurrency(filePath, FileMode.CreateNew, manifest.SerializerOptions, cancellationToken);
     }
 
-    static async Task<SagaStorageFile> OpenWithRetryOnConcurrency(string filePath, FileMode fileAccess, CancellationToken cancellationToken)
+    static async Task<SagaStorageFile> OpenWithRetryOnConcurrency(string filePath, FileMode fileAccess, JsonSerializerOptions options, CancellationToken cancellationToken)
     {
         var numRetries = 0;
 
@@ -78,7 +83,7 @@ class SagaStorageFile : IDisposable, IAsyncDisposable
 
             try
             {
-                return new SagaStorageFile(new FileStream(filePath, fileAccess, FileAccess.ReadWrite, FileShare.None, DefaultBufferSize, FileOptions.Asynchronous));
+                return new SagaStorageFile(new FileStream(filePath, fileAccess, FileAccess.ReadWrite, FileShare.None, DefaultBufferSize, FileOptions.Asynchronous), options);
             }
             catch (IOException)
             {
@@ -101,8 +106,19 @@ class SagaStorageFile : IDisposable, IAsyncDisposable
         ObjectDisposedException.ThrowIf(fileStream is null, this);
 
         fileStream.Position = 0;
-        await JsonSerializer.SerializeAsync(fileStream, sagaData, sagaData.GetType(), Options, cancellationToken)
-            .ConfigureAwait(false);
+
+        var sagaDataType = sagaData.GetType();
+        var typeInfo = ResolveTypeInfo(sagaDataType, options);
+        if (typeInfo is not null)
+        {
+            await JsonSerializer.SerializeAsync(fileStream, sagaData, typeInfo, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        else
+        {
+            await SerializeWithReflectionAsync(fileStream, sagaData, sagaDataType, options, cancellationToken)
+                .ConfigureAwait(false);
+        }
 
         // Because the file is opened in ReadWrite mode, leftover content from last write
         // could be left behind if the new content is shorter.
@@ -115,17 +131,62 @@ class SagaStorageFile : IDisposable, IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(fileStream is null, this);
 
-        return JsonSerializer.DeserializeAsync<TSagaData>(fileStream, Options, cancellationToken);
+        var typeInfo = ResolveTypeInfo(typeof(TSagaData), options);
+        if (typeInfo is not null)
+        {
+            return ReadWithTypeInfoAsync<TSagaData>(fileStream, typeInfo, cancellationToken);
+        }
+        else
+        {
+            return DeserializeWithReflectionAsync<TSagaData>(fileStream, options, cancellationToken);
+        }
     }
 
+    static async ValueTask<TSagaData?> ReadWithTypeInfoAsync<TSagaData>(Stream stream, JsonTypeInfo typeInfo, CancellationToken cancellationToken) where TSagaData : class
+        => (TSagaData?)await JsonSerializer.DeserializeAsync(stream, typeInfo, cancellationToken).ConfigureAwait(false);
+
+    static JsonTypeInfo? ResolveTypeInfo(Type runtimeType, JsonSerializerOptions? options)
+    {
+        if (options is null)
+        {
+            return null;
+        }
+
+        var typeInfo = options.TypeInfoResolver?.GetTypeInfo(runtimeType, options);
+        if (typeInfo is not null)
+        {
+            return typeInfo;
+        }
+
+        return JsonSerializer.IsReflectionEnabledByDefault ? null : throw new InvalidOperationException($"No JSON metadata was found for '{runtimeType.FullName}'.");
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Only called when System.Text.Json reflection serialization is enabled.")]
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Only called when System.Text.Json reflection serialization is enabled.")]
+    static Task SerializeWithReflectionAsync(Stream stream, object value, Type inputType, JsonSerializerOptions options, CancellationToken cancellationToken)
+        => JsonSerializer.SerializeAsync(stream, value, inputType, options, cancellationToken);
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Only called when System.Text.Json reflection serialization is enabled.")]
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Only called when System.Text.Json reflection serialization is enabled.")]
+    static async ValueTask<TSagaData?> DeserializeWithReflectionAsync<TSagaData>(Stream stream, JsonSerializerOptions options, CancellationToken cancellationToken) where TSagaData : class
+        => (TSagaData?)await JsonSerializer.DeserializeAsync(stream, typeof(TSagaData), options, cancellationToken).ConfigureAwait(false);
+
     FileStream? fileStream;
+    readonly JsonSerializerOptions options;
     bool isCompleted;
 
     const int DefaultBufferSize = 4096;
     static readonly Task<SagaStorageFile?> noSagaFoundResult = Task.FromResult<SagaStorageFile?>(null);
-
-    static readonly JsonSerializerOptions Options = new()
-    {
-        Converters = { new JsonStringEnumConverter() }
-    };
 }

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
@@ -108,7 +108,7 @@ class SagaStorageFile : IDisposable, IAsyncDisposable
         fileStream.Position = 0;
 
         var sagaDataType = sagaData.GetType();
-        var typeInfo = ResolveTypeInfo(sagaDataType, options);
+        var typeInfo = options.ResolveTypeInfo(sagaDataType);
         if (typeInfo is not null)
         {
             await JsonSerializer.SerializeAsync(fileStream, sagaData, typeInfo, cancellationToken)
@@ -131,7 +131,7 @@ class SagaStorageFile : IDisposable, IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(fileStream is null, this);
 
-        var typeInfo = ResolveTypeInfo(typeof(TSagaData), options);
+        var typeInfo = options.ResolveTypeInfo(typeof(TSagaData));
         if (typeInfo is not null)
         {
             return ReadWithTypeInfoAsync<TSagaData>(fileStream, typeInfo, cancellationToken);
@@ -144,22 +144,6 @@ class SagaStorageFile : IDisposable, IAsyncDisposable
 
     static async ValueTask<TSagaData?> ReadWithTypeInfoAsync<TSagaData>(Stream stream, JsonTypeInfo typeInfo, CancellationToken cancellationToken) where TSagaData : class
         => (TSagaData?)await JsonSerializer.DeserializeAsync(stream, typeInfo, cancellationToken).ConfigureAwait(false);
-
-    static JsonTypeInfo? ResolveTypeInfo(Type runtimeType, JsonSerializerOptions? options)
-    {
-        if (options is null)
-        {
-            return null;
-        }
-
-        var typeInfo = options.TypeInfoResolver?.GetTypeInfo(runtimeType, options);
-        if (typeInfo is not null)
-        {
-            return typeInfo;
-        }
-
-        return JsonSerializer.IsReflectionEnabledByDefault ? null : throw new InvalidOperationException($"No JSON metadata was found for '{runtimeType.FullName}'.");
-    }
 
     [UnconditionalSuppressMessage(
         "Trimming",

--- a/src/NServiceBus.Core/Serializers/JsonSerializerOptionsExtensions.cs
+++ b/src/NServiceBus.Core/Serializers/JsonSerializerOptionsExtensions.cs
@@ -1,0 +1,24 @@
+﻿#nullable enable
+
+namespace NServiceBus;
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+static class JsonSerializerOptionsExtensions
+{
+    extension(JsonSerializerOptions? options)
+    {
+        public JsonTypeInfo? ResolveTypeInfo(Type runtimeType)
+        {
+            var typeInfo = options?.TypeInfoResolver?.GetTypeInfo(runtimeType, options);
+            if (typeInfo is not null)
+            {
+                return typeInfo;
+            }
+
+            return JsonSerializer.IsReflectionEnabledByDefault ? null : throw new InvalidOperationException($"No JSON metadata was found for '{runtimeType.FullName}'.");
+        }
+    }
+}

--- a/src/NServiceBus.Core/Serializers/SystemJson/JsonMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/SystemJson/JsonMessageSerializer.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Serialization.Metadata;
 using NServiceBus.MessageInterfaces;
 using NServiceBus.Serialization;
 
@@ -31,7 +30,7 @@ class JsonMessageSerializer : IMessageSerializer
     public void Serialize(object message, Stream stream)
     {
         var messageType = message.GetType();
-        var typeInfo = ResolveTypeInfo(messageType, serializerOptions);
+        var typeInfo = serializerOptions.ResolveTypeInfo(messageType);
         if (typeInfo is not null)
         {
             JsonSerializer.Serialize(stream, message, typeInfo);
@@ -62,7 +61,7 @@ class JsonMessageSerializer : IMessageSerializer
     object Deserialize(ReadOnlyMemory<byte> body, Type type)
     {
         var actualType = GetMappedType(type);
-        var typeInfo = ResolveTypeInfo(actualType, serializerOptions);
+        var typeInfo = serializerOptions.ResolveTypeInfo(actualType);
         if (typeInfo is not null)
         {
             using var stream = new ReadOnlyStream(body);
@@ -73,22 +72,6 @@ class JsonMessageSerializer : IMessageSerializer
             using var stream = new ReadOnlyStream(body);
             return DeserializeWithReflection(stream, actualType, serializerOptions)!;
         }
-    }
-
-    static JsonTypeInfo? ResolveTypeInfo(Type runtimeType, JsonSerializerOptions? options)
-    {
-        if (options is null)
-        {
-            return null;
-        }
-
-        var typeInfo = options.TypeInfoResolver?.GetTypeInfo(runtimeType, options);
-        if (typeInfo is not null)
-        {
-            return typeInfo;
-        }
-
-        return JsonSerializer.IsReflectionEnabledByDefault ? null : throw new InvalidOperationException($"No JSON metadata was found for '{runtimeType.FullName}'.");
     }
 
     [UnconditionalSuppressMessage(

--- a/src/NServiceBus.Core/Serializers/SystemJson/JsonMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/SystemJson/JsonMessageSerializer.cs
@@ -3,9 +3,11 @@ namespace NServiceBus.Serializers.SystemJson;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using NServiceBus.MessageInterfaces;
 using NServiceBus.Serialization;
 
@@ -27,7 +29,18 @@ class JsonMessageSerializer : IMessageSerializer
     public string ContentType { get; }
 
     public void Serialize(object message, Stream stream)
-        => JsonSerializer.Serialize(stream, message, serializerOptions);
+    {
+        var messageType = message.GetType();
+        var typeInfo = ResolveTypeInfo(messageType, serializerOptions);
+        if (typeInfo is not null)
+        {
+            JsonSerializer.Serialize(stream, message, typeInfo);
+        }
+        else
+        {
+            SerializeWithReflection(message, stream, messageType, serializerOptions);
+        }
+    }
 
     public object[] Deserialize(ReadOnlyMemory<byte> body, IList<Type>? messageTypes = null)
     {
@@ -49,9 +62,56 @@ class JsonMessageSerializer : IMessageSerializer
     object Deserialize(ReadOnlyMemory<byte> body, Type type)
     {
         var actualType = GetMappedType(type);
-        using var stream = new ReadOnlyStream(body);
-        return JsonSerializer.Deserialize(stream, actualType, serializerOptions)!;
+        var typeInfo = ResolveTypeInfo(actualType, serializerOptions);
+        if (typeInfo is not null)
+        {
+            using var stream = new ReadOnlyStream(body);
+            return JsonSerializer.Deserialize(stream, typeInfo)!;
+        }
+        else
+        {
+            using var stream = new ReadOnlyStream(body);
+            return DeserializeWithReflection(stream, actualType, serializerOptions)!;
+        }
     }
+
+    static JsonTypeInfo? ResolveTypeInfo(Type runtimeType, JsonSerializerOptions? options)
+    {
+        if (options is null)
+        {
+            return null;
+        }
+
+        var typeInfo = options.TypeInfoResolver?.GetTypeInfo(runtimeType, options);
+        if (typeInfo is not null)
+        {
+            return typeInfo;
+        }
+
+        return JsonSerializer.IsReflectionEnabledByDefault ? null : throw new InvalidOperationException($"No JSON metadata was found for '{runtimeType.FullName}'.");
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Only called when System.Text.Json reflection serialization is enabled.")]
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Only called when System.Text.Json reflection serialization is enabled.")]
+    static void SerializeWithReflection(object message, Stream stream, Type messageType, JsonSerializerOptions? options)
+        => JsonSerializer.Serialize(stream, message, messageType, options);
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Only called when System.Text.Json reflection serialization is enabled.")]
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Only called when System.Text.Json reflection serialization is enabled.")]
+    static object DeserializeWithReflection(Stream stream, Type type, JsonSerializerOptions? options)
+        => JsonSerializer.Deserialize(stream, type, options)!;
 
     static IEnumerable<Type> FindRootTypes(IEnumerable<Type> messageTypesToDeserialize)
     {

--- a/src/NServiceBus.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using NServiceBus;
@@ -37,7 +38,8 @@ public partial class PersistenceTestsConfiguration
 
         var sagaManifests = new SagaManifestCollection(SagaMetadataCollection,
             storageLocation,
-            name => DeterministicGuid.Create(name).ToString());
+            name => DeterministicGuid.Create(name).ToString(),
+            JsonSerializerOptions.Default);
 
         SagaStorage = new LearningSagaPersister(sagaManifests);
 

--- a/src/NServiceBus.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -38,8 +38,7 @@ public partial class PersistenceTestsConfiguration
 
         var sagaManifests = new SagaManifestCollection(SagaMetadataCollection,
             storageLocation,
-            name => DeterministicGuid.Create(name).ToString(),
-            JsonSerializerOptions.Default);
+            name => DeterministicGuid.Create(name).ToString());
 
         SagaStorage = new LearningSagaPersister(sagaManifests);
 

--- a/src/NServiceBus.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.IO;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using NServiceBus;


### PR DESCRIPTION
This PR makes the `SystemJson` message serializer and the Learning Saga Persister AOT and trimming compliant, following the same pattern we established in `NServiceBus.Persistence.NonDurable`'s `SagaEntry`.

**What changed**

The core idea is straightforward: instead of calling the reflection-based `JsonSerializer` overloads directly, we first try to resolve `JsonTypeInfo` via `TypeInfoResolver`. When metadata is available (source-generated or user-registered), we use the typed overloads that are AOT-safe. When it isn't, we fall back to reflection — but only when `JsonSerializer.IsReflectionEnabledByDefault` is `true`. The reflection fallback methods are annotated with `[UnconditionalSuppressMessage]` to keep the analyzer quiet.

The `ResolveTypeInfo` logic is extracted into a reusable extension method on `JsonSerializerOptions?` so both consumers share the same implementation.

**Learning Saga Persister specifics**

The saga persister previously had a hardcoded `JsonStringEnumConverter` in its static options. I moved that into a configurable default and guarded it behind `IsReflectionEnabledByDefault` — in AOT mode the converter is omitted and enums are serialized as integers. Since learning persistence is file-based and local to the endpoint, the format difference between AOT and non-AOT deployments shouldn't cause issues in practice.

I also added a `SagaSerializerOptions()` extension method so users can provide custom `JsonSerializerOptions` if the defaults don't fit their scenario.