### PR TITLE
Emit handler spans from a dedicated NServiceBus.Core.Handler ActivitySource

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_processing_message_with_default_activity_sources.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_processing_message_with_default_activity_sources.cs
@@ -1,0 +1,48 @@
+namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry.Traces;
+
+using System.Linq;
+using System.Threading.Tasks;
+using EndpointTemplates;
+using NServiceBus.AcceptanceTesting;
+using NUnit.Framework;
+
+public class When_processing_message_with_default_activity_sources : OpenTelemetryAcceptanceTest
+{
+    // Until v11, handler spans are emitted from the "NServiceBus.Core" ActivitySource by default
+    // for backwards compatibility. The dedicated "NServiceBus.Core.Handler" source is opt-in via
+    // the NServiceBus.Core.OpenTelemetry.UseHandlerActivitySource AppContext switch (default in v11).
+    [Test]
+    public async Task Should_emit_handler_span_from_main_source()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<ReceivingEndpoint>(b =>
+                b.When(session => session.SendLocal(new SomeMessage()))
+            )
+            .Run();
+
+        var invokedHandlerActivities = NServiceBusActivityListener.CompletedActivities.GetInvokedHandlerActivities();
+
+        Assert.That(invokedHandlerActivities, Has.Count.EqualTo(1));
+        Assert.That(invokedHandlerActivities.Single().Source.Name, Is.EqualTo("NServiceBus.Core"),
+            "without the opt-in switch, handler spans must keep coming from the main source so existing OpenTelemetry configurations keep seeing them");
+    }
+
+    public class Context : ScenarioContext;
+
+    public class ReceivingEndpoint : EndpointConfigurationBuilder
+    {
+        public ReceivingEndpoint() => EndpointSetup<DefaultServer>();
+
+        [Handler]
+        public class MessageHandler(Context testContext) : IHandleMessages<SomeMessage>
+        {
+            public Task Handle(SomeMessage message, IMessageHandlerContext context)
+            {
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class SomeMessage : IMessage;
+}

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/HandlerActivitySourceTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/HandlerActivitySourceTests.cs
@@ -1,0 +1,95 @@
+#nullable enable
+
+namespace NServiceBus.Core.Tests.OpenTelemetry;
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Helpers;
+using NServiceBus.Pipeline;
+using NUnit.Framework;
+
+[TestFixture]
+public class HandlerActivitySourceTests
+{
+    readonly ActivityFactory activityFactory = new(new InstrumentationOptions());
+
+    TestingActivityListener mainListener;
+
+    [SetUp]
+    public void SetUp() => mainListener = TestingActivityListener.SetupNServiceBusDiagnosticListener();
+
+    [TearDown]
+    public void TearDown()
+    {
+        mainListener.Dispose();
+        AppContext.SetSwitch(HandlerActivitySourceSwitch.UseHandlerActivitySourceSwitchName, false);
+        HandlerActivitySourceSwitch.ResetUseHandlerActivitySource();
+    }
+
+    static void OptIn()
+    {
+        AppContext.SetSwitch(HandlerActivitySourceSwitch.UseHandlerActivitySourceSwitchName, true);
+        HandlerActivitySourceSwitch.ResetUseHandlerActivitySource();
+    }
+
+    [Test]
+    public void Default_emits_handler_activity_from_main_source()
+    {
+        using var ambientActivity = new Activity("ambient activity");
+        ambientActivity.Start();
+
+        var activity = activityFactory.StartHandlerActivity(new MessageHandler { HandlerType = typeof(HandlerActivitySourceTests) });
+
+        Assert.That(activity, Is.Not.Null);
+        Assert.That(activity!.Source.Name, Is.EqualTo("NServiceBus.Core"));
+    }
+
+    [Test]
+    public void Opt_in_emits_handler_activity_from_handler_source()
+    {
+        OptIn();
+        using var handlerListener = TestingActivityListener.SetupDiagnosticListener("NServiceBus.Core.Handler");
+
+        using var ambientActivity = new Activity("ambient activity");
+        ambientActivity.Start();
+
+        var activity = activityFactory.StartHandlerActivity(new MessageHandler { HandlerType = typeof(HandlerActivitySourceTests) });
+
+        Assert.That(activity, Is.Not.Null);
+        Assert.That(activity!.Source.Name, Is.EqualTo("NServiceBus.Core.Handler"));
+    }
+
+    [Test]
+    public void Opt_in_preserves_display_name_and_handler_type_tag()
+    {
+        OptIn();
+        using var handlerListener = TestingActivityListener.SetupDiagnosticListener("NServiceBus.Core.Handler");
+
+        using var ambientActivity = new Activity("ambient activity");
+        ambientActivity.Start();
+
+        Type handlerType = typeof(HandlerActivitySourceTests);
+        var activity = activityFactory.StartHandlerActivity(new MessageHandler { HandlerType = handlerType });
+
+        Assert.That(activity, Is.Not.Null);
+        Assert.That(activity!.DisplayName, Is.EqualTo(handlerType.Name));
+        var tags = activity.Tags.ToImmutableDictionary();
+        Assert.That(tags[ActivityTags.HandlerType], Is.EqualTo(handlerType.FullName));
+    }
+
+    [Test]
+    public void Opt_in_without_handler_source_listener_does_not_create_handler_activity()
+    {
+        OptIn();
+
+        using var ambientActivity = new Activity("ambient activity");
+        ambientActivity.Start();
+
+        var activity = activityFactory.StartHandlerActivity(new MessageHandler { HandlerType = typeof(HandlerActivitySourceTests) });
+
+        Assert.That(activity, Is.Null, "handler activity must not be created when the dedicated source has no listeners");
+        Assert.That(Activity.Current, Is.SameAs(ambientActivity), "user tags must land on the parent (process message) activity");
+    }
+}

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
@@ -111,7 +111,13 @@ sealed class ActivityFactory : IActivityFactory
             return null;
         }
 
-        var activity = ActivitySources.Main.StartActivity(ActivityNames.InvokeHandlerActivityName);
+        // Until v11 the dedicated handler source is opt-in; existing configurations only
+        // subscribe to the main source and must keep receiving handler spans from it.
+        var source = HandlerActivitySourceSwitch.UseHandlerActivitySource
+            ? ActivitySources.Handler
+            : ActivitySources.Main;
+
+        var activity = source.StartActivity(ActivityNames.InvokeHandlerActivityName);
 
         if (activity is null)
         {

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivitySources.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivitySources.cs
@@ -9,4 +9,8 @@ static class ActivitySources
     public static readonly ActivitySource Main =
         new("NServiceBus.Core",
             "0.1.0");
+
+    public static readonly ActivitySource Handler =
+        new("NServiceBus.Core.Handler",
+            "0.1.0");
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/obsolete_v11.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/obsolete_v11.cs
@@ -137,3 +137,53 @@ static class LegacyContextPropagation
         }
     }
 }
+
+// Handler spans move from the "NServiceBus.Core" ActivitySource to the dedicated
+// "NServiceBus.Core.Handler" source so they can be filtered/sampled independently
+// (https://github.com/Particular/NServiceBus/issues/7284). Existing OpenTelemetry
+// configurations only subscribe to "NServiceBus.Core" and would silently lose handler
+// spans, so the new source is opt-in via an AppContext switch until v11.
+//
+// In v11 the dedicated source becomes the default: delete this class and remove the
+// source selection in ActivityFactory.StartHandlerActivity so it always uses
+// ActivitySources.Handler.
+static class HandlerActivitySourceSwitch
+{
+    enum SwitchState : byte
+    {
+        Unchecked = 0,
+        Enabled = 1,
+        Disabled = 2
+    }
+
+    static SwitchState cachedUseHandlerActivitySource;
+
+    [PreObsolete("https://github.com/Particular/NServiceBus/issues/7284",
+        Note = "In v11, handler spans are always emitted from the NServiceBus.Core.Handler ActivitySource and this switch will be removed.",
+        ReplacementTypeOrMember = "ActivitySources.Handler")]
+    public const string UseHandlerActivitySourceSwitchName = "NServiceBus.Core.OpenTelemetry.UseHandlerActivitySource";
+
+    [PreObsolete("https://github.com/Particular/NServiceBus/issues/7284",
+        Note = "In v11, handler spans are always emitted from the NServiceBus.Core.Handler ActivitySource and this switch will be removed.",
+        ReplacementTypeOrMember = "ActivitySources.Handler")]
+    public static bool UseHandlerActivitySource
+    {
+        get
+        {
+            var state = cachedUseHandlerActivitySource;
+            if (state != SwitchState.Unchecked)
+            {
+                return state == SwitchState.Enabled;
+            }
+
+            state = AppContext.TryGetSwitch(UseHandlerActivitySourceSwitchName, out var isEnabled) && isEnabled
+                ? SwitchState.Enabled
+                : SwitchState.Disabled;
+            cachedUseHandlerActivitySource = state;
+
+            return state == SwitchState.Enabled;
+        }
+    }
+
+    internal static void ResetUseHandlerActivitySource() => cachedUseHandlerActivitySource = SwitchState.Unchecked;
+}


### PR DESCRIPTION
Fixes:

- #7284

Handler (`InvokeHandler`) spans can now be emitted from a dedicated `NServiceBus.Core.Handler` ActivitySource instead of `NServiceBus.Core`, so they can be subscribed, filtered, and sampled independently of the pipeline spans.

Because existing OpenTelemetry configurations only subscribe to `NServiceBus.Core` and would silently stop receiving handler spans, the new source is **opt-in until v11** via an AppContext switch.

### AppContext switch

| Switch | Values | Effect |
|---|---|---|
| `NServiceBus.Core.OpenTelemetry.UseHandlerActivitySource` | `false` / not set (default) | Handler spans are emitted from `NServiceBus.Core` — current behavior, unchanged. |
| | `true` | Handler spans are emitted from `NServiceBus.Core.Handler`. Subscribe to both sources to keep the full trace. |

```csharp
AppContext.SetSwitch("NServiceBus.Core.OpenTelemetry.UseHandlerActivitySource", true);
```

or via `runtimeconfig.json` / MSBuild:

```xml
<ItemGroup>
  <RuntimeHostConfigurationOption Include="NServiceBus.Core.OpenTelemetry.UseHandlerActivitySource" Value="true" />
</ItemGroup>
```

The switch is read once and cached; set it at process startup, before endpoint creation.

### Filtering handler spans

With the switch enabled, subscribing only to `NServiceBus.Core` (omitting `NServiceBus.Core.Handler`) suppresses handler spans entirely. `Activity.Current` inside handlers and `IInvokeHandlerContext` behaviors then refers to the `process message` span, so custom tags land there — producing the flattened single-span trace requested in #7284.

### v11

In v11 the dedicated source becomes the default and the switch is removed. All temporary code lives in `obsolete_v11.cs`.