### PR TITLE
Add support for nullable reference types -Pipeline folder

### DIFF
--- a/src/NServiceBus.Core/Pipeline/IPipelineTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/IPipelineTerminator.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 /// <summary>

--- a/src/NServiceBus.Core/Pipeline/IPipelineTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/IPipelineTerminator.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus;
+﻿#nullable enable
+namespace NServiceBus;
 
 /// <summary>
 /// Marker interface for pipeline terminators.

--- a/src/NServiceBus.Core/Pipeline/Incoming/MessageHandlerInvoker.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/MessageHandlerInvoker.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System;


### PR DESCRIPTION
- https://github.com/Particular/NServiceBus/issues/6257
Follow-up to #7536. One file in the Pipeline folder was not annotated during the original pass: `IPipelineTerminator.cs`. This is a marker interface with no members, so there's no functional nullability change. This PR just adds `#nullable enable` for consistency with the rest of the folder.