### PR TITLE
Add support for nullable reference types - Recoverability

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
@@ -9,7 +9,6 @@ NServiceBus.ContentTypes
 NServiceBus.DateTimeOffsetHelper
 NServiceBus.DistributionPolicy
 NServiceBus.EndpointConfiguration
-NServiceBus.Faults.FailedMessage
 NServiceBus.Headers
 NServiceBus.IDistributionPolicy
 NServiceBus.IMessageHandlerContext

--- a/src/NServiceBus.Core/Recoverability/Faults/FailedMessage.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/FailedMessage.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace NServiceBus.Faults;
 
 using System;


### PR DESCRIPTION
- #6257 

- Follow-up to #7555 

This PR adds #nullable enabled for consistency with the rest of the folder.  There is no functional nullability change here as the arguments explicitly cannot be null.