### PR TITLE
Add support for nullable types - StaticHeaders

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
@@ -64,7 +64,6 @@ NServiceBus.SerializationContextExtensions
 NServiceBus.SerializationExtensionsExtensions
 NServiceBus.Settings.IReadOnlySettings
 NServiceBus.Settings.SettingsHolder
-NServiceBus.StaticHeadersConfigExtensions
 NServiceBus.SubscriptionMigrationModeSettings
 NServiceBus.Support.RuntimeEnvironment
 NServiceBus.Transport.DispatchProperties

--- a/src/NServiceBus.Core/StaticHeaders/ApplyStaticHeadersBehavior.cs
+++ b/src/NServiceBus.Core/StaticHeaders/ApplyStaticHeadersBehavior.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/StaticHeaders/CurrentStaticHeaders.cs
+++ b/src/NServiceBus.Core/StaticHeaders/CurrentStaticHeaders.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace NServiceBus;
 
 using System.Collections.Generic;

--- a/src/NServiceBus.Core/StaticHeaders/StaticHeaders.cs
+++ b/src/NServiceBus.Core/StaticHeaders/StaticHeaders.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus;
+﻿#nullable enable
+
+namespace NServiceBus;
 
 using Features;
 

--- a/src/NServiceBus.Core/StaticHeaders/StaticHeadersConfigExtensions.cs
+++ b/src/NServiceBus.Core/StaticHeaders/StaticHeadersConfigExtensions.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/StaticHeaders/StaticHeadersConfigExtensions.cs
+++ b/src/NServiceBus.Core/StaticHeaders/StaticHeadersConfigExtensions.cs
@@ -21,6 +21,7 @@ public static class StaticHeadersConfigExtensions
     public static void AddHeaderToAllOutgoingMessages(this EndpointConfiguration config, string key, string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
 
         if (!config.Settings.TryGet(out CurrentStaticHeaders headers))
         {

--- a/src/NServiceBus.Core/StaticHeaders/StaticHeadersConfigExtensions.cs
+++ b/src/NServiceBus.Core/StaticHeaders/StaticHeadersConfigExtensions.cs
@@ -21,7 +21,9 @@ public static class StaticHeadersConfigExtensions
     public static void AddHeaderToAllOutgoingMessages(this EndpointConfiguration config, string key, string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
-        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+        // TODO Uncomment this in the next major version so that we actually enforce non-null values here
+        //ArgumentException.ThrowIfNullOrWhiteSpace(value);
 
         if (!config.Settings.TryGet(out CurrentStaticHeaders headers))
         {


### PR DESCRIPTION
- Introduce support for nullable reference types #6257


This PR enables `#nullable enable` on the files in the folder, and removes
`NServiceBus.StaticHeadersConfigExtensions` from `NullableAnnotations.ApproveNullableTypes.approved.txt`