### PR TITLE
Resolve globally registered endpoint-keyed services inside keyed endpoints

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_registering_keyed_async_disposables_externally_managed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_registering_keyed_async_disposables_externally_managed.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.DependencyInjection;
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using AcceptanceTesting;
 using EndpointTemplates;

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_resolving_all_services_within_an_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_resolving_all_services_within_an_endpoint.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AcceptanceTesting;
-using AcceptanceTesting.Support;
 using EndpointTemplates;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_resolving_endpoint_specific_keyed_services.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_resolving_endpoint_specific_keyed_services.cs
@@ -1,0 +1,97 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.DependencyInjection;
+
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+public class When_resolving_endpoint_specific_keyed_services : NServiceBusAcceptanceTest
+{
+    // When registering keyed services globally that match endpoint-specific keys, each endpoint should resolve its own
+    // global keyed service without having to use FromKeyedServices. Local keyed services using the same logical key
+    // should still be isolated per endpoint.
+    [Test]
+    public async Task Should_be_possible()
+    {
+        var result = await Scenario.Define<Context>()
+            .WithServices(static services =>
+            {
+                var firstEndpointName = AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(FirstEndpointUsingGlobalKeyedService));
+                var secondEndpointName = AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(SecondEndpointUsingGlobalKeyedService));
+
+                services.AddKeyedSingleton<IMyComponent, FirstEndpointComponent>($"{firstEndpointName}1");
+                services.AddKeyedSingleton<IMyComponent, SecondEndpointComponent>($"{secondEndpointName}2");
+            })
+            .WithEndpoint<FirstEndpointUsingGlobalKeyedService>(b => b
+                .Services(static services => services.AddKeyedSingleton<ILocalComponent, FirstLocalComponent>("local"))
+                .When((session, _) => session.SendLocal(new SomeMessage())))
+            .WithEndpoint<SecondEndpointUsingGlobalKeyedService>(b => b
+                .Services(static services => services.AddKeyedSingleton<ILocalComponent, SecondLocalComponent>("local"))
+                .When((session, _) => session.SendLocal(new SomeMessage())))
+            .Run();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.FirstComponent, Is.InstanceOf<FirstEndpointComponent>());
+            Assert.That(result.FirstLocalComponent, Is.InstanceOf<FirstLocalComponent>());
+            Assert.That(result.SecondComponent, Is.InstanceOf<SecondEndpointComponent>());
+            Assert.That(result.SecondLocalComponent, Is.InstanceOf<SecondLocalComponent>());
+        }
+    }
+
+    public class Context : ScenarioContext
+    {
+        public IMyComponent FirstComponent { get; set; }
+        public ILocalComponent FirstLocalComponent { get; set; }
+        public IMyComponent SecondComponent { get; set; }
+        public ILocalComponent SecondLocalComponent { get; set; }
+
+        public void MaybeCompleted() => MarkAsCompleted(FirstComponent is not null && FirstLocalComponent is not null && SecondComponent is not null && SecondLocalComponent is not null);
+    }
+
+    public interface IMyComponent;
+    public interface ILocalComponent;
+
+    public class FirstEndpointComponent : IMyComponent;
+    public class FirstLocalComponent : ILocalComponent;
+
+    public class SecondEndpointComponent : IMyComponent;
+    public class SecondLocalComponent : ILocalComponent;
+
+    public class FirstEndpointUsingGlobalKeyedService : EndpointConfigurationBuilder
+    {
+        public FirstEndpointUsingGlobalKeyedService() => EndpointSetup<DefaultServer>();
+
+        [Handler]
+        public class SomeMessageHandler(Context testContext, IMyComponent component, [FromKeyedServices("local")] ILocalComponent localComponent) : IHandleMessages<SomeMessage>
+        {
+            public Task Handle(SomeMessage message, IMessageHandlerContext context)
+            {
+                testContext.FirstComponent = component;
+                testContext.FirstLocalComponent = localComponent;
+                testContext.MaybeCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class SecondEndpointUsingGlobalKeyedService : EndpointConfigurationBuilder
+    {
+        public SecondEndpointUsingGlobalKeyedService() => EndpointSetup<DefaultServer>();
+
+        [Handler]
+        public class SomeMessageHandler(Context testContext, IMyComponent component, [FromKeyedServices("local")] ILocalComponent localComponent) : IHandleMessages<SomeMessage>
+        {
+            public Task Handle(SomeMessage message, IMessageHandlerContext context)
+            {
+                testContext.SecondComponent = component;
+                testContext.SecondLocalComponent = localComponent;
+                testContext.MaybeCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class SomeMessage : ICommand;
+}

--- a/src/NServiceBus.Core.Tests/Hosting/KeyedServiceCollectionAdapterTests.cs
+++ b/src/NServiceBus.Core.Tests/Hosting/KeyedServiceCollectionAdapterTests.cs
@@ -9,8 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using NUnit.Framework;
 
-#pragma warning disable IDE0028 // Collection initialization can be simplified — test clarity requires explicit Add calls
-
 [TestFixture]
 public class KeyedServiceCollectionAdapterTests
 {
@@ -414,20 +412,6 @@ public class KeyedServiceCollectionAdapterTests
     }
 
     [Test]
-    public void Remove_should_decrement_service_type_count()
-    {
-        var inner = new ServiceCollection();
-        var adapter = new KeyedServiceCollectionAdapter(inner, "ep");
-
-        var descriptor = new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Singleton);
-        adapter.Add(descriptor);
-
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.True);
-        adapter.Remove(descriptor);
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.False);
-    }
-
-    [Test]
     public void RemoveAt_should_remove_descriptor_at_index()
     {
         var inner = new ServiceCollection();
@@ -450,27 +434,14 @@ public class KeyedServiceCollectionAdapterTests
     }
 
     [Test]
-    public void RemoveAt_should_decrement_service_type_count()
-    {
-        var inner = new ServiceCollection();
-        var adapter = new KeyedServiceCollectionAdapter(inner, "ep");
-
-        var d1 = new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Transient);
-        adapter.Add(d1);
-
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.True);
-        adapter.RemoveAt(0);
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.False);
-    }
-
-    [Test]
     public void Clear_should_remove_all_from_adapter_and_inner()
     {
         var inner = new ServiceCollection();
-        var adapter = new KeyedServiceCollectionAdapter(inner, "ep");
-
-        adapter.Add(new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Transient));
-        adapter.Add(new ServiceDescriptor(typeof(IBar), typeof(Bar), ServiceLifetime.Scoped));
+        var adapter = new KeyedServiceCollectionAdapter(inner, "ep")
+        {
+            new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Transient),
+            new ServiceDescriptor(typeof(IBar), typeof(Bar), ServiceLifetime.Scoped)
+        };
 
         adapter.Clear();
 
@@ -479,18 +450,6 @@ public class KeyedServiceCollectionAdapterTests
             Assert.That(adapter, Is.Empty);
             Assert.That(inner, Is.Empty);
         }
-    }
-
-    [Test]
-    public void Clear_should_reset_service_type_counts()
-    {
-        var adapter = CreateAdapter("ep");
-
-        adapter.Add(new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Transient));
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.True);
-
-        adapter.Clear();
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.False);
     }
 
     [Test]
@@ -515,78 +474,79 @@ public class KeyedServiceCollectionAdapterTests
     }
 
     [Test]
-    public void ContainsService_should_return_true_for_registered_type()
+    public void ContainsLocalService_should_distinguish_keyed_and_non_keyed_registrations()
     {
         var adapter = CreateAdapter();
         adapter.Add(new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Transient));
+        adapter.Add(new ServiceDescriptor(typeof(IFoo), "sub", typeof(Foo2), ServiceLifetime.Transient));
 
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.True);
-    }
-
-    [Test]
-    public void ContainsService_should_return_false_for_unregistered_type()
-    {
-        var adapter = CreateAdapter();
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.False);
-    }
-
-    [Test]
-    public void ContainsService_should_return_true_for_open_generic_when_closed_registered()
-    {
-        var adapter = CreateAdapter();
-        adapter.Add(new ServiceDescriptor(typeof(IGeneric<>), typeof(GenericFoo<>), ServiceLifetime.Transient));
-
-        Assert.That(adapter.ContainsService(typeof(IGeneric<Foo>)), Is.True);
-    }
-
-    [Test]
-    public void ContainsService_should_return_false_for_closed_when_only_other_closed_registered()
-    {
-        var adapter = CreateAdapter();
-        adapter.Add(new ServiceDescriptor(typeof(IGeneric<Foo>), typeof(GenericFoo<Foo>), ServiceLifetime.Transient));
-
-        Assert.That(adapter.ContainsService(typeof(IGeneric<Bar>)), Is.False);
-    }
-
-    [Test]
-    public void ContainsService_should_throw_on_null()
-    {
-        var adapter = CreateAdapter();
-        Assert.Throws<ArgumentNullException>(() => adapter.ContainsService(null!));
-    }
-
-    [Test]
-    public void Multiple_same_type_should_increment_count()
-    {
-        var adapter = CreateAdapter();
-
-        adapter.Add(new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Transient));
-        adapter.Add(new ServiceDescriptor(typeof(IFoo), typeof(Foo2), ServiceLifetime.Transient));
-
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.True);
-    }
-
-    [Test]
-    public void Removing_all_of_same_type_should_remove_service_type()
-    {
-        var inner = new ServiceCollection();
-        var adapter = new KeyedServiceCollectionAdapter(inner, "ep");
-
-        var d1 = new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Transient);
-        var d2 = new ServiceDescriptor(typeof(IFoo), typeof(Foo2), ServiceLifetime.Transient);
-        adapter.Add(d1);
-        adapter.Add(d2);
-
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.True);
-
-        adapter.Remove(d1);
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.True);
-
-        adapter.Remove(d2);
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(adapter.ContainsService(typeof(IFoo)), Is.False);
-            Assert.That(inner, Is.Empty);
+            Assert.That(adapter.ContainsLocalService(typeof(IFoo), null), Is.True);
+            Assert.That(adapter.ContainsLocalService(typeof(IFoo), "sub"), Is.True);
+            Assert.That(adapter.ContainsLocalService(typeof(IFoo), "other"), Is.False);
+        }
+    }
+
+    [Test]
+    public void ContainsLocalService_should_match_closed_generic_request_for_open_generic_registration()
+    {
+        var adapter = CreateAdapter();
+        adapter.Add(new ServiceDescriptor(typeof(IGeneric<>), "sub", typeof(GenericFoo<>), ServiceLifetime.Transient));
+
+        Assert.That(adapter.ContainsLocalService(typeof(IGeneric<Foo>), "sub"), Is.True);
+    }
+
+    [Test]
+    public void ContainsLocalService_should_return_false_after_remove()
+    {
+        var adapter = CreateAdapter();
+        var descriptor = new ServiceDescriptor(typeof(IFoo), "sub", typeof(Foo), ServiceLifetime.Transient);
+        adapter.Add(descriptor);
+
+        adapter.Remove(descriptor);
+
+        Assert.That(adapter.ContainsLocalService(typeof(IFoo), "sub"), Is.False);
+    }
+
+    [Test]
+    public void ContainsLocalService_should_return_false_after_remove_at()
+    {
+        var adapter = CreateAdapter();
+        adapter.Add(new ServiceDescriptor(typeof(IFoo), "sub", typeof(Foo), ServiceLifetime.Transient));
+
+        adapter.RemoveAt(0);
+
+        Assert.That(adapter.ContainsLocalService(typeof(IFoo), "sub"), Is.False);
+    }
+
+    [Test]
+    public void ContainsLocalService_should_return_false_after_clear()
+    {
+        var adapter = CreateAdapter();
+        adapter.Add(new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Transient));
+        adapter.Add(new ServiceDescriptor(typeof(IFoo), "sub", typeof(Foo2), ServiceLifetime.Transient));
+
+        adapter.Clear();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(adapter.ContainsLocalService(typeof(IFoo), null), Is.False);
+            Assert.That(adapter.ContainsLocalService(typeof(IFoo), "sub"), Is.False);
+        }
+    }
+
+    [Test]
+    public void GetLocalServiceKey_should_project_to_endpoint_composite_key()
+    {
+        var adapter = CreateAdapter("ep");
+
+        var key = adapter.GetLocalServiceKey("sub");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(key.BaseKey, Is.EqualTo("ep"));
+            Assert.That(key.ServiceKey, Is.EqualTo("sub"));
         }
     }
 
@@ -594,9 +554,11 @@ public class KeyedServiceCollectionAdapterTests
     public void Add_should_augment_non_keyed_descriptor_to_keyed_in_inner()
     {
         var inner = new ServiceCollection();
-        var adapter = new KeyedServiceCollectionAdapter(inner, "ep");
 
-        adapter.Add(new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Singleton));
+        _ = new KeyedServiceCollectionAdapter(inner, "ep")
+        {
+            new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Singleton)
+        };
 
         Assert.That(inner[0].ServiceKey, Is.InstanceOf<KeyedServiceKey>());
         var key = (KeyedServiceKey)inner[0].ServiceKey!;
@@ -611,9 +573,11 @@ public class KeyedServiceCollectionAdapterTests
     public void Add_should_augment_keyed_descriptor_with_composite_key_in_inner()
     {
         var inner = new ServiceCollection();
-        var adapter = new KeyedServiceCollectionAdapter(inner, "ep");
 
-        adapter.Add(new ServiceDescriptor(typeof(IFoo), "sub", typeof(Foo), ServiceLifetime.Singleton));
+        _ = new KeyedServiceCollectionAdapter(inner, "ep")
+        {
+            new ServiceDescriptor(typeof(IFoo), "sub", typeof(Foo), ServiceLifetime.Singleton)
+        };
 
         Assert.That(inner[0].ServiceKey, Is.InstanceOf<KeyedServiceKey>());
         var key = (KeyedServiceKey)inner[0].ServiceKey!;
@@ -667,10 +631,11 @@ public class KeyedServiceCollectionAdapterTests
     public void Clear_should_remove_all_from_inner()
     {
         var inner = new ServiceCollection();
-        var adapter = new KeyedServiceCollectionAdapter(inner, "ep");
-
-        adapter.Add(new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Singleton));
-        adapter.Add(new ServiceDescriptor(typeof(IBar), typeof(Bar), ServiceLifetime.Scoped));
+        var adapter = new KeyedServiceCollectionAdapter(inner, "ep")
+        {
+            new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Singleton),
+            new ServiceDescriptor(typeof(IBar), typeof(Bar), ServiceLifetime.Scoped)
+        };
 
         adapter.Clear();
 
@@ -823,36 +788,6 @@ public class KeyedServiceCollectionAdapterTests
         Assert.That(adapter[0].ImplementationInstance, Is.SameAs(instance));
     }
 
-    [Test]
-    public void Service_type_counts_should_track_multiple_registrations()
-    {
-        var inner = new ServiceCollection();
-        var adapter = new KeyedServiceCollectionAdapter(inner, "ep");
-
-        adapter.Add(new ServiceDescriptor(typeof(IFoo), typeof(Foo), ServiceLifetime.Transient));
-        adapter.Add(new ServiceDescriptor(typeof(IFoo), typeof(Foo2), ServiceLifetime.Transient));
-        adapter.Add(new ServiceDescriptor(typeof(IFoo), typeof(Foo3), ServiceLifetime.Transient));
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(adapter.ContainsService(typeof(IFoo)), Is.True);
-            Assert.That(inner, Has.Count.EqualTo(3));
-        }
-
-        adapter.Remove(adapter[0]);
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.True);
-
-        adapter.Remove(adapter[0]);
-        Assert.That(adapter.ContainsService(typeof(IFoo)), Is.True);
-
-        adapter.Remove(adapter[0]);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(adapter.ContainsService(typeof(IFoo)), Is.False);
-            Assert.That(inner, Is.Empty);
-        }
-    }
-
     interface IFoo;
 
     interface IBar;
@@ -864,8 +799,6 @@ public class KeyedServiceCollectionAdapterTests
     class Foo : IFoo;
 
     class Foo2 : IFoo;
-
-    class Foo3 : IFoo;
 
     class Bar : IBar;
 

--- a/src/NServiceBus.Core.Tests/Hosting/KeyedServiceProviderAdapterTests.cs
+++ b/src/NServiceBus.Core.Tests/Hosting/KeyedServiceProviderAdapterTests.cs
@@ -2,6 +2,9 @@
 
 namespace NServiceBus.Core.Tests.Host;
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -36,4 +39,369 @@ public class KeyedServiceProviderAdapterTests
         var scopeFactory = adapter.GetRequiredService<IServiceScopeFactory>();
         Assert.DoesNotThrow(() => scopeFactory.CreateScope().Dispose());
     }
+
+    [Test]
+    public void GetRequiredService_should_resolve_root_service_registered_with_endpoint_key()
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IComponent, RootEndpointComponent>("endpoint");
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var component = adapter.GetRequiredService(typeof(IComponent));
+
+        Assert.That(component, Is.InstanceOf<RootEndpointComponent>());
+    }
+
+    [Test]
+    public void GetService_should_resolve_root_service_registered_with_endpoint_key()
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IComponent, RootEndpointComponent>("endpoint");
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var component = adapter.GetService(typeof(IComponent));
+
+        Assert.That(component, Is.InstanceOf<RootEndpointComponent>());
+    }
+
+    [Test]
+    public void IsKeyedService_should_return_true_for_local_keyed_service()
+    {
+        var services = new ServiceCollection();
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        keyedServices.AddKeyedSingleton<IComponent, LocalKeyedComponent>("component");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var result = adapter.IsKeyedService(typeof(IComponent), "component");
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsKeyedService_should_return_true_for_root_keyed_service()
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IComponent, RootKeyedComponent>("component");
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var result = adapter.IsKeyedService(typeof(IComponent), "component");
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsKeyedService_should_use_root_keyed_service_probe()
+    {
+        var providerServices = new ServiceCollection();
+        providerServices.AddKeyedSingleton<IComponent, RootKeyedComponent>("component");
+        var adapterServices = new ServiceCollection();
+        var keyedServices = new KeyedServiceCollectionAdapter(adapterServices, "endpoint");
+        using var rootProvider = providerServices.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var result = adapter.IsKeyedService(typeof(IComponent), "component");
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsKeyedService_should_return_false_when_service_is_not_available()
+    {
+        var services = new ServiceCollection();
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var result = adapter.IsKeyedService(typeof(IComponent), "component");
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsKeyedService_should_return_false_for_local_service_with_different_endpoint_key()
+    {
+        var services = new ServiceCollection();
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        keyedServices.AddKeyedSingleton<IComponent, LocalKeyedComponent>("component");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var result = adapter.IsKeyedService(typeof(IComponent), new KeyedServiceKey("other-endpoint", "component"));
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsService_should_return_true_for_local_endpoint_service()
+    {
+        var services = new ServiceCollection();
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        keyedServices.AddSingleton<IComponent, LocalComponent>();
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var result = adapter.IsService(typeof(IComponent));
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsService_should_return_true_for_root_service_registered_with_endpoint_key()
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IComponent, RootEndpointComponent>("endpoint");
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var result = adapter.IsService(typeof(IComponent));
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsService_should_return_true_for_root_unkeyed_service()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IComponent, RootComponent>();
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var result = adapter.IsService(typeof(IComponent));
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsService_should_use_root_service_probe()
+    {
+        var providerServices = new ServiceCollection();
+        providerServices.AddSingleton<IComponent, RootComponent>();
+        var adapterServices = new ServiceCollection();
+        var keyedServices = new KeyedServiceCollectionAdapter(adapterServices, "endpoint");
+        using var rootProvider = providerServices.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var result = adapter.IsService(typeof(IComponent));
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsService_should_return_false_when_service_is_not_available()
+    {
+        var services = new ServiceCollection();
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var result = adapter.IsService(typeof(IComponent));
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsService_should_return_true_for_adapter_services()
+    {
+        var services = new ServiceCollection();
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(adapter.IsService(typeof(IServiceProvider)), Is.True);
+            Assert.That(adapter.IsService(typeof(ISupportRequiredService)), Is.True);
+            Assert.That(adapter.IsService(typeof(IServiceProviderIsService)), Is.True);
+            Assert.That(adapter.IsService(typeof(IServiceProviderIsKeyedService)), Is.True);
+            Assert.That(adapter.IsService(typeof(IServiceScopeFactory)), Is.True);
+            Assert.That(adapter.IsService(typeof(IEnumerable<IComponent>)), Is.True);
+        }
+    }
+
+    [Test]
+    public void GetService_and_GetRequiredService_should_return_adapter_services()
+    {
+        var services = new ServiceCollection();
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(adapter.GetService(typeof(IServiceProvider)), Is.SameAs(adapter));
+            Assert.That(adapter.GetRequiredService(typeof(ISupportRequiredService)), Is.SameAs(adapter));
+            Assert.That(adapter.GetService(typeof(IServiceProviderIsService)), Is.SameAs(adapter));
+            Assert.That(adapter.GetRequiredService(typeof(IServiceProviderIsKeyedService)), Is.SameAs(adapter));
+            Assert.That(adapter.GetService(typeof(IServiceScopeFactory)), Is.Not.Null);
+            Assert.That(adapter.GetRequiredService(typeof(IServiceScopeFactory)), Is.Not.Null);
+        }
+    }
+
+    [Test]
+    public void GetRequiredKeyedService_should_prefer_local_keyed_service_for_matching_key()
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IComponent, RootKeyedComponent>("component");
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        keyedServices.AddKeyedSingleton<IComponent, LocalKeyedComponent>("component");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var component = adapter.GetRequiredKeyedService(typeof(IComponent), "component");
+
+        Assert.That(component, Is.InstanceOf<LocalKeyedComponent>());
+    }
+
+    [Test]
+    public void GetKeyedService_should_prefer_local_keyed_service_for_matching_key()
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IComponent, RootKeyedComponent>("component");
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        keyedServices.AddKeyedSingleton<IComponent, LocalKeyedComponent>("component");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var component = adapter.GetKeyedService(typeof(IComponent), "component");
+
+        Assert.That(component, Is.InstanceOf<LocalKeyedComponent>());
+    }
+
+    [Test]
+    public void GetRequiredKeyedService_should_fallback_to_root_keyed_service_when_local_key_does_not_match()
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IComponent, RootKeyedComponent>("root-component");
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        keyedServices.AddKeyedSingleton<IComponent, LocalKeyedComponent>("local-component");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var component = adapter.GetRequiredKeyedService(typeof(IComponent), "root-component");
+
+        Assert.That(component, Is.InstanceOf<RootKeyedComponent>());
+    }
+
+    [Test]
+    public void GetKeyedService_should_return_null_when_keyed_service_is_not_available()
+    {
+        var services = new ServiceCollection();
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var component = adapter.GetKeyedService(typeof(IComponent), "component");
+
+        Assert.That(component, Is.Null);
+    }
+
+    [Test]
+    public void GetService_and_GetRequiredService_should_resolve_local_endpoint_enumerables()
+    {
+        var services = new ServiceCollection();
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        keyedServices.AddSingleton<IComponent, LocalComponent>();
+        keyedServices.AddSingleton<IComponent, LocalKeyedComponent>();
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var components = ((IEnumerable<IComponent>)adapter.GetService(typeof(IEnumerable<IComponent>))!).ToList();
+        var requiredComponents = ((IEnumerable<IComponent>)adapter.GetRequiredService(typeof(IEnumerable<IComponent>))).ToList();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(components, Has.Count.EqualTo(2));
+            Assert.That(requiredComponents, Has.Count.EqualTo(2));
+            Assert.That(requiredComponents, Is.EquivalentTo(components));
+        }
+    }
+
+    [Test]
+    public void GetService_and_GetRequiredService_should_resolve_root_endpoint_keyed_enumerables()
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IComponent, RootEndpointComponent>("endpoint");
+        services.AddKeyedSingleton<IComponent, SecondRootEndpointComponent>("endpoint");
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var components = ((IEnumerable<IComponent>)adapter.GetService(typeof(IEnumerable<IComponent>))!).ToList();
+        var requiredComponents = ((IEnumerable<IComponent>)adapter.GetRequiredService(typeof(IEnumerable<IComponent>))).ToList();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(components, Has.Count.EqualTo(2));
+            Assert.That(requiredComponents, Has.Count.EqualTo(2));
+            Assert.That(requiredComponents, Is.EquivalentTo(components));
+        }
+    }
+
+    [Test]
+    public void GetKeyedService_and_GetRequiredKeyedService_should_resolve_local_keyed_enumerables()
+    {
+        var services = new ServiceCollection();
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        keyedServices.AddKeyedSingleton<IComponent, LocalKeyedComponent>("component");
+        keyedServices.AddKeyedSingleton<IComponent, SecondLocalKeyedComponent>("component");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var components = ((IEnumerable<IComponent>)adapter.GetKeyedService(typeof(IEnumerable<IComponent>), "component")!).ToList();
+        var requiredComponents = ((IEnumerable<IComponent>)adapter.GetRequiredKeyedService(typeof(IEnumerable<IComponent>), "component")).ToList();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(components, Has.Count.EqualTo(2));
+            Assert.That(requiredComponents, Has.Count.EqualTo(2));
+            Assert.That(requiredComponents, Is.EquivalentTo(components));
+        }
+    }
+
+    [Test]
+    public void GetKeyedService_and_GetRequiredKeyedService_should_resolve_all_services_for_any_key()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IComponent, RootComponent>();
+        var keyedServices = new KeyedServiceCollectionAdapter(services, "endpoint");
+        keyedServices.AddSingleton<IComponent, LocalComponent>();
+        keyedServices.AddKeyedSingleton<IComponent, LocalKeyedComponent>("component");
+        using var rootProvider = services.BuildServiceProvider();
+        var adapter = new KeyedServiceProviderAdapter(rootProvider, "endpoint", keyedServices);
+
+        var components = ((IEnumerable<IComponent>)adapter.GetKeyedService(typeof(IEnumerable<IComponent>), KeyedServiceKey.Any)!).ToList();
+        var requiredComponents = ((IEnumerable<IComponent>)adapter.GetRequiredKeyedService(typeof(IEnumerable<IComponent>), KeyedServiceKey.Any)).ToList();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(components, Has.Count.EqualTo(3));
+            Assert.That(requiredComponents, Has.Count.EqualTo(3));
+            Assert.That(requiredComponents, Is.EquivalentTo(components));
+        }
+    }
+
+    interface IComponent;
+
+    class LocalComponent : IComponent;
+
+    class LocalKeyedComponent : IComponent;
+
+    class SecondLocalKeyedComponent : IComponent;
+
+    class RootEndpointComponent : IComponent;
+
+    class SecondRootEndpointComponent : IComponent;
+
+    class RootComponent : IComponent;
+
+    class RootKeyedComponent : IComponent;
 }

--- a/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServiceCollectionAdapter.cs
+++ b/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServiceCollectionAdapter.cs
@@ -53,7 +53,6 @@ class KeyedServiceCollectionAdapter : IServiceCollection
 
         keyedDescriptors.Clear();
         originalDescriptors.Clear();
-        serviceTypeCounts.Clear();
     }
 
     public bool Contains(ServiceDescriptor item)
@@ -90,7 +89,6 @@ class KeyedServiceCollectionAdapter : IServiceCollection
         originalDescriptors.RemoveAt(index);
         keyedDescriptors.RemoveAt(index);
         _ = Inner.Remove(keyedDescriptor);
-        DecrementServiceTypeCount(keyedDescriptor.ServiceType);
         return true;
     }
 
@@ -100,28 +98,38 @@ class KeyedServiceCollectionAdapter : IServiceCollection
         keyedDescriptors.RemoveAt(index);
         originalDescriptors.RemoveAt(index);
         _ = Inner.Remove(keyedDescriptor);
-        DecrementServiceTypeCount(keyedDescriptor.ServiceType);
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    public bool ContainsService(Type serviceType)
+    public bool ContainsLocalService(Type serviceType, object? serviceKey)
     {
         ArgumentNullException.ThrowIfNull(serviceType);
 
-        if (serviceTypeCounts.ContainsKey(serviceType))
+        foreach (var descriptor in originalDescriptors)
+        {
+            if (ServiceTypeMatches(descriptor.ServiceType, serviceType) && Equals(GetServiceKey(descriptor), serviceKey))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public KeyedServiceKey GetLocalServiceKey(object? serviceKey) => new(ServiceKey, serviceKey);
+
+    static bool ServiceTypeMatches(Type registeredServiceType, Type requestedServiceType)
+    {
+        if (registeredServiceType == requestedServiceType)
         {
             return true;
         }
 
-        if (!serviceType.IsGenericType)
-        {
-            return false;
-        }
-
-        var definition = serviceType.GetGenericTypeDefinition();
-        return serviceTypeCounts.ContainsKey(definition);
+        return requestedServiceType.IsGenericType && registeredServiceType == requestedServiceType.GetGenericTypeDefinition();
     }
+
+    static object? GetServiceKey(ServiceDescriptor descriptor) => descriptor.IsKeyedService ? descriptor.ServiceKey : null;
 
     ServiceDescriptor EnsureKeyedDescriptor(ServiceDescriptor descriptor)
     {
@@ -191,28 +199,7 @@ class KeyedServiceCollectionAdapter : IServiceCollection
             }
         }
 
-        if (!serviceTypeCounts.TryAdd(keyedDescriptor.ServiceType, 1))
-        {
-            serviceTypeCounts[keyedDescriptor.ServiceType]++;
-        }
-
         return keyedDescriptor;
-    }
-
-    void DecrementServiceTypeCount(Type serviceType)
-    {
-        if (!serviceTypeCounts.TryGetValue(serviceType, out var count))
-        {
-            return;
-        }
-
-        if (count <= 1)
-        {
-            _ = serviceTypeCounts.Remove(serviceType);
-            return;
-        }
-
-        serviceTypeCounts[serviceType] = count - 1;
     }
 
     static class UnsafeAccessor
@@ -223,6 +210,5 @@ class KeyedServiceCollectionAdapter : IServiceCollection
 
     readonly List<ServiceDescriptor> originalDescriptors = [];
     readonly List<ServiceDescriptor> keyedDescriptors = [];
-    readonly Dictionary<Type, int> serviceTypeCounts = [];
     readonly ConcurrentDictionary<Type, ObjectFactory> factories = new();
 }

--- a/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServiceProviderAdapter.cs
+++ b/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServiceProviderAdapter.cs
@@ -230,7 +230,7 @@ sealed class KeyedServiceProviderAdapter : IKeyedServiceProvider, ISupportRequir
     bool ContainsRootService(Type serviceType)
     {
         var rootServiceProbe = serviceProvider?.GetService<IServiceProviderIsService>();
-        if (rootServiceProbe?.IsService(serviceType) == true)
+        if (rootServiceProbe?.IsService(serviceType) is true)
         {
             return true;
         }
@@ -249,7 +249,7 @@ sealed class KeyedServiceProviderAdapter : IKeyedServiceProvider, ISupportRequir
     bool ContainsRootKeyedService(Type serviceType, object? serviceKey)
     {
         var rootKeyedServiceProbe = serviceProvider?.GetService<IServiceProviderIsKeyedService>();
-        if (rootKeyedServiceProbe?.IsKeyedService(serviceType, serviceKey) == true)
+        if (rootKeyedServiceProbe?.IsKeyedService(serviceType, serviceKey) is true)
         {
             return true;
         }

--- a/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServiceProviderAdapter.cs
+++ b/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServiceProviderAdapter.cs
@@ -4,6 +4,7 @@ namespace NServiceBus;
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -221,49 +222,54 @@ sealed class KeyedServiceProviderAdapter : IKeyedServiceProvider, ISupportRequir
     // this allows resolving services by either the KeyedServiceKey or the base key and makes the experience consistent
     static object? GetBaseKeyOrServiceKey(object? serviceKey) => serviceKey is KeyedServiceKey key ? key.BaseKey : serviceKey;
 
-    bool ContainsLocalEndpointService(Type serviceType, KeyedServiceKey key) => Equals(serviceKeyedServiceKey.BaseKey, key.BaseKey) && serviceCollection.ContainsLocalService(serviceType, key.ServiceKey);
+    bool ContainsLocalEndpointService(Type serviceType, KeyedServiceKey key) =>
+        Equals(serviceKeyedServiceKey.BaseKey, key.BaseKey) &&
+        localEndpointServiceLookup.GetOrAdd((serviceType, key.ServiceKey), static (lookupKey, collection) =>
+            collection.ContainsLocalService(lookupKey.ServiceType, lookupKey.ServiceKey), serviceCollection);
 
     KeyedServiceKey GetLocalEndpointServiceKey(KeyedServiceKey key) => serviceCollection.GetLocalServiceKey(key.ServiceKey);
 
     bool ContainsRootEndpointKeyedService(Type serviceType) => ContainsRootKeyedService(serviceType, serviceKeyedServiceKey.BaseKey);
 
-    bool ContainsRootService(Type serviceType)
-    {
-        var rootServiceProbe = serviceProvider?.GetService<IServiceProviderIsService>();
-        if (rootServiceProbe?.IsService(serviceType) is true)
+    bool ContainsRootService(Type serviceType) =>
+        rootServiceLookup.GetOrAdd(serviceType, static (lookupServiceType, state) =>
         {
-            return true;
-        }
-
-        foreach (var descriptor in serviceCollection.Inner)
-        {
-            if (!descriptor.IsKeyedService && ServiceTypeMatches(descriptor.ServiceType, serviceType))
+            var rootServiceProbe = state.ServiceProvider?.GetService<IServiceProviderIsService>();
+            if (rootServiceProbe?.IsService(lookupServiceType) is true)
             {
                 return true;
             }
-        }
 
-        return false;
-    }
+            foreach (var descriptor in state.ServiceCollection.Inner)
+            {
+                if (!descriptor.IsKeyedService && ServiceTypeMatches(descriptor.ServiceType, lookupServiceType))
+                {
+                    return true;
+                }
+            }
 
-    bool ContainsRootKeyedService(Type serviceType, object? serviceKey)
-    {
-        var rootKeyedServiceProbe = serviceProvider?.GetService<IServiceProviderIsKeyedService>();
-        if (rootKeyedServiceProbe?.IsKeyedService(serviceType, serviceKey) is true)
+            return false;
+        }, (ServiceProvider: serviceProvider, ServiceCollection: serviceCollection));
+
+    bool ContainsRootKeyedService(Type serviceType, object? serviceKey) =>
+        rootKeyedServiceLookup.GetOrAdd((serviceType, serviceKey), static (lookupKey, state) =>
         {
-            return true;
-        }
-
-        foreach (var descriptor in serviceCollection.Inner)
-        {
-            if (descriptor.IsKeyedService && ServiceTypeMatches(descriptor.ServiceType, serviceType) && Equals(serviceKey, descriptor.ServiceKey))
+            var rootKeyedServiceProbe = state.ServiceProvider?.GetService<IServiceProviderIsKeyedService>();
+            if (rootKeyedServiceProbe?.IsKeyedService(lookupKey.ServiceType, lookupKey.ServiceKey) is true)
             {
                 return true;
             }
-        }
 
-        return false;
-    }
+            foreach (var descriptor in state.ServiceCollection.Inner)
+            {
+                if (descriptor.IsKeyedService && ServiceTypeMatches(descriptor.ServiceType, lookupKey.ServiceType) && Equals(lookupKey.ServiceKey, descriptor.ServiceKey))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }, (ServiceProvider: serviceProvider, ServiceCollection: serviceCollection));
 
     KeyedServiceKey GetOrCreateComputedKey(object? serviceKey)
     {
@@ -298,4 +304,7 @@ sealed class KeyedServiceProviderAdapter : IKeyedServiceProvider, ISupportRequir
     readonly bool ownsProvider;
     readonly KeyedServiceKey anyKey;
     readonly KeyedServiceScopeFactory keyedScopeFactory;
+    readonly ConcurrentDictionary<(Type ServiceType, object? ServiceKey), bool> localEndpointServiceLookup = new();
+    readonly ConcurrentDictionary<Type, bool> rootServiceLookup = new();
+    readonly ConcurrentDictionary<(Type ServiceType, object? ServiceKey), bool> rootKeyedServiceLookup = new();
 }

--- a/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServiceProviderAdapter.cs
+++ b/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServiceProviderAdapter.cs
@@ -27,21 +27,22 @@ sealed class KeyedServiceProviderAdapter : IKeyedServiceProvider, ISupportRequir
         keyedScopeFactory = new KeyedServiceScopeFactory(serviceProvider.GetRequiredService<IServiceScopeFactory>(), serviceKeyedServiceKey, serviceCollection);
     }
 
-    public bool IsService(Type serviceType) => serviceCollection.ContainsService(serviceType);
+    public bool IsService(Type serviceType)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+
+        if (IsServiceProvider(serviceType) || IsScopeFactory(serviceType) || IsServicesRequest(serviceType))
+        {
+            return true;
+        }
+
+        return ContainsLocalEndpointService(serviceType, serviceKeyedServiceKey) || ContainsRootEndpointKeyedService(serviceType) || ContainsRootService(serviceType);
+    }
 
     public bool IsKeyedService(Type serviceType, object? serviceKey)
     {
-        if (!serviceCollection.ContainsService(serviceType))
-        {
-            return false;
-        }
-
-        if (serviceKey is KeyedServiceKey key)
-        {
-            return Equals(serviceKeyedServiceKey.BaseKey, key.BaseKey);
-        }
-
-        return false;
+        var computedKey = GetOrCreateComputedKey(serviceKey);
+        return ContainsLocalEndpointService(serviceType, computedKey) || ContainsRootKeyedService(serviceType, GetBaseKeyOrServiceKey(serviceKey));
     }
 
     public object? GetService(Type serviceType)
@@ -61,13 +62,21 @@ sealed class KeyedServiceProviderAdapter : IKeyedServiceProvider, ISupportRequir
 
         if (!IsServicesRequest(serviceType))
         {
-            return IsKeyedService(serviceType, serviceKeyedServiceKey)
-                ? serviceProvider.GetKeyedService(serviceType, serviceKeyedServiceKey)
-                : serviceProvider.GetService(serviceType);
+            if (ContainsLocalEndpointService(serviceType, serviceKeyedServiceKey))
+            {
+                return serviceProvider.GetKeyedService(serviceType, GetLocalEndpointServiceKey(serviceKeyedServiceKey));
+            }
+
+            return ContainsRootEndpointKeyedService(serviceType) ? serviceProvider.GetKeyedService(serviceType, serviceKeyedServiceKey.BaseKey) : serviceProvider.GetService(serviceType);
         }
 
         var itemType = serviceType.GetGenericArguments()[0];
-        return IsKeyedService(itemType, serviceKeyedServiceKey) ? serviceProvider.GetKeyedServices(itemType, serviceKeyedServiceKey) : serviceProvider.GetServices(itemType);
+        if (ContainsLocalEndpointService(itemType, serviceKeyedServiceKey))
+        {
+            return serviceProvider.GetKeyedServices(itemType, GetLocalEndpointServiceKey(serviceKeyedServiceKey));
+        }
+
+        return ContainsRootEndpointKeyedService(itemType) ? serviceProvider.GetKeyedServices(itemType, serviceKeyedServiceKey.BaseKey) : serviceProvider.GetServices(itemType);
     }
 
     public object GetRequiredService(Type serviceType)
@@ -87,13 +96,21 @@ sealed class KeyedServiceProviderAdapter : IKeyedServiceProvider, ISupportRequir
 
         if (!IsServicesRequest(serviceType))
         {
-            return IsKeyedService(serviceType, serviceKeyedServiceKey)
-                ? serviceProvider.GetRequiredKeyedService(serviceType, serviceKeyedServiceKey)
-                : serviceProvider.GetRequiredService(serviceType);
+            if (ContainsLocalEndpointService(serviceType, serviceKeyedServiceKey))
+            {
+                return serviceProvider.GetRequiredKeyedService(serviceType, GetLocalEndpointServiceKey(serviceKeyedServiceKey));
+            }
+
+            return ContainsRootEndpointKeyedService(serviceType) ? serviceProvider.GetRequiredKeyedService(serviceType, serviceKeyedServiceKey.BaseKey) : serviceProvider.GetRequiredService(serviceType);
         }
 
         var itemType = serviceType.GetGenericArguments()[0];
-        return IsKeyedService(itemType, serviceKeyedServiceKey) ? serviceProvider.GetKeyedServices(itemType, serviceKeyedServiceKey) : serviceProvider.GetServices(itemType);
+        if (ContainsLocalEndpointService(itemType, serviceKeyedServiceKey))
+        {
+            return serviceProvider.GetKeyedServices(itemType, GetLocalEndpointServiceKey(serviceKeyedServiceKey));
+        }
+
+        return ContainsRootEndpointKeyedService(itemType) ? serviceProvider.GetKeyedServices(itemType, serviceKeyedServiceKey.BaseKey) : serviceProvider.GetServices(itemType);
     }
 
     public object? GetKeyedService(Type serviceType, object? serviceKey)
@@ -114,16 +131,16 @@ sealed class KeyedServiceProviderAdapter : IKeyedServiceProvider, ISupportRequir
         var computedKey = GetOrCreateComputedKey(serviceKey);
         if (!IsServicesRequest(serviceType))
         {
-            return IsKeyedService(serviceType, computedKey)
-                ? serviceProvider.GetKeyedService(serviceType, computedKey)
+            return ContainsLocalEndpointService(serviceType, computedKey)
+                ? serviceProvider.GetKeyedService(serviceType, GetLocalEndpointServiceKey(computedKey))
                 : serviceProvider.GetKeyedService(serviceType, GetBaseKeyOrServiceKey(serviceKey));
         }
 
         var itemType = serviceType.GetGenericArguments()[0];
         if (!Equals(computedKey, anyKey))
         {
-            return IsKeyedService(itemType, computedKey)
-                ? serviceProvider.GetKeyedServices(itemType, computedKey)
+            return ContainsLocalEndpointService(itemType, computedKey)
+                ? serviceProvider.GetKeyedServices(itemType, GetLocalEndpointServiceKey(computedKey))
                 : serviceProvider.GetKeyedServices(itemType, GetBaseKeyOrServiceKey(serviceKey));
         }
 
@@ -148,16 +165,16 @@ sealed class KeyedServiceProviderAdapter : IKeyedServiceProvider, ISupportRequir
         var computedKey = GetOrCreateComputedKey(serviceKey);
         if (!IsServicesRequest(serviceType))
         {
-            return IsKeyedService(serviceType, computedKey)
-                ? serviceProvider.GetRequiredKeyedService(serviceType, computedKey)
+            return ContainsLocalEndpointService(serviceType, computedKey)
+                ? serviceProvider.GetRequiredKeyedService(serviceType, GetLocalEndpointServiceKey(computedKey))
                 : serviceProvider.GetRequiredKeyedService(serviceType, GetBaseKeyOrServiceKey(serviceKey));
         }
 
         var itemType = serviceType.GetGenericArguments()[0];
         if (!Equals(computedKey, anyKey))
         {
-            return IsKeyedService(itemType, computedKey)
-                ? serviceProvider.GetKeyedServices(itemType, computedKey)
+            return ContainsLocalEndpointService(itemType, computedKey)
+                ? serviceProvider.GetKeyedServices(itemType, GetLocalEndpointServiceKey(computedKey))
                 : serviceProvider.GetKeyedServices(itemType, GetBaseKeyOrServiceKey(serviceKey));
         }
 
@@ -204,6 +221,50 @@ sealed class KeyedServiceProviderAdapter : IKeyedServiceProvider, ISupportRequir
     // this allows resolving services by either the KeyedServiceKey or the base key and makes the experience consistent
     static object? GetBaseKeyOrServiceKey(object? serviceKey) => serviceKey is KeyedServiceKey key ? key.BaseKey : serviceKey;
 
+    bool ContainsLocalEndpointService(Type serviceType, KeyedServiceKey key) => Equals(serviceKeyedServiceKey.BaseKey, key.BaseKey) && serviceCollection.ContainsLocalService(serviceType, key.ServiceKey);
+
+    KeyedServiceKey GetLocalEndpointServiceKey(KeyedServiceKey key) => serviceCollection.GetLocalServiceKey(key.ServiceKey);
+
+    bool ContainsRootEndpointKeyedService(Type serviceType) => ContainsRootKeyedService(serviceType, serviceKeyedServiceKey.BaseKey);
+
+    bool ContainsRootService(Type serviceType)
+    {
+        var rootServiceProbe = serviceProvider?.GetService<IServiceProviderIsService>();
+        if (rootServiceProbe?.IsService(serviceType) == true)
+        {
+            return true;
+        }
+
+        foreach (var descriptor in serviceCollection.Inner)
+        {
+            if (!descriptor.IsKeyedService && ServiceTypeMatches(descriptor.ServiceType, serviceType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool ContainsRootKeyedService(Type serviceType, object? serviceKey)
+    {
+        var rootKeyedServiceProbe = serviceProvider?.GetService<IServiceProviderIsKeyedService>();
+        if (rootKeyedServiceProbe?.IsKeyedService(serviceType, serviceKey) == true)
+        {
+            return true;
+        }
+
+        foreach (var descriptor in serviceCollection.Inner)
+        {
+            if (descriptor.IsKeyedService && ServiceTypeMatches(descriptor.ServiceType, serviceType) && Equals(serviceKey, descriptor.ServiceKey))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     KeyedServiceKey GetOrCreateComputedKey(object? serviceKey)
     {
         if (serviceKey is KeyedServiceKey key && Equals(serviceKeyedServiceKey.BaseKey, key.BaseKey))
@@ -226,6 +287,7 @@ sealed class KeyedServiceProviderAdapter : IKeyedServiceProvider, ISupportRequir
     }
 
     static bool IsServicesRequest(Type serviceType) => serviceType.IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+    static bool ServiceTypeMatches(Type registeredServiceType, Type requestedServiceType) => registeredServiceType == requestedServiceType || (requestedServiceType.IsGenericType && registeredServiceType == requestedServiceType.GetGenericTypeDefinition());
     static bool IsServiceProvider(Type serviceType) => serviceType == typeof(IServiceProvider) || serviceType == typeof(ISupportRequiredService) || serviceType == typeof(IServiceProviderIsKeyedService) || serviceType == typeof(IServiceProviderIsService);
     static bool IsScopeFactory(Type serviceType) => serviceType == typeof(IServiceScopeFactory);
 


### PR DESCRIPTION
This fixes a gap in the keyed endpoint service provider adapter introduced in the 10.2 multi-hosting work.

When an endpoint is registered with an endpoint identifier, services registered directly on the root `IServiceCollection` with that endpoint key should be resolvable from inside endpoint-created components. Before this change, the adapter only considered services registered through the endpoint-local service collection adapter. That meant constructor injection inside handlers and other endpoint components could fail even though the service was registered in the underlying Microsoft DI container.

The scenario was not covered by the existing acceptance tests. Those tests mostly go through the acceptance testing infrastructure, which adapts endpoint registrations into keyed services for us. That made the endpoint-local keyed path work, but did not exercise the case where a user manually registers an endpoint-keyed service on the root service collection.

The change separates the responsibilities a bit more clearly:

- `KeyedServiceCollectionAdapter` tracks the endpoint-local registrations it projects into the root collection.
- `KeyedServiceProviderAdapter` owns the runtime lookup policy and now falls back to root keyed services where appropriate.
- Lookup decisions are cached per provider adapter to avoid repeatedly scanning registrations on hot resolution paths. This is scoped to each provider adapter, which is created after the underlying service provider has been built, so the lookup results are stable for the lifetime of the adapter.

The test coverage now includes:

- globally registered endpoint-keyed services resolving inside one or more keyed endpoints
- local keyed services continuing to use endpoint-specific composite keys
- local and root keyed registrations coexisting without leaking between endpoints
- `IServiceProviderIsService` / `IServiceProviderIsKeyedService` behavior
- enumerable and wildcard keyed resolution paths

Azure Functions should not be affected by the bug because the infrastructure and documented usage there rely on explicit keyed service resolution.

- Fixes #7834
- Backported to 10.2 branch in #7833