### PR TITLE
Add support for nullable reference types - Logging

### DIFF
--- a/src/NServiceBus.Core/Logging/ExternalLoggerFactoryAdapter.cs
+++ b/src/NServiceBus.Core/Logging/ExternalLoggerFactoryAdapter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System;
@@ -11,6 +12,8 @@ sealed class ExternalLoggerFactoryAdapter(ILoggerFactory externalFactory, Micros
     readonly ILogger scopeLogger = microsoftLoggerFactory.CreateLogger(MicrosoftLoggerFactoryAdapter.ScopeLoggerName);
 
     public ILog GetLogger(Type type) => GetLogger(type.FullName ?? type.Name);
+
     public ILog GetLogger(string name) => externalFactory.GetLogger(name);
+
     public IDisposable BeginScope(LogScopeState scopeState) => scopeLogger.BeginScope(scopeState) ?? NullScope.Instance;
 }

--- a/src/NServiceBus.Core/Logging/IUnsupportedDefaultFactoryLoggerFactory.cs
+++ b/src/NServiceBus.Core/Logging/IUnsupportedDefaultFactoryLoggerFactory.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 interface IUnsupportedDefaultFactoryLoggerFactory;

--- a/src/NServiceBus.Core/Logging/IUnsupportedDefaultFactoryLoggerFactory.cs
+++ b/src/NServiceBus.Core/Logging/IUnsupportedDefaultFactoryLoggerFactory.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace NServiceBus;
 
 interface IUnsupportedDefaultFactoryLoggerFactory;

--- a/src/NServiceBus.Core/Logging/MicrosoftLoggerAdapter.cs
+++ b/src/NServiceBus.Core/Logging/MicrosoftLoggerAdapter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System;


### PR DESCRIPTION
- https://github.com/Particular/NServiceBus/issues/6257

Follow-up to #7384. `IUnsupportedDefaultFactoryLoggerFactory.cs` wasn't part of the original pass as it was added later in #7665, after the Logging folder had already been nullable-enabled

This PR  just adds `#nullable enable` for consistency with the rest of the folder