### PR TITLE
Add support for nullable reference types - OpenTelemetry

### DIFF
--- a/src/NServiceBus.Core.Tests/OpenTelemetry/PopulateRecoverabilityTraceMetadataBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/PopulateRecoverabilityTraceMetadataBehaviorTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace NServiceBus.Core.Tests.OpenTelemetry;
 
 using System;

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/PopulateRecoverabilityTraceMetadataBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/PopulateRecoverabilityTraceMetadataBehavior.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace NServiceBus;
 
 using System;


### PR DESCRIPTION
- https://github.com/Particular/NServiceBus/issues/6257

Follow-up to #7474. `PopulateRecoverabilityTraceMetadataBehavior.cs`
It's an internal behavior with no nullable-annotatable members, so there's no functional nullability change here. This PR just adds `#nullable enable` for consistency with the rest of the folder.