### PR TITLE
Add support for nullable reference types - UnitOfWork

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_transactionscope_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_transactionscope_enabled.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.AcceptanceTests.Core.UnitOfWork.TransactionScope;
+﻿#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.UnitOfWork.TransactionScope;
 
 using System.Threading.Tasks;
 using System.Transactions;
@@ -47,7 +49,7 @@ public class When_transactionscope_enabled : NServiceBusAcceptanceTest
                 if (Transaction.Current != null)
                 {
                     testContext.AmbientTransactionPresent = Transaction.Current != null;
-                    testContext.IsolationLevel = Transaction.Current.IsolationLevel;
+                    testContext.IsolationLevel = Transaction.Current!.IsolationLevel;
                 }
                 testContext.MarkAsCompleted();
                 return Task.CompletedTask;

--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_transactionscope_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_transactionscope_enabled.cs
@@ -46,12 +46,16 @@ public class When_transactionscope_enabled : NServiceBusAcceptanceTest
         {
             public Task Handle(MyMessage message, IMessageHandlerContext context)
             {
-                if (Transaction.Current != null)
+                var transaction = Transaction.Current;
+
+                if (transaction is not null)
                 {
-                    testContext.AmbientTransactionPresent = Transaction.Current != null;
-                    testContext.IsolationLevel = Transaction.Current!.IsolationLevel;
+                    testContext.AmbientTransactionPresent = true;
+                    testContext.IsolationLevel = transaction.IsolationLevel;
                 }
+
                 testContext.MarkAsCompleted();
+
                 return Task.CompletedTask;
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_used_with_default_transaction_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_used_with_default_transaction_mode.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.AcceptanceTests.Core.UnitOfWork.TransactionScope;
+﻿#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.UnitOfWork.TransactionScope;
 
 using System.Threading.Tasks;
 using AcceptanceTesting;

--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_used_with_transport_scopes.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_used_with_transport_scopes.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.AcceptanceTests.Core.UnitOfWork.TransactionScope;
+﻿#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.UnitOfWork.TransactionScope;
 
 using System;
 using AcceptanceTesting;

--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_using_timeout_greater_than_machine_max.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_using_timeout_greater_than_machine_max.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.AcceptanceTests.Core.UnitOfWork.TransactionScope;
+﻿#nullable enable
+
+namespace NServiceBus.AcceptanceTests.Core.UnitOfWork.TransactionScope;
 
 using System;
 using AcceptanceTesting;

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
@@ -99,6 +99,5 @@ NServiceBus.Unicast.Queuing.QueueNotFoundException
 NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.ISubscriptionStorage
 NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber
 NServiceBus.Unicast.Subscriptions.MessageType
-NServiceBus.UnitOfWorkSettingsExtensions
 NServiceBus.XmlSerializationExtensions
 NServiceBus.XmlSerializer

--- a/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
+++ b/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Features;
+﻿#nullable enable
+
+namespace NServiceBus.Features;
 
 using System;
 using System.Transactions;

--- a/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWorkBehavior.cs
+++ b/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWorkBehavior.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus;
+﻿#nullable enable
+
+namespace NServiceBus;
 
 using System;
 using System.Threading.Tasks;

--- a/src/NServiceBus.Core/UnitOfWork/UnitOfWorkSettings.cs
+++ b/src/NServiceBus.Core/UnitOfWork/UnitOfWorkSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus;
+﻿#nullable enable
+
+namespace NServiceBus;
 
 using System;
 using System.Transactions;

--- a/src/NServiceBus.Core/UnitOfWork/UnitOfWorkSettingsExtensions.cs
+++ b/src/NServiceBus.Core/UnitOfWork/UnitOfWorkSettingsExtensions.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace NServiceBus;
 
 using System;


### PR DESCRIPTION
- #6257 

This PR enables `#nullable enable` in the UnitOfWork folder and removes `NServiceBus.UnitOfWorkSettingsExtensions` from the `NullableAnnotations.ApproveNullableTypes.approved.txt` file.
