### PR TITLE
Add support for nullable types - Support

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
@@ -66,7 +66,6 @@ NServiceBus.Settings.IReadOnlySettings
 NServiceBus.Settings.SettingsHolder
 NServiceBus.StaticHeadersConfigExtensions
 NServiceBus.SubscriptionMigrationModeSettings
-NServiceBus.Support.RuntimeEnvironment
 NServiceBus.Transport.DispatchProperties
 NServiceBus.Transport.ErrorContext
 NServiceBus.Transport.IMessageDispatcher

--- a/src/NServiceBus.Core.Tests/Hosting/HostInfoSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Hosting/HostInfoSettingsTests.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Core.Tests.Host;
+﻿#nullable enable
+
+namespace NServiceBus.Core.Tests.Host;
 
 using System;
 using NServiceBus.Support;

--- a/src/NServiceBus.Core/Support/RuntimeEnvironment.cs
+++ b/src/NServiceBus.Core/Support/RuntimeEnvironment.cs
@@ -1,5 +1,4 @@
-﻿
-#nullable enable
+﻿#nullable enable
 
 namespace NServiceBus.Support;
 

--- a/src/NServiceBus.Core/Support/RuntimeEnvironment.cs
+++ b/src/NServiceBus.Core/Support/RuntimeEnvironment.cs
@@ -1,4 +1,7 @@
-﻿namespace NServiceBus.Support;
+﻿
+#nullable enable
+
+namespace NServiceBus.Support;
 
 using System;
 


### PR DESCRIPTION

- Introduce support for nullable reference types #6257


This PR enables `#nullable enable` on the file `RuntimeEnvironment.cs`, and removes
`NServiceBus.Support.RuntimeEnvironment` from `NullableAnnotations.ApproveNullableTypes.approved.txt`