### PR TITLE
Optimize DispatchProperties and ReceiveProperties storage

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/DeepCopy.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/DeepCopy.cs
@@ -15,6 +15,7 @@ namespace System
     using System.ArrayExtensions;
     using System.Collections.Generic;
     using System.Reflection;
+    using System.Runtime.CompilerServices;
 
     [Diagnostics.CodeAnalysis.SuppressMessage("Code", "PS0025:Dictionary keys should implement IEquatable<T>",
         Justification = "A DeepCopy algorithm requires reference counting necessitating dictionaries keyed on objects by reference")]
@@ -123,7 +124,11 @@ namespace System
                 return 0;
             }
 
-            return obj.GetHashCode();
+            // RuntimeHelpers.GetHashCode returns the identity hash code, which avoids
+            // calling ValueType.GetHashCode() on structs marked with [InlineArray]
+            // (that throws NotSupportedException). This matches the BCL
+            // System.Collections.Generic.ReferenceEqualityComparer behavior.
+            return RuntimeHelpers.GetHashCode(obj);
         }
     }
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2473,7 +2473,7 @@ namespace NServiceBus.Transport
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, string>> GetEnumerator() { }
         public bool Remove(string key) { }
         public bool TryAdd(string key, string value) { }
-        public bool TryGetValue(string key, out string value) { }
+        public bool TryGetValue(string key, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out string value) { }
     }
     public class ErrorContext
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2455,13 +2455,26 @@ namespace NServiceBus.Transport
         Default = 1,
         Isolated = 2,
     }
-    public class DispatchProperties : System.Collections.Generic.Dictionary<string, string>
+    public class DispatchProperties : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.Generic.IDictionary<string, string>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
     {
         public DispatchProperties() { }
         public DispatchProperties(System.Collections.Generic.Dictionary<string, string> properties) { }
-        public NServiceBus.DelayedDelivery.DelayDeliveryWith DelayDeliveryWith { get; set; }
-        public NServiceBus.Performance.TimeToBeReceived.DiscardIfNotReceivedBefore DiscardIfNotReceivedBefore { get; set; }
-        public NServiceBus.DelayedDelivery.DoNotDeliverBefore DoNotDeliverBefore { get; set; }
+        public DispatchProperties(System.Collections.Generic.IDictionary<string, string> properties) { }
+        public int Count { get; }
+        public NServiceBus.DelayedDelivery.DelayDeliveryWith? DelayDeliveryWith { get; set; }
+        public NServiceBus.Performance.TimeToBeReceived.DiscardIfNotReceivedBefore? DiscardIfNotReceivedBefore { get; set; }
+        public NServiceBus.DelayedDelivery.DoNotDeliverBefore? DoNotDeliverBefore { get; set; }
+        public bool IsReadOnly { get; }
+        public string this[string key] { get; set; }
+        public System.Collections.Generic.ICollection<string> Keys { get; }
+        public System.Collections.Generic.ICollection<string> Values { get; }
+        public void Add(string key, string value) { }
+        public void Clear() { }
+        public bool ContainsKey(string key) { }
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, string>> GetEnumerator() { }
+        public bool Remove(string key) { }
+        public bool TryAdd(string key, string value) { }
+        public bool TryGetValue(string key, out string value) { }
     }
     public class ErrorContext
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2458,7 +2458,6 @@ namespace NServiceBus.Transport
     public class DispatchProperties : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.Generic.IDictionary<string, string>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
     {
         public DispatchProperties() { }
-        public DispatchProperties(System.Collections.Generic.Dictionary<string, string> properties) { }
         public DispatchProperties(System.Collections.Generic.IDictionary<string, string> properties) { }
         public int Count { get; }
         public NServiceBus.DelayedDelivery.DelayDeliveryWith? DelayDeliveryWith { get; set; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2455,9 +2455,10 @@ namespace NServiceBus.Transport
         Default = 1,
         Isolated = 2,
     }
-    public class DispatchProperties : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.Generic.IDictionary<string, string>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
+    public class DispatchProperties : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.Generic.IDictionary<string, string>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.Generic.IReadOnlyDictionary<string, string>, System.Collections.IEnumerable
     {
         public DispatchProperties() { }
+        public DispatchProperties(System.Collections.Generic.Dictionary<string, string> properties) { }
         public DispatchProperties(System.Collections.Generic.IDictionary<string, string> properties) { }
         public int Count { get; }
         public NServiceBus.DelayedDelivery.DelayDeliveryWith? DelayDeliveryWith { get; set; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
@@ -53,6 +53,7 @@ NServiceBus.Settings.IReadOnlySettings
 NServiceBus.Settings.SettingsHolder
 NServiceBus.SubscriptionMigrationModeSettings
 NServiceBus.Transport.DispatchProperties
+NServiceBus.Support.RuntimeEnvironment
 NServiceBus.Transport.ErrorContext
 NServiceBus.Transport.IMessageDispatcher
 NServiceBus.Transport.IMessageReceiver

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
@@ -52,8 +52,6 @@ NServiceBus.SagasConfigExtensions
 NServiceBus.Settings.IReadOnlySettings
 NServiceBus.Settings.SettingsHolder
 NServiceBus.SubscriptionMigrationModeSettings
-NServiceBus.Transport.DispatchProperties
-NServiceBus.Support.RuntimeEnvironment
 NServiceBus.Transport.ErrorContext
 NServiceBus.Transport.IMessageDispatcher
 NServiceBus.Transport.IMessageReceiver

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/StructConventionsTests.ApproveStructsWhichDontFollowStructGuidelines.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/StructConventionsTests.ApproveStructsWhichDontFollowStructGuidelines.approved.txt
@@ -19,3 +19,21 @@ NServiceBus.Extensibility.ContextBag+Slot violates the following rules:
       - Field Value of type System.Object is a reference type.
    - The size cannot be determined because there are fields that are reference types.
 
+NServiceBus.Transport.DispatchProperties+Slot violates the following rules:
+   - The following fields are public, so the type is not immutable:
+      - Field Key of type System.String is public.
+      - Field Value of type System.String is public.
+   - The following fields are reference types, which are potentially mutable:
+      - Field Key of type System.String is a reference type.
+      - Field Value of type System.String is a reference type.
+   - The size cannot be determined because there are fields that are reference types.
+
+NServiceBus.Transport.ReceiveProperties+Slot violates the following rules:
+   - The following fields are public, so the type is not immutable:
+      - Field Key of type System.String is public.
+      - Field Value of type System.String is public.
+   - The following fields are reference types, which are potentially mutable:
+      - Field Key of type System.String is a reference type.
+      - Field Value of type System.String is a reference type.
+   - The size cannot be determined because there are fields that are reference types.
+

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
@@ -43,7 +43,7 @@ public class TransportReceiveToPhysicalMessageConnectorTests
 
         await Invoke(context);
 
-        var operationProperties = new DispatchProperties(fakeBatchPipeline.TransportOperations?.First().Properties);
+        var operationProperties = new DispatchProperties(fakeBatchPipeline.TransportOperations?.First().Properties ?? []);
         var delayDeliveryWith = operationProperties.DelayDeliveryWith;
         Assert.That(delayDeliveryWith, Is.Not.Null);
         Assert.That(delayDeliveryWith.Delay, Is.EqualTo(TimeSpan.FromSeconds(10)));
@@ -94,14 +94,12 @@ public class TransportReceiveToPhysicalMessageConnectorTests
         var messageId = "id";
         var properties = new DispatchProperties
         {
-            ["EventType"] = typeof(MyEvent).AssemblyQualifiedName
+            ["EventType"] = typeof(MyEvent).AssemblyQualifiedName!
         };
 
-
-        fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new[]
-        {
+        fakeOutbox.ExistingMessage = new OutboxMessage(messageId, [
             new NServiceBus.Outbox.TransportOperation("x", properties, Array.Empty<byte>(), [])
-        });
+        ]);
 
         var context = CreateContext(fakeBatchPipeline, messageId);
 

--- a/src/NServiceBus.Core.Tests/Transports/ReceivePropertiesTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/ReceivePropertiesTests.cs
@@ -34,7 +34,7 @@ public class ReceivePropertiesTests
     }
 
     [Test]
-    public void Should_be_same_reference_as_source()
+    public void Should_copy_from_provided_dictionary()
     {
         var source = new Dictionary<string, string> { ["Key"] = "Value" };
         var properties = new ReceiveProperties(source);

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
@@ -128,16 +128,19 @@ class TransportReceiveToPhysicalMessageConnector(
         }
     }
 
-    static AddressTag DeserializeRoutingStrategy(DispatchProperties options)
+    static AddressTag DeserializeRoutingStrategy(DispatchProperties? options)
     {
-        if (options.Remove("Destination", out var destination))
+        if (options is not null)
         {
-            return new UnicastAddressTag(destination);
-        }
+            if (options.Remove("Destination", out var destination))
+            {
+                return new UnicastAddressTag(destination);
+            }
 
-        if (options.Remove("EventType", out var eventType))
-        {
-            return new MulticastAddressTag(Type.GetType(eventType, true));
+            if (options.Remove("EventType", out var eventType))
+            {
+                return new MulticastAddressTag(Type.GetType(eventType, true));
+            }
         }
 
         throw new Exception("Could not find routing strategy to deserialize");

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
@@ -113,7 +113,7 @@ class TransportReceiveToPhysicalMessageConnector(
         return transportOperations;
     }
 
-    static void SerializeRoutingStrategy(AddressTag addressTag, Dictionary<string, string> options)
+    static void SerializeRoutingStrategy(AddressTag addressTag, DispatchProperties options)
     {
         switch (addressTag)
         {
@@ -128,19 +128,16 @@ class TransportReceiveToPhysicalMessageConnector(
         }
     }
 
-    static AddressTag DeserializeRoutingStrategy(Dictionary<string, string>? options)
+    static AddressTag DeserializeRoutingStrategy(DispatchProperties options)
     {
-        if (options is not null)
+        if (options.Remove("Destination", out var destination))
         {
-            if (options.Remove("Destination", out var destination))
-            {
-                return new UnicastAddressTag(destination);
-            }
+            return new UnicastAddressTag(destination);
+        }
 
-            if (options.Remove("EventType", out var eventType))
-            {
-                return new MulticastAddressTag(Type.GetType(eventType, true));
-            }
+        if (options.Remove("EventType", out var eventType))
+        {
+            return new MulticastAddressTag(Type.GetType(eventType, true));
         }
 
         throw new Exception("Could not find routing strategy to deserialize");

--- a/src/NServiceBus.Core/Transports/DispatchProperties.cs
+++ b/src/NServiceBus.Core/Transports/DispatchProperties.cs
@@ -17,9 +17,9 @@ using Performance.TimeToBeReceived;
 public class DispatchProperties : IDictionary<string, string>
 {
     //These can't be changed to be backwards compatible with previous versions of the core
-    static readonly string DoNotDeliverBeforeKeyName = "DeliverAt";
-    static readonly string DelayDeliveryWithKeyName = "DelayDeliveryFor";
-    static readonly string DiscardIfNotReceivedBeforeKeyName = "TimeToBeReceived";
+    const string DoNotDeliverBeforeKeyName = "DeliverAt";
+    const string DelayDeliveryWithKeyName = "DelayDeliveryFor";
+    const string DiscardIfNotReceivedBeforeKeyName = "TimeToBeReceived";
 
     // Dedicated fields for the three well-known properties, avoiding string-key lookups
     string? deliverAt;
@@ -132,7 +132,7 @@ public class DispatchProperties : IDictionary<string, string>
             }
 
             ThrowKeyNotFoundException(key);
-            return default;
+            return null;
         }
         set
         {
@@ -191,12 +191,14 @@ public class DispatchProperties : IDictionary<string, string>
                 keys[index++] = slots[i].Key;
             }
 
-            if (stash is not null)
+            if (stash is null)
             {
-                foreach (var key in stash.Keys)
-                {
-                    keys[index++] = key;
-                }
+                return keys;
+            }
+
+            foreach (var key in stash.Keys)
+            {
+                keys[index++] = key;
             }
 
             return keys;
@@ -231,12 +233,14 @@ public class DispatchProperties : IDictionary<string, string>
                 values[index++] = slots[i].Value;
             }
 
-            if (stash is not null)
+            if (stash is null)
             {
-                foreach (var value in stash.Values)
-                {
-                    values[index++] = value;
-                }
+                return values;
+            }
+
+            foreach (var value in stash.Values)
+            {
+                values[index++] = value;
             }
 
             return values;
@@ -331,18 +335,19 @@ public class DispatchProperties : IDictionary<string, string>
         {
             ref var slot = ref slots[i];
 
-            if (StringComparer.Ordinal.Equals(key, slot.Key))
+            if (!StringComparer.Ordinal.Equals(key, slot.Key))
             {
-                count--;
-
-                if (i != count)
-                {
-                    slots[i] = slots[count];
-                }
-
-                slots[count] = new Slot();
-                return true;
+                continue;
             }
+
+            count--;
+            if (i != count)
+            {
+                slots[i] = slots[count];
+            }
+
+            slots[count] = new Slot();
+            return true;
         }
 
         return stash?.Remove(key) ?? false;
@@ -361,11 +366,13 @@ public class DispatchProperties : IDictionary<string, string>
         {
             ref var slot = ref slots[i];
 
-            if (StringComparer.Ordinal.Equals(key, slot.Key))
+            if (!StringComparer.Ordinal.Equals(key, slot.Key))
             {
-                value = slot.Value;
-                return true;
+                continue;
             }
+
+            value = slot.Value;
+            return true;
         }
 
         if (stash is not null && stash.TryGetValue(key, out var stashedValue))
@@ -374,7 +381,7 @@ public class DispatchProperties : IDictionary<string, string>
             return true;
         }
 
-        value = default!;
+        value = null!;
         return false;
     }
 
@@ -448,12 +455,14 @@ public class DispatchProperties : IDictionary<string, string>
             yield return new KeyValuePair<string, string>(slot.Key, slot.Value);
         }
 
-        if (stash is not null)
+        if (stash is null)
         {
-            foreach (var kvp in stash)
-            {
-                yield return kvp;
-            }
+            yield break;
+        }
+
+        foreach (var kvp in stash)
+        {
+            yield return kvp;
         }
     }
 
@@ -471,12 +480,7 @@ public class DispatchProperties : IDictionary<string, string>
             return true;
         }
 
-        if (timeToBeReceived is not null && key == DiscardIfNotReceivedBeforeKeyName)
-        {
-            return true;
-        }
-
-        return false;
+        return timeToBeReceived is not null && key == DiscardIfNotReceivedBeforeKeyName;
     }
 
     bool TryGetValueFromFields(string key, out string value)
@@ -499,31 +503,26 @@ public class DispatchProperties : IDictionary<string, string>
             return true;
         }
 
-        value = default!;
+        value = null!;
         return false;
     }
 
     bool TrySetField(string key, string value)
     {
-        if (key == DoNotDeliverBeforeKeyName)
+        switch (key)
         {
-            deliverAt = value;
-            return true;
+            case DoNotDeliverBeforeKeyName:
+                deliverAt = value;
+                return true;
+            case DelayDeliveryWithKeyName:
+                delayDeliveryFor = value;
+                return true;
+            case DiscardIfNotReceivedBeforeKeyName:
+                timeToBeReceived = value;
+                return true;
+            default:
+                return false;
         }
-
-        if (key == DelayDeliveryWithKeyName)
-        {
-            delayDeliveryFor = value;
-            return true;
-        }
-
-        if (key == DiscardIfNotReceivedBeforeKeyName)
-        {
-            timeToBeReceived = value;
-            return true;
-        }
-
-        return false;
     }
 
     bool RemoveFromFields(string key)
@@ -540,13 +539,14 @@ public class DispatchProperties : IDictionary<string, string>
             return true;
         }
 
-        if (timeToBeReceived is not null && key == DiscardIfNotReceivedBeforeKeyName)
+        if (timeToBeReceived is null || key != DiscardIfNotReceivedBeforeKeyName)
         {
-            timeToBeReceived = null;
-            return true;
+            return false;
         }
 
-        return false;
+        timeToBeReceived = null;
+        return true;
+
     }
 
     void AddInternal(string key, string value)
@@ -568,10 +568,7 @@ public class DispatchProperties : IDictionary<string, string>
 
     void ICollection<KeyValuePair<string, string>>.Add(KeyValuePair<string, string> item) => Add(item.Key, item.Value);
 
-    bool ICollection<KeyValuePair<string, string>>.Contains(KeyValuePair<string, string> item)
-    {
-        return TryGetValue(item.Key, out var value) && StringComparer.Ordinal.Equals(value, item.Value);
-    }
+    bool ICollection<KeyValuePair<string, string>>.Contains(KeyValuePair<string, string> item) => TryGetValue(item.Key, out var value) && StringComparer.Ordinal.Equals(value, item.Value);
 
     void ICollection<KeyValuePair<string, string>>.CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
     {
@@ -606,24 +603,18 @@ public class DispatchProperties : IDictionary<string, string>
             array[index++] = new KeyValuePair<string, string>(slot.Key, slot.Value);
         }
 
-        if (stash is not null)
+        if (stash is null)
         {
-            foreach (var kvp in stash)
-            {
-                array[index++] = kvp;
-            }
+            return;
+        }
+
+        foreach (var kvp in stash)
+        {
+            array[index++] = kvp;
         }
     }
 
-    bool ICollection<KeyValuePair<string, string>>.Remove(KeyValuePair<string, string> item)
-    {
-        if (!((ICollection<KeyValuePair<string, string>>)this).Contains(item))
-        {
-            return false;
-        }
-
-        return Remove(item.Key);
-    }
+    bool ICollection<KeyValuePair<string, string>>.Remove(KeyValuePair<string, string> item) => ((ICollection<KeyValuePair<string, string>>)this).Contains(item) && Remove(item.Key);
 
     [DoesNotReturn]
     static void ThrowKeyNotFoundException(string key) => throw new KeyNotFoundException($"The given key '{key}' was not present in the dictionary.");

--- a/src/NServiceBus.Core/Transports/DispatchProperties.cs
+++ b/src/NServiceBus.Core/Transports/DispatchProperties.cs
@@ -111,6 +111,7 @@ public class DispatchProperties : IDictionary<string, string>
     {
         get
         {
+            ArgumentNullException.ThrowIfNull(key);
             if (TryGetValueFromFields(key, out var fieldValue))
             {
                 return fieldValue;
@@ -136,6 +137,7 @@ public class DispatchProperties : IDictionary<string, string>
         }
         set
         {
+            ArgumentNullException.ThrowIfNull(key);
             if (TrySetField(key, value))
             {
                 return;
@@ -279,6 +281,7 @@ public class DispatchProperties : IDictionary<string, string>
     /// <inheritdoc />
     public void Add(string key, string value)
     {
+        ArgumentNullException.ThrowIfNull(key);
         if (ContainsKeyInFields(key))
         {
             throw new ArgumentException($"An item with the same key '{key}' has already been added.");
@@ -305,6 +308,7 @@ public class DispatchProperties : IDictionary<string, string>
     /// <inheritdoc />
     public bool ContainsKey(string key)
     {
+        ArgumentNullException.ThrowIfNull(key);
         if (ContainsKeyInFields(key))
         {
             return true;
@@ -326,6 +330,7 @@ public class DispatchProperties : IDictionary<string, string>
     /// <inheritdoc />
     public bool Remove(string key)
     {
+        ArgumentNullException.ThrowIfNull(key);
         if (RemoveFromFields(key))
         {
             return true;
@@ -356,6 +361,7 @@ public class DispatchProperties : IDictionary<string, string>
     /// <inheritdoc />
     public bool TryGetValue(string key, out string value)
     {
+        ArgumentNullException.ThrowIfNull(key);
         if (TryGetValueFromFields(key, out var fieldValue))
         {
             value = fieldValue;
@@ -391,6 +397,7 @@ public class DispatchProperties : IDictionary<string, string>
     /// <returns>true if the key/value pair was added; false if the key already exists.</returns>
     public bool TryAdd(string key, string value)
     {
+        ArgumentNullException.ThrowIfNull(key);
         if (ContainsKeyInFields(key))
         {
             return false;

--- a/src/NServiceBus.Core/Transports/DispatchProperties.cs
+++ b/src/NServiceBus.Core/Transports/DispatchProperties.cs
@@ -36,26 +36,31 @@ public class DispatchProperties : IDictionary<string, string>
     /// <summary>
     /// Creates a new instance of <see cref="DispatchProperties"/> an copies the values from the provided dictionary.
     /// </summary>
-    public DispatchProperties(Dictionary<string, string> properties)
+    public DispatchProperties(IDictionary<string, string> properties)
     {
         if (properties is null)
         {
             return;
         }
 
-        foreach (var kvp in properties)
+        if (properties is DispatchProperties source)
         {
-            AddInternal(kvp.Key, kvp.Value);
-        }
-    }
+            // Fast path: direct field copy when source is a DispatchProperties
+            deliverAt = source.deliverAt;
+            delayDeliveryFor = source.delayDeliveryFor;
+            timeToBeReceived = source.timeToBeReceived;
 
-    /// <summary>
-    /// Creates a new instance of <see cref="DispatchProperties"/> an copies the values from the provided dictionary.
-    /// </summary>
-    public DispatchProperties(IDictionary<string, string> properties)
-    {
-        if (properties is null)
-        {
+            count = source.count;
+            for (int i = 0; i < count; i++)
+            {
+                slots[i] = source.slots[i];
+            }
+
+            if (source.stash is { Count: > 0 })
+            {
+                stash = new Dictionary<string, string>(source.stash);
+            }
+
             return;
         }
 

--- a/src/NServiceBus.Core/Transports/DispatchProperties.cs
+++ b/src/NServiceBus.Core/Transports/DispatchProperties.cs
@@ -14,7 +14,7 @@ using Performance.TimeToBeReceived;
 /// Describes additional properties for an outgoing message.
 /// </summary>
 [SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "Name reflects domain semantics, not collection implementation.")]
-public class DispatchProperties : IDictionary<string, string>
+public class DispatchProperties : IDictionary<string, string>, IReadOnlyDictionary<string, string>
 {
     //These can't be changed to be backwards compatible with previous versions of the core
     const string DoNotDeliverBeforeKeyName = "DeliverAt";
@@ -30,6 +30,14 @@ public class DispatchProperties : IDictionary<string, string>
     /// Creates a new instance of <see cref="DispatchProperties"/>.
     /// </summary>
     public DispatchProperties()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="DispatchProperties"/> and copies the values from the provided dictionary.
+    /// </summary>
+    public DispatchProperties(Dictionary<string, string> properties)
+        : this((IDictionary<string, string>)properties)
     {
     }
 
@@ -572,6 +580,9 @@ public class DispatchProperties : IDictionary<string, string>
 
         (stash ??= [])[key] = value;
     }
+
+    IEnumerable<string> IReadOnlyDictionary<string, string>.Keys => Keys;
+    IEnumerable<string> IReadOnlyDictionary<string, string>.Values => Values;
 
     void ICollection<KeyValuePair<string, string>>.Add(KeyValuePair<string, string> item) => Add(item.Key, item.Value);
 

--- a/src/NServiceBus.Core/Transports/DispatchProperties.cs
+++ b/src/NServiceBus.Core/Transports/DispatchProperties.cs
@@ -1,14 +1,20 @@
-﻿namespace NServiceBus.Transport;
+#nullable enable
+
+namespace NServiceBus.Transport;
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using DelayedDelivery;
 using Performance.TimeToBeReceived;
 
 /// <summary>
 /// Describes additional properties for an outgoing message.
 /// </summary>
-public class DispatchProperties : Dictionary<string, string>
+[SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "Name reflects domain semantics, not collection implementation.")]
+public class DispatchProperties : IDictionary<string, string>
 {
     //These can't be changed to be backwards compatible with previous versions of the core
     static readonly string DoNotDeliverBeforeKeyName = "DeliverAt";
@@ -25,43 +31,390 @@ public class DispatchProperties : Dictionary<string, string>
     /// <summary>
     /// Creates a new instance of <see cref="DispatchProperties"/> an copies the values from the provided dictionary.
     /// </summary>
-    public DispatchProperties(Dictionary<string, string> properties) : base(properties ?? [])
+    public DispatchProperties(Dictionary<string, string> properties)
     {
+        if (properties is null)
+        {
+            return;
+        }
+
+        foreach (var kvp in properties)
+        {
+            AddInternal(kvp.Key, kvp.Value);
+        }
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="DispatchProperties"/> an copies the values from the provided dictionary.
+    /// </summary>
+    public DispatchProperties(IDictionary<string, string> properties)
+    {
+        if (properties is null)
+        {
+            return;
+        }
+
+        foreach (var kvp in properties)
+        {
+            AddInternal(kvp.Key, kvp.Value);
+        }
     }
 
     /// <summary>
     /// Delay message delivery to a specific <see cref="DateTimeOffset"/>.
     /// </summary>
-    public DoNotDeliverBefore DoNotDeliverBefore
+    public DoNotDeliverBefore? DoNotDeliverBefore
     {
         get => ContainsKey(DoNotDeliverBeforeKeyName)
             ? new DoNotDeliverBefore(DateTimeOffsetHelper.ToDateTimeOffset(this[DoNotDeliverBeforeKeyName]))
             : null;
 
-        set => this[DoNotDeliverBeforeKeyName] = DateTimeOffsetHelper.ToWireFormattedString(value.At);
+        set => this[DoNotDeliverBeforeKeyName] = DateTimeOffsetHelper.ToWireFormattedString(value!.At);
     }
 
     /// <summary>
     /// Delay message delivery by a certain <see cref="TimeSpan"/>.
     /// </summary>
-    public DelayDeliveryWith DelayDeliveryWith
+    public DelayDeliveryWith? DelayDeliveryWith
     {
         get => ContainsKey(DelayDeliveryWithKeyName)
             ? new DelayDeliveryWith(TimeSpan.Parse(this[DelayDeliveryWithKeyName]))
             : null;
 
-        set => this[DelayDeliveryWithKeyName] = value.Delay.ToString();
+        set => this[DelayDeliveryWithKeyName] = value!.Delay.ToString();
     }
 
     /// <summary>
     /// Discard the message after a certain period of time.
     /// </summary>
-    public DiscardIfNotReceivedBefore DiscardIfNotReceivedBefore
+    public DiscardIfNotReceivedBefore? DiscardIfNotReceivedBefore
     {
         get => ContainsKey(DiscardIfNotReceivedBeforeKeyName)
             ? new DiscardIfNotReceivedBefore(TimeSpan.Parse(this[DiscardIfNotReceivedBeforeKeyName]))
             : null;
 
-        set => this[DiscardIfNotReceivedBeforeKeyName] = value.MaxTime.ToString();
+        set => this[DiscardIfNotReceivedBeforeKeyName] = value!.MaxTime.ToString();
+    }
+
+    /// <inheritdoc />
+    public string this[string key]
+    {
+        get
+        {
+            for (int i = 0; i < count; i++)
+            {
+                ref var slot = ref slots[i];
+
+                if (StringComparer.Ordinal.Equals(key, slot.Key))
+                {
+                    return slot.Value;
+                }
+            }
+
+            if (stash is not null && stash.TryGetValue(key, out var value))
+            {
+                return value;
+            }
+
+            ThrowKeyNotFoundException(key);
+            return default;
+        }
+        set
+        {
+            for (int i = 0; i < count; i++)
+            {
+                ref var slot = ref slots[i];
+
+                if (StringComparer.Ordinal.Equals(key, slot.Key))
+                {
+                    slot.Value = value;
+                    return;
+                }
+            }
+
+            if (count < InlineArrayLength)
+            {
+                slots[count] = new Slot { Key = key, Value = value };
+                count++;
+                return;
+            }
+
+            (stash ??= [])[key] = value;
+        }
+    }
+
+    /// <inheritdoc />
+    public ICollection<string> Keys
+    {
+        get
+        {
+            var keys = new string[count + (stash?.Count ?? 0)];
+            int index = 0;
+
+            for (int i = 0; i < count; i++)
+            {
+                keys[index++] = slots[i].Key;
+            }
+
+            if (stash is not null)
+            {
+                foreach (var key in stash.Keys)
+                {
+                    keys[index++] = key;
+                }
+            }
+
+            return keys;
+        }
+    }
+
+    /// <inheritdoc />
+    public ICollection<string> Values
+    {
+        get
+        {
+            var values = new string[count + (stash?.Count ?? 0)];
+            int index = 0;
+
+            for (int i = 0; i < count; i++)
+            {
+                values[index++] = slots[i].Value;
+            }
+
+            if (stash is not null)
+            {
+                foreach (var value in stash.Values)
+                {
+                    values[index++] = value;
+                }
+            }
+
+            return values;
+        }
+    }
+
+    /// <inheritdoc />
+    public int Count => count + (stash?.Count ?? 0);
+
+    /// <inheritdoc />
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc />
+    public void Add(string key, string value)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            ref var slot = ref slots[i];
+
+            if (StringComparer.Ordinal.Equals(key, slot.Key))
+            {
+                throw new ArgumentException($"An item with the same key '{key}' has already been added.");
+            }
+        }
+
+        if (stash is not null && stash.ContainsKey(key))
+        {
+            throw new ArgumentException($"An item with the same key '{key}' has already been added.");
+        }
+
+        AddInternal(key, value);
+    }
+
+    /// <inheritdoc />
+    public bool ContainsKey(string key)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            ref var slot = ref slots[i];
+
+            if (StringComparer.Ordinal.Equals(key, slot.Key))
+            {
+                return true;
+            }
+        }
+
+        return stash is not null && stash.ContainsKey(key);
+    }
+
+    /// <inheritdoc />
+    public bool Remove(string key)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            ref var slot = ref slots[i];
+
+            if (StringComparer.Ordinal.Equals(key, slot.Key))
+            {
+                count--;
+
+                if (i != count)
+                {
+                    slots[i] = slots[count];
+                }
+
+                slots[count] = new Slot();
+                return true;
+            }
+        }
+
+        return stash?.Remove(key) ?? false;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetValue(string key, out string value)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            ref var slot = ref slots[i];
+
+            if (StringComparer.Ordinal.Equals(key, slot.Key))
+            {
+                value = slot.Value;
+                return true;
+            }
+        }
+
+        if (stash is not null && stash.TryGetValue(key, out var stashedValue))
+        {
+            value = stashedValue;
+            return true;
+        }
+
+        value = default!;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to add the specified key and value to the dictionary.
+    /// </summary>
+    /// <returns>true if the key/value pair was added; false if the key already exists.</returns>
+    public bool TryAdd(string key, string value)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            ref var slot = ref slots[i];
+
+            if (StringComparer.Ordinal.Equals(key, slot.Key))
+            {
+                return false;
+            }
+        }
+
+        if (stash is not null && stash.ContainsKey(key))
+        {
+            return false;
+        }
+
+        AddInternal(key, value);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public void Clear()
+    {
+        for (int i = 0; i < count; i++)
+        {
+            slots[i] = default;
+        }
+
+        count = 0;
+        stash?.Clear();
+    }
+
+    /// <inheritdoc />
+    public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+    {
+        for (int i = 0; i < count; i++)
+        {
+            ref var slot = ref slots[i];
+            yield return new KeyValuePair<string, string>(slot.Key, slot.Value);
+        }
+
+        if (stash is not null)
+        {
+            foreach (var kvp in stash)
+            {
+                yield return kvp;
+            }
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    void AddInternal(string key, string value)
+    {
+        if (count < InlineArrayLength)
+        {
+            slots[count] = new Slot { Key = key, Value = value };
+            count++;
+            return;
+        }
+
+        (stash ??= [])[key] = value;
+    }
+
+    void ICollection<KeyValuePair<string, string>>.Add(KeyValuePair<string, string> item) => Add(item.Key, item.Value);
+
+    bool ICollection<KeyValuePair<string, string>>.Contains(KeyValuePair<string, string> item)
+    {
+        return TryGetValue(item.Key, out var value) && StringComparer.Ordinal.Equals(value, item.Value);
+    }
+
+    void ICollection<KeyValuePair<string, string>>.CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
+    {
+        ArgumentNullException.ThrowIfNull(array);
+        ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+
+        if (array.Length - arrayIndex < Count)
+        {
+            throw new ArgumentException("Destination array is not long enough to copy all items.");
+        }
+
+        int index = arrayIndex;
+
+        for (int i = 0; i < count; i++)
+        {
+            ref var slot = ref slots[i];
+            array[index++] = new KeyValuePair<string, string>(slot.Key, slot.Value);
+        }
+
+        if (stash is not null)
+        {
+            foreach (var kvp in stash)
+            {
+                array[index++] = kvp;
+            }
+        }
+    }
+
+    bool ICollection<KeyValuePair<string, string>>.Remove(KeyValuePair<string, string> item)
+    {
+        if (!((ICollection<KeyValuePair<string, string>>)this).Contains(item))
+        {
+            return false;
+        }
+
+        return Remove(item.Key);
+    }
+
+    [DoesNotReturn]
+    static void ThrowKeyNotFoundException(string key) => throw new KeyNotFoundException($"The given key '{key}' was not present in the dictionary.");
+
+    SlotArray slots;
+    int count;
+    Dictionary<string, string>? stash;
+
+    const int InlineArrayLength = 4;
+
+    struct Slot
+    {
+        public string Key;
+        public string Value;
+    }
+
+    [InlineArray(InlineArrayLength)]
+    struct SlotArray
+    {
+        Slot _element0;
     }
 }

--- a/src/NServiceBus.Core/Transports/DispatchProperties.cs
+++ b/src/NServiceBus.Core/Transports/DispatchProperties.cs
@@ -359,7 +359,7 @@ public class DispatchProperties : IDictionary<string, string>
     }
 
     /// <inheritdoc />
-    public bool TryGetValue(string key, out string value)
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out string value)
     {
         ArgumentNullException.ThrowIfNull(key);
         if (TryGetValueFromFields(key, out var fieldValue))

--- a/src/NServiceBus.Core/Transports/DispatchProperties.cs
+++ b/src/NServiceBus.Core/Transports/DispatchProperties.cs
@@ -42,7 +42,7 @@ public class DispatchProperties : IDictionary<string, string>, IReadOnlyDictiona
     }
 
     /// <summary>
-    /// Creates a new instance of <see cref="DispatchProperties"/> an copies the values from the provided dictionary.
+    /// Creates a new instance of <see cref="DispatchProperties"/> and copies the values from the provided dictionary.
     /// </summary>
     public DispatchProperties(IDictionary<string, string> properties)
     {

--- a/src/NServiceBus.Core/Transports/DispatchProperties.cs
+++ b/src/NServiceBus.Core/Transports/DispatchProperties.cs
@@ -21,6 +21,11 @@ public class DispatchProperties : IDictionary<string, string>
     static readonly string DelayDeliveryWithKeyName = "DelayDeliveryFor";
     static readonly string DiscardIfNotReceivedBeforeKeyName = "TimeToBeReceived";
 
+    // Dedicated fields for the three well-known properties, avoiding string-key lookups
+    string? deliverAt;
+    string? delayDeliveryFor;
+    string? timeToBeReceived;
+
     /// <summary>
     /// Creates a new instance of <see cref="DispatchProperties"/>.
     /// </summary>
@@ -65,11 +70,11 @@ public class DispatchProperties : IDictionary<string, string>
     /// </summary>
     public DoNotDeliverBefore? DoNotDeliverBefore
     {
-        get => ContainsKey(DoNotDeliverBeforeKeyName)
-            ? new DoNotDeliverBefore(DateTimeOffsetHelper.ToDateTimeOffset(this[DoNotDeliverBeforeKeyName]))
+        get => deliverAt is not null
+            ? new DoNotDeliverBefore(DateTimeOffsetHelper.ToDateTimeOffset(deliverAt))
             : null;
 
-        set => this[DoNotDeliverBeforeKeyName] = DateTimeOffsetHelper.ToWireFormattedString(value!.At);
+        set => deliverAt = value is not null ? DateTimeOffsetHelper.ToWireFormattedString(value.At) : null;
     }
 
     /// <summary>
@@ -77,11 +82,11 @@ public class DispatchProperties : IDictionary<string, string>
     /// </summary>
     public DelayDeliveryWith? DelayDeliveryWith
     {
-        get => ContainsKey(DelayDeliveryWithKeyName)
-            ? new DelayDeliveryWith(TimeSpan.Parse(this[DelayDeliveryWithKeyName]))
+        get => delayDeliveryFor is not null
+            ? new DelayDeliveryWith(TimeSpan.Parse(delayDeliveryFor))
             : null;
 
-        set => this[DelayDeliveryWithKeyName] = value!.Delay.ToString();
+        set => delayDeliveryFor = value?.Delay.ToString();
     }
 
     /// <summary>
@@ -89,11 +94,11 @@ public class DispatchProperties : IDictionary<string, string>
     /// </summary>
     public DiscardIfNotReceivedBefore? DiscardIfNotReceivedBefore
     {
-        get => ContainsKey(DiscardIfNotReceivedBeforeKeyName)
-            ? new DiscardIfNotReceivedBefore(TimeSpan.Parse(this[DiscardIfNotReceivedBeforeKeyName]))
+        get => timeToBeReceived is not null
+            ? new DiscardIfNotReceivedBefore(TimeSpan.Parse(timeToBeReceived))
             : null;
 
-        set => this[DiscardIfNotReceivedBeforeKeyName] = value!.MaxTime.ToString();
+        set => timeToBeReceived = value?.MaxTime.ToString();
     }
 
     /// <inheritdoc />
@@ -101,6 +106,11 @@ public class DispatchProperties : IDictionary<string, string>
     {
         get
         {
+            if (TryGetValueFromFields(key, out var fieldValue))
+            {
+                return fieldValue;
+            }
+
             for (int i = 0; i < count; i++)
             {
                 ref var slot = ref slots[i];
@@ -121,6 +131,11 @@ public class DispatchProperties : IDictionary<string, string>
         }
         set
         {
+            if (TrySetField(key, value))
+            {
+                return;
+            }
+
             for (int i = 0; i < count; i++)
             {
                 ref var slot = ref slots[i];
@@ -148,8 +163,23 @@ public class DispatchProperties : IDictionary<string, string>
     {
         get
         {
-            var keys = new string[count + (stash?.Count ?? 0)];
+            var keys = new string[Count];
             int index = 0;
+
+            if (deliverAt is not null)
+            {
+                keys[index++] = DoNotDeliverBeforeKeyName;
+            }
+
+            if (delayDeliveryFor is not null)
+            {
+                keys[index++] = DelayDeliveryWithKeyName;
+            }
+
+            if (timeToBeReceived is not null)
+            {
+                keys[index++] = DiscardIfNotReceivedBeforeKeyName;
+            }
 
             for (int i = 0; i < count; i++)
             {
@@ -173,8 +203,23 @@ public class DispatchProperties : IDictionary<string, string>
     {
         get
         {
-            var values = new string[count + (stash?.Count ?? 0)];
+            var values = new string[Count];
             int index = 0;
+
+            if (deliverAt is not null)
+            {
+                values[index++] = deliverAt;
+            }
+
+            if (delayDeliveryFor is not null)
+            {
+                values[index++] = delayDeliveryFor;
+            }
+
+            if (timeToBeReceived is not null)
+            {
+                values[index++] = timeToBeReceived;
+            }
 
             for (int i = 0; i < count; i++)
             {
@@ -194,7 +239,30 @@ public class DispatchProperties : IDictionary<string, string>
     }
 
     /// <inheritdoc />
-    public int Count => count + (stash?.Count ?? 0);
+    public int Count
+    {
+        get
+        {
+            int fieldCount = 0;
+
+            if (deliverAt is not null)
+            {
+                fieldCount++;
+            }
+
+            if (delayDeliveryFor is not null)
+            {
+                fieldCount++;
+            }
+
+            if (timeToBeReceived is not null)
+            {
+                fieldCount++;
+            }
+
+            return fieldCount + count + (stash?.Count ?? 0);
+        }
+    }
 
     /// <inheritdoc />
     public bool IsReadOnly => false;
@@ -202,6 +270,11 @@ public class DispatchProperties : IDictionary<string, string>
     /// <inheritdoc />
     public void Add(string key, string value)
     {
+        if (ContainsKeyInFields(key))
+        {
+            throw new ArgumentException($"An item with the same key '{key}' has already been added.");
+        }
+
         for (int i = 0; i < count; i++)
         {
             ref var slot = ref slots[i];
@@ -223,6 +296,11 @@ public class DispatchProperties : IDictionary<string, string>
     /// <inheritdoc />
     public bool ContainsKey(string key)
     {
+        if (ContainsKeyInFields(key))
+        {
+            return true;
+        }
+
         for (int i = 0; i < count; i++)
         {
             ref var slot = ref slots[i];
@@ -239,6 +317,11 @@ public class DispatchProperties : IDictionary<string, string>
     /// <inheritdoc />
     public bool Remove(string key)
     {
+        if (RemoveFromFields(key))
+        {
+            return true;
+        }
+
         for (int i = 0; i < count; i++)
         {
             ref var slot = ref slots[i];
@@ -263,6 +346,12 @@ public class DispatchProperties : IDictionary<string, string>
     /// <inheritdoc />
     public bool TryGetValue(string key, out string value)
     {
+        if (TryGetValueFromFields(key, out var fieldValue))
+        {
+            value = fieldValue;
+            return true;
+        }
+
         for (int i = 0; i < count; i++)
         {
             ref var slot = ref slots[i];
@@ -290,6 +379,11 @@ public class DispatchProperties : IDictionary<string, string>
     /// <returns>true if the key/value pair was added; false if the key already exists.</returns>
     public bool TryAdd(string key, string value)
     {
+        if (ContainsKeyInFields(key))
+        {
+            return false;
+        }
+
         for (int i = 0; i < count; i++)
         {
             ref var slot = ref slots[i];
@@ -312,9 +406,13 @@ public class DispatchProperties : IDictionary<string, string>
     /// <inheritdoc />
     public void Clear()
     {
+        deliverAt = null;
+        delayDeliveryFor = null;
+        timeToBeReceived = null;
+
         for (int i = 0; i < count; i++)
         {
-            slots[i] = default;
+            slots[i] = new Slot();
         }
 
         count = 0;
@@ -324,6 +422,21 @@ public class DispatchProperties : IDictionary<string, string>
     /// <inheritdoc />
     public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
     {
+        if (deliverAt is not null)
+        {
+            yield return new KeyValuePair<string, string>(DoNotDeliverBeforeKeyName, deliverAt);
+        }
+
+        if (delayDeliveryFor is not null)
+        {
+            yield return new KeyValuePair<string, string>(DelayDeliveryWithKeyName, delayDeliveryFor);
+        }
+
+        if (timeToBeReceived is not null)
+        {
+            yield return new KeyValuePair<string, string>(DiscardIfNotReceivedBeforeKeyName, timeToBeReceived);
+        }
+
         for (int i = 0; i < count; i++)
         {
             ref var slot = ref slots[i];
@@ -341,8 +454,103 @@ public class DispatchProperties : IDictionary<string, string>
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+    bool ContainsKeyInFields(string key)
+    {
+        if (deliverAt is not null && key == DoNotDeliverBeforeKeyName)
+        {
+            return true;
+        }
+
+        if (delayDeliveryFor is not null && key == DelayDeliveryWithKeyName)
+        {
+            return true;
+        }
+
+        if (timeToBeReceived is not null && key == DiscardIfNotReceivedBeforeKeyName)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    bool TryGetValueFromFields(string key, out string value)
+    {
+        if (deliverAt is not null && key == DoNotDeliverBeforeKeyName)
+        {
+            value = deliverAt;
+            return true;
+        }
+
+        if (delayDeliveryFor is not null && key == DelayDeliveryWithKeyName)
+        {
+            value = delayDeliveryFor;
+            return true;
+        }
+
+        if (timeToBeReceived is not null && key == DiscardIfNotReceivedBeforeKeyName)
+        {
+            value = timeToBeReceived;
+            return true;
+        }
+
+        value = default!;
+        return false;
+    }
+
+    bool TrySetField(string key, string value)
+    {
+        if (key == DoNotDeliverBeforeKeyName)
+        {
+            deliverAt = value;
+            return true;
+        }
+
+        if (key == DelayDeliveryWithKeyName)
+        {
+            delayDeliveryFor = value;
+            return true;
+        }
+
+        if (key == DiscardIfNotReceivedBeforeKeyName)
+        {
+            timeToBeReceived = value;
+            return true;
+        }
+
+        return false;
+    }
+
+    bool RemoveFromFields(string key)
+    {
+        if (deliverAt is not null && key == DoNotDeliverBeforeKeyName)
+        {
+            deliverAt = null;
+            return true;
+        }
+
+        if (delayDeliveryFor is not null && key == DelayDeliveryWithKeyName)
+        {
+            delayDeliveryFor = null;
+            return true;
+        }
+
+        if (timeToBeReceived is not null && key == DiscardIfNotReceivedBeforeKeyName)
+        {
+            timeToBeReceived = null;
+            return true;
+        }
+
+        return false;
+    }
+
     void AddInternal(string key, string value)
     {
+        if (TrySetField(key, value))
+        {
+            return;
+        }
+
         if (count < InlineArrayLength)
         {
             slots[count] = new Slot { Key = key, Value = value };
@@ -371,6 +579,21 @@ public class DispatchProperties : IDictionary<string, string>
         }
 
         int index = arrayIndex;
+
+        if (deliverAt is not null)
+        {
+            array[index++] = new KeyValuePair<string, string>(DoNotDeliverBeforeKeyName, deliverAt);
+        }
+
+        if (delayDeliveryFor is not null)
+        {
+            array[index++] = new KeyValuePair<string, string>(DelayDeliveryWithKeyName, delayDeliveryFor);
+        }
+
+        if (timeToBeReceived is not null)
+        {
+            array[index++] = new KeyValuePair<string, string>(DiscardIfNotReceivedBeforeKeyName, timeToBeReceived);
+        }
 
         for (int i = 0; i < count; i++)
         {
@@ -404,7 +627,9 @@ public class DispatchProperties : IDictionary<string, string>
     int count;
     Dictionary<string, string>? stash;
 
-    const int InlineArrayLength = 4;
+    // Only needed for custom properties added by transports; the three well-known
+    // properties are stored as dedicated fields to avoid string-key lookups.
+    const int InlineArrayLength = 2;
 
     struct Slot
     {

--- a/src/NServiceBus.Core/Transports/ReceiveProperties.cs
+++ b/src/NServiceBus.Core/Transports/ReceiveProperties.cs
@@ -45,6 +45,7 @@ public sealed class ReceiveProperties : IReadOnlyDictionary<string, string>
     {
         get
         {
+            ArgumentNullException.ThrowIfNull(key);
             for (int i = 0; i < count; i++)
             {
                 ref var slot = ref slots[i];
@@ -61,7 +62,7 @@ public sealed class ReceiveProperties : IReadOnlyDictionary<string, string>
             }
 
             ThrowKeyNotFoundException(key);
-            return default;
+            return null;
         }
     }
 
@@ -111,6 +112,7 @@ public sealed class ReceiveProperties : IReadOnlyDictionary<string, string>
     /// <inheritdoc />
     public bool ContainsKey(string key)
     {
+        ArgumentNullException.ThrowIfNull(key);
         for (int i = 0; i < count; i++)
         {
             ref var slot = ref slots[i];
@@ -127,15 +129,18 @@ public sealed class ReceiveProperties : IReadOnlyDictionary<string, string>
     /// <inheritdoc />
     public bool TryGetValue(string key, [MaybeNullWhen(false)] out string value)
     {
+        ArgumentNullException.ThrowIfNull(key);
         for (int i = 0; i < count; i++)
         {
             ref var slot = ref slots[i];
 
-            if (StringComparer.Ordinal.Equals(key, slot.Key))
+            if (!StringComparer.Ordinal.Equals(key, slot.Key))
             {
-                value = slot.Value;
-                return true;
+                continue;
             }
+
+            value = slot.Value;
+            return true;
         }
 
         if (stash is not null && stash.TryGetValue(key, out var stashedValue))
@@ -144,7 +149,7 @@ public sealed class ReceiveProperties : IReadOnlyDictionary<string, string>
             return true;
         }
 
-        value = default;
+        value = null;
         return false;
     }
 
@@ -157,12 +162,14 @@ public sealed class ReceiveProperties : IReadOnlyDictionary<string, string>
             yield return new KeyValuePair<string, string>(slot.Key, slot.Value);
         }
 
-        if (stash is not null)
+        if (stash is null)
         {
-            foreach (var kvp in stash)
-            {
-                yield return kvp;
-            }
+            yield break;
+        }
+
+        foreach (var kvp in stash)
+        {
+            yield return kvp;
         }
     }
 

--- a/src/NServiceBus.Core/Transports/ReceiveProperties.cs
+++ b/src/NServiceBus.Core/Transports/ReceiveProperties.cs
@@ -2,9 +2,11 @@
 
 namespace NServiceBus.Transport;
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 /// <summary>
 /// Properties received from the transport that can be propagated to outgoing dispatch operations.
@@ -13,8 +15,6 @@ using System.Diagnostics.CodeAnalysis;
 [SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "Name reflects domain semantics, not collection implementation.")]
 public sealed class ReceiveProperties : IReadOnlyDictionary<string, string>
 {
-    readonly Dictionary<string, string> properties;
-
     /// <summary>
     /// An empty <see cref="ReceiveProperties" /> instance.
     /// </summary>
@@ -23,34 +23,181 @@ public sealed class ReceiveProperties : IReadOnlyDictionary<string, string>
     /// <summary>
     /// Creates an empty instance of <see cref="ReceiveProperties" />.
     /// </summary>
-    public ReceiveProperties() => properties = [];
+    public ReceiveProperties()
+    {
+    }
 
     /// <summary>
     /// Creates a <see cref="ReceiveProperties" /> from the provided dictionary.
-    /// The dictionary is stored by reference — do not mutate it after passing to this constructor.
     /// </summary>
-    public ReceiveProperties(Dictionary<string, string> dictionary) => properties = dictionary;
+    public ReceiveProperties(Dictionary<string, string> dictionary)
+    {
+        ArgumentNullException.ThrowIfNull(dictionary);
+
+        foreach (var kvp in dictionary)
+        {
+            AddInternal(kvp.Key, kvp.Value);
+        }
+    }
 
     /// <inheritdoc />
-    public string this[string key] => properties[key];
+    public string this[string key]
+    {
+        get
+        {
+            for (int i = 0; i < count; i++)
+            {
+                ref var slot = ref slots[i];
+
+                if (StringComparer.Ordinal.Equals(key, slot.Key))
+                {
+                    return slot.Value;
+                }
+            }
+
+            if (stash is not null && stash.TryGetValue(key, out var value))
+            {
+                return value;
+            }
+
+            ThrowKeyNotFoundException(key);
+            return default;
+        }
+    }
 
     /// <inheritdoc />
-    public IEnumerable<string> Keys => properties.Keys;
+    public IEnumerable<string> Keys
+    {
+        get
+        {
+            for (int i = 0; i < count; i++)
+            {
+                yield return slots[i].Key;
+            }
+
+            if (stash is not null)
+            {
+                foreach (var key in stash.Keys)
+                {
+                    yield return key;
+                }
+            }
+        }
+    }
 
     /// <inheritdoc />
-    public IEnumerable<string> Values => properties.Values;
+    public IEnumerable<string> Values
+    {
+        get
+        {
+            for (int i = 0; i < count; i++)
+            {
+                yield return slots[i].Value;
+            }
+
+            if (stash is not null)
+            {
+                foreach (var value in stash.Values)
+                {
+                    yield return value;
+                }
+            }
+        }
+    }
 
     /// <inheritdoc />
-    public int Count => properties.Count;
+    public int Count => count + (stash?.Count ?? 0);
 
     /// <inheritdoc />
-    public bool ContainsKey(string key) => properties.ContainsKey(key);
+    public bool ContainsKey(string key)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            ref var slot = ref slots[i];
+
+            if (StringComparer.Ordinal.Equals(key, slot.Key))
+            {
+                return true;
+            }
+        }
+
+        return stash is not null && stash.ContainsKey(key);
+    }
 
     /// <inheritdoc />
-    public bool TryGetValue(string key, [MaybeNullWhen(false)] out string value) => properties.TryGetValue(key, out value);
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out string value)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            ref var slot = ref slots[i];
+
+            if (StringComparer.Ordinal.Equals(key, slot.Key))
+            {
+                value = slot.Value;
+                return true;
+            }
+        }
+
+        if (stash is not null && stash.TryGetValue(key, out var stashedValue))
+        {
+            value = stashedValue;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
 
     /// <inheritdoc />
-    public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => properties.GetEnumerator();
+    public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+    {
+        for (int i = 0; i < count; i++)
+        {
+            ref var slot = ref slots[i];
+            yield return new KeyValuePair<string, string>(slot.Key, slot.Value);
+        }
+
+        if (stash is not null)
+        {
+            foreach (var kvp in stash)
+            {
+                yield return kvp;
+            }
+        }
+    }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    void AddInternal(string key, string value)
+    {
+        if (count < InlineArrayLength)
+        {
+            slots[count] = new Slot { Key = key, Value = value };
+            count++;
+            return;
+        }
+
+        (stash ??= [])[key] = value;
+    }
+
+    [DoesNotReturn]
+    static void ThrowKeyNotFoundException(string key) => throw new KeyNotFoundException($"The given key '{key}' was not present in the dictionary.");
+
+    SlotArray slots;
+    int count;
+    Dictionary<string, string>? stash;
+
+    const int InlineArrayLength = 4;
+
+    struct Slot
+    {
+        public string Key;
+        public string Value;
+    }
+
+    [InlineArray(InlineArrayLength)]
+    struct SlotArray
+    {
+        Slot _element0;
+    }
 }


### PR DESCRIPTION
Applies the same trick as shown in:

- https://github.com/Particular/NServiceBus/pull/7823

`DispatchProperties` and `ReceiveProperties` get allocated on every outgoing and incoming message. Both were backed by `Dictionary<string, string>`, so every instance paid for a full dictionary allocation regardless of whether it held zero entries or three.

This swaps the dictionary for inline storage. `DispatchProperties` now stores its three well-known properties (`DoNotDeliverBefore`, `DelayDeliveryWith`, `DiscardIfNotReceivedBefore`) in dedicated fields, with a small inline array for the custom properties that transports occasionally add. `ReceiveProperties` uses an inline array with an overflow dictionary that almost never needs to allocate.

The copy constructor has a fast path. When the source is already a `DispatchProperties`, it copies fields and inline slots directly instead of iterating key-value pairs.

Benchmarks on an M3 Max (BenchmarkDotNet, SimpleJob):

DispatchProperties:
- Indexer set for well-known keys: ~18 ns to ~0.6 ns, 216 B to 0 B
- ContainsKey for well-known keys: ~4 ns to ~0.3 ns
- Copy construction: ~72 ns to ~9 ns, 488 B to 88 B
- Typed property set: ~28 ns to ~8 ns, 256 B to 40 B
- Construction with one well-known property: ~29 ns to ~13 ns, 256 B to 128 B
- Construction with a custom property: ~19 ns to ~4 ns, 216 B to 88 B

ReceiveProperties:
- Indexer get: ~2.6 ns to ~0.5 ns
- ContainsKey and TryGetValue are essentially free when entries fit inline
- Construction is a bit slower because we now copy entries instead of aliasing the source dictionary. Total system allocation is still better since the caller no longer allocates a Dictionary.

Two side effects. The acceptance test framework's DeepCopy utility used `ValueType.GetHashCode()` on boxed structs, which throws for `[InlineArray]` types. Switched to `RuntimeHelpers.GetHashCode()`, matching the BCL `ReferenceEqualityComparer`. And both types now guard null keys explicitly to match the `Dictionary<string, string>` contract.

The change is backward compatible at the source level. All five downstream transport packages (RabbitMQ, SQL Server, Azure Storage Queues, Amazon SQS, Azure Service Bus) were audited and use only the typed properties and the indexer.

All six persistence packages (DynamoDB, MongoDB, NHibernate, SQL, CosmosDB, Azure Table) were also audited. None of them serialize `DispatchProperties` directly. Each persists outbox transport operations through a storage DTO whose `Options` is a concrete `Dictionary<string,string>`, so the serializer only ever sees a plain `Dictionary` and the base-type change is invisible on the wire. The only source break found was a MongoDB test helper whose generic constraint referenced `Dictionary<string,string>`, relaxed to `IDictionary<string,string>` in https://github.com/Particular/NServiceBus.Storage.MongoDB/pull/982.

Review notes. `DispatchProperties` keeps the original `Dictionary<string,string>` constructor (delegating to the `IDictionary` one) and now also implements `IReadOnlyDictionary<string,string>`, so passing it to a read-only dictionary parameter keeps compiling. The base-type change is binary-breaking by necessity, because the optimization only works by not inheriting from `Dictionary`. Binary compatibility isn't part of the [release policy](https://docs.particular.net/nservicebus/upgrades/release-policy), which frames breaking changes as source-level, so this ships as a minor rather than a major.
