### PR TITLE
Add support for nullable reference types - Serialization

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2382,7 +2382,7 @@ namespace NServiceBus.Serialization
     public interface IMessageSerializer
     {
         string ContentType { get; }
-        object[] Deserialize(System.ReadOnlyMemory<byte> body, System.Collections.Generic.IList<System.Type> messageTypes = null);
+        object[] Deserialize(System.ReadOnlyMemory<byte> body, System.Collections.Generic.IList<System.Type>? messageTypes = null);
         void Serialize(object message, System.IO.Stream stream);
     }
     public abstract class SerializationDefinition

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
@@ -56,12 +56,6 @@ NServiceBus.Sagas.SagaCorrelationProperty
 NServiceBus.Sagas.SagaFinderDefinition
 NServiceBus.Sagas.SagaIdGeneratorContext
 NServiceBus.SagasConfigExtensions
-NServiceBus.Serialization.IMessageSerializer
-NServiceBus.Serialization.SerializationDefinition
-NServiceBus.Serialization.SerializationExtensions`1
-NServiceBus.SerializationConfigExtensions
-NServiceBus.SerializationContextExtensions
-NServiceBus.SerializationExtensionsExtensions
 NServiceBus.Settings.IReadOnlySettings
 NServiceBus.Settings.SettingsHolder
 NServiceBus.StaticHeadersConfigExtensions

--- a/src/NServiceBus.Core/Serialization/IMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serialization/IMessageSerializer.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus.Serialization;
 
 using System;

--- a/src/NServiceBus.Core/Serialization/IMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serialization/IMessageSerializer.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace NServiceBus.Serialization;
 
 using System;
@@ -30,5 +31,5 @@ public interface IMessageSerializer
     /// serialized data.
     /// </param>
     /// <returns>Deserialized messages.</returns>
-    object[] Deserialize(ReadOnlyMemory<byte> body, IList<Type> messageTypes = null);
+    object[] Deserialize(ReadOnlyMemory<byte> body, IList<Type>? messageTypes = null);
 }

--- a/src/NServiceBus.Core/Serialization/SerializationConfigExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationConfigExtensions.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus;
+﻿#nullable enable
+namespace NServiceBus;
 
 using System;
 using Configuration.AdvancedExtensibility;

--- a/src/NServiceBus.Core/Serialization/SerializationConfigExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationConfigExtensions.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Serialization/SerializationContextExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationContextExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Serialization/SerializationContextExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationContextExtensions.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Serialization/SerializationDefinition.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationDefinition.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus.Serialization;
 
 using System;

--- a/src/NServiceBus.Core/Serialization/SerializationDefinition.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationDefinition.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.Serialization;
+﻿#nullable enable
+namespace NServiceBus.Serialization;
 
 using System;
 using MessageInterfaces;

--- a/src/NServiceBus.Core/Serialization/SerializationExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus.Serialization;
 
 using Configuration.AdvancedExtensibility;

--- a/src/NServiceBus.Core/Serialization/SerializationExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationExtensions.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.Serialization;
+﻿#nullable enable
+namespace NServiceBus.Serialization;
 
 using Configuration.AdvancedExtensibility;
 using Settings;

--- a/src/NServiceBus.Core/Serialization/SerializationExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationExtensions.cs
@@ -2,6 +2,7 @@
 
 namespace NServiceBus.Serialization;
 
+using System;
 using Configuration.AdvancedExtensibility;
 using Settings;
 
@@ -15,7 +16,10 @@ public class SerializationExtensions<T> : ExposeSettings where T : Serialization
     /// Initializes a new instance of <see cref="SerializationExtensions{T}" />.
     /// </summary>
     public SerializationExtensions(SettingsHolder serializerSettings, SettingsHolder endpointConfigurationSettings) : base(serializerSettings)
-        => EndpointConfigurationSettings = endpointConfigurationSettings;
+    {
+        ArgumentNullException.ThrowIfNull(endpointConfigurationSettings);
+        EndpointConfigurationSettings = endpointConfigurationSettings;
+    }
 
     // provides access to the settings backing EndpointConfiguration. The settings provided by the 'Settings' property are isolated settings for the serializer.
     internal readonly SettingsHolder EndpointConfigurationSettings;

--- a/src/NServiceBus.Core/Serialization/SerializationExtensionsExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationExtensionsExtensions.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus;
+﻿#nullable enable
+namespace NServiceBus;
 
 using System;
 using Serialization;

--- a/src/NServiceBus.Core/Serialization/SerializationExtensionsExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationExtensionsExtensions.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus;
+﻿#nullable enable
+namespace NServiceBus;
 
 using System;
 using System.Collections.Generic;

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Serialization/SerializationSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationSettingsExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Serialization/SerializationSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationSettingsExtensions.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System;


### PR DESCRIPTION
- Introduce support for nullable reference types #6257


This PR enables `#nullable enable` on the files in the folder, and removes the following from `NullableAnnotations.ApproveNullableTypes.approved.txt`

- NServiceBus.Serialization.IMessageSerializer
- NServiceBus.Serialization.SerializationDefinition
- NServiceBus.Serialization.SerializationExtensions`1
- NServiceBus.SerializationConfigExtensions
- NServiceBus.SerializationContextExtensions
- NServiceBus.SerializationExtensionsExtensions
