### PR TITLE
Add support for nullable reference types - Hosting folder

### DIFF
--- a/src/NServiceBus.Core/Hosting/AddHostInfoHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Hosting/AddHostInfoHeadersBehavior.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/AuditHostInformationBehavior.cs
+++ b/src/NServiceBus.Core/Hosting/AuditHostInformationBehavior.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/ExternallyManagedContainerHost.cs
+++ b/src/NServiceBus.Core/Hosting/ExternallyManagedContainerHost.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus.Hosting.Helpers;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerResults.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerResults.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus.Hosting.Helpers;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -39,7 +39,7 @@ class AssemblyScanningComponent
 
         // Deliberately strongly typed because we need to truncate this super large section when writing to the logs
         var assemblyScanningDiagnostics = new AssemblyScanningDiagnostics(
-            scannableAssemblies.Assemblies.Select(a => new AssemblyDetails(a.FullName, FileVersionRetriever.GetFileVersion(a))),
+            scannableAssemblies.Assemblies.Select(a => new AssemblyDetails(a.FullName ?? "Unknown assembly", FileVersionRetriever.GetFileVersion(a))),
             scannableAssemblies.SkippedFiles.Select(f => new SkippedFile(f.FilePath, f.SkipReason)),
             scannableAssemblies.ErrorsThrownDuringScanning,
             assemblyScannerSettings

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;
@@ -75,7 +76,7 @@ class AssemblyScanningComponent
 
     public class Configuration(SettingsHolder settings)
     {
-        // This is only used for testability until we have a dedicated AOT test project. Not called on the hot path so has no performance implications. 
+        // This is only used for testability until we have a dedicated AOT test project. Not called on the hot path so has no performance implications.
         public bool DynamicCodeSupported { get; set; } = System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported;
 
         public List<Type>? UserProvidedTypes { get; set; }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningDiagnostics.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningDiagnostics.cs
@@ -26,6 +26,4 @@ sealed class AssemblyScanningDiagnostics(
             Settings
         );
 }
- 
-
 record AssemblyDetails(string? FullName, string FileVersion);

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningDiagnostics.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningDiagnostics.cs
@@ -1,6 +1,6 @@
 #nullable enable
 
- namespace NServiceBus;
+namespace NServiceBus;
 
 using System.Collections.Generic;
 using Hosting.Helpers;

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningDiagnostics.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningDiagnostics.cs
@@ -26,4 +26,4 @@ sealed class AssemblyScanningDiagnostics(
             Settings
         );
 }
-record AssemblyDetails(string? FullName, string FileVersion);
+record AssemblyDetails(string FullName, string FileVersion);

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningDiagnostics.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningDiagnostics.cs
@@ -5,25 +5,19 @@ namespace NServiceBus;
 using System.Collections.Generic;
 using Hosting.Helpers;
 
-sealed class AssemblyScanningDiagnostics(
-    IEnumerable<AssemblyDetails> assemblies,
-    IEnumerable<SkippedFile> skippedFiles,
-    bool errorsThrownDuringScanning,
-    AssemblyScannerConfiguration settings)
+sealed class AssemblyScanningDiagnostics(IEnumerable<AssemblyDetails> assemblies, IEnumerable<SkippedFile> skippedFiles, bool errorsThrownDuringScanning, AssemblyScannerConfiguration settings)
 {
     public const string SectionName = "AssemblyScanning";
 
     public IEnumerable<AssemblyDetails> Assemblies { get; } = assemblies;
+
     public IEnumerable<SkippedFile> SkippedFiles { get; } = skippedFiles;
+
     public bool ErrorsThrownDuringScanning { get; } = errorsThrownDuringScanning;
+
     public AssemblyScannerConfiguration Settings { get; } = settings;
 
-    public AssemblyScanningDiagnostics CreateCompactedVersion() =>
-        new(
-            [],
-            [],
-            ErrorsThrownDuringScanning,
-            Settings
-        );
+    public AssemblyScanningDiagnostics CreateCompactedVersion() => new([], [], ErrorsThrownDuringScanning, Settings);
 }
+
 record AssemblyDetails(string FullName, string FileVersion);

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningDiagnostics.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningDiagnostics.cs
@@ -1,4 +1,6 @@
-namespace NServiceBus;
+#nullable enable
+
+ namespace NServiceBus;
 
 using System.Collections.Generic;
 using Hosting.Helpers;
@@ -24,5 +26,6 @@ sealed class AssemblyScanningDiagnostics(
             Settings
         );
 }
+ 
 
-record AssemblyDetails(string FullName, string FileVersion);
+record AssemblyDetails(string? FullName, string FileVersion);

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/Helpers/SkippedFile.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/SkippedFile.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus.Hosting.Helpers;
 
 /// <summary>

--- a/src/NServiceBus.Core/Hosting/HostInfoConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Hosting/HostInfoConfigurationExtensions.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/HostInfoSettings.cs
+++ b/src/NServiceBus.Core/Hosting/HostInfoSettings.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/HostInformation.cs
+++ b/src/NServiceBus.Core/Hosting/HostInformation.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus.Hosting;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/HostingComponent.cs
+++ b/src/NServiceBus.Core/Hosting/HostingComponent.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/InternallyManagedContainerHost.cs
+++ b/src/NServiceBus.Core/Hosting/InternallyManagedContainerHost.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;


### PR DESCRIPTION
- https://github.com/Particular/NServiceBus/issues/6257

- Follow-up to #7377
 This PR just adds `#nullable enable` for consistency
 

Assembly.FullName can sometimes be null. Rather than let that null spread into AssemblyDetails, we now just fall back to "Unknown assembly" when the name isn't available. No outside impact
since both types are internal.