### PR TITLE
Add support for nullable reference types - Utils

### DIFF
--- a/src/NServiceBus.Core.Tests/Hosting/PathUtilities_Tests.cs
+++ b/src/NServiceBus.Core.Tests/Hosting/PathUtilities_Tests.cs
@@ -54,4 +54,11 @@ public class PathUtilities_Tests
 
         Assert.That(path2, Is.EqualTo(path1));
     }
+
+    [Test]
+    public void Null_path_returns_empty_string()
+    {
+        var path = PathUtilities.SanitizedPath(null);
+        Assert.That(path, Is.EqualTo(string.Empty));
+    }
 }

--- a/src/NServiceBus.Core.Tests/Hosting/PathUtilities_Tests.cs
+++ b/src/NServiceBus.Core.Tests/Hosting/PathUtilities_Tests.cs
@@ -54,11 +54,4 @@ public class PathUtilities_Tests
 
         Assert.That(path2, Is.EqualTo(path1));
     }
-
-    [Test]
-    public void Null_path_returns_empty_string()
-    {
-        var path = PathUtilities.SanitizedPath(null);
-        Assert.That(path, Is.EqualTo(string.Empty));
-    }
 }

--- a/src/NServiceBus.Core.Tests/Utils/Reflection/InspectTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/Reflection/InspectTests.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Core.Utils.Reflection;
+﻿#nullable enable
+
+namespace NServiceBus.Core.Utils.Reflection;
 
 using System;
 using NUnit.Framework;
@@ -19,7 +21,7 @@ public class InspectTests
 
         public class Target
         {
-            public string Property { get; set; }
+            public required string Property { get; set; }
         }
     }
 
@@ -36,7 +38,7 @@ public class InspectTests
 
         public class Target
         {
-            public string Field;
+            public required string Field;
         }
     }
 
@@ -61,12 +63,12 @@ public class InspectTests
 
         public class Target1
         {
-            public Target2 Property1 { get; set; }
+            public required Target2 Property1 { get; set; }
         }
 
         public class Target2
         {
-            public string Property2 { get; set; }
+            public required string Property2 { get; set; }
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Utils/Reflection/MethodInfoExtensionTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/Reflection/MethodInfoExtensionTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace NServiceBus.Core.Utils.Reflection;
 
 using System.Reflection;
@@ -10,7 +12,7 @@ public class MethodInfoExtensionTests
     public void When_method_has_no_return_type_Should_return_null()
     {
         var instance = new TypeWithMethods();
-        var result = TypeWithMethods.MethodWithNoReturnInfo.InvokeGeneric(instance, [typeof(InputType)]);
+        var result = TypeWithMethods.MethodWithNoReturnInfo!.InvokeGeneric(instance, [typeof(InputType)]);
 
         Assert.That(result, Is.Null);
     }
@@ -19,7 +21,7 @@ public class MethodInfoExtensionTests
     public void When_method_has_return_type_Should_return_value()
     {
         var instance = new TypeWithMethods();
-        var result = TypeWithMethods.MethodWithReturnInfo.InvokeGeneric(instance, [typeof(InputType)]);
+        var result = TypeWithMethods.MethodWithReturnInfo!.InvokeGeneric(instance, [typeof(InputType)]);
 
         Assert.That(result, Is.EqualTo(42));
     }
@@ -28,7 +30,7 @@ public class MethodInfoExtensionTests
     public void When_method_has_return_type_Should_return_strong_typed_value()
     {
         var instance = new TypeWithMethods();
-        var result = TypeWithMethods.MethodWithReturnInfo.InvokeGeneric<int>(instance, [], [typeof(InputType)]);
+        var result = TypeWithMethods.MethodWithReturnInfo!.InvokeGeneric<int>(instance, [], [typeof(InputType)]);
 
         Assert.That(result, Is.EqualTo(42));
     }
@@ -36,7 +38,7 @@ public class MethodInfoExtensionTests
     [Test]
     public void When_static_method_has_no_return_type_Should_return_null()
     {
-        var result = TypeWithMethods.StaticMethodWithNoReturnInfo.InvokeGeneric(null, [], [typeof(InputType)]);
+        var result = TypeWithMethods.StaticMethodWithNoReturnInfo!.InvokeGeneric(null, [], [typeof(InputType)]);
 
         Assert.That(result, Is.Null);
     }
@@ -44,7 +46,7 @@ public class MethodInfoExtensionTests
     [Test]
     public void When_static_method_has_return_type_Should_return_value()
     {
-        var result = TypeWithMethods.StaticMethodWithReturnInfo.InvokeGeneric(null, [typeof(InputType)]);
+        var result = TypeWithMethods.StaticMethodWithReturnInfo!.InvokeGeneric(null, [typeof(InputType)]);
 
         Assert.That(result, Is.EqualTo(42));
     }
@@ -52,7 +54,7 @@ public class MethodInfoExtensionTests
     [Test]
     public void When_static_method_has_return_type_Should_return_strong_typed_value()
     {
-        var result = TypeWithMethods.StaticMethodWithReturnInfo.InvokeGeneric<int>(null, [], [typeof(InputType)]);
+        var result = TypeWithMethods.StaticMethodWithReturnInfo!.InvokeGeneric<int>(null, [], [typeof(InputType)]);
 
         Assert.That(result, Is.EqualTo(42));
     }
@@ -70,9 +72,9 @@ public class MethodInfoExtensionTests
 
         public static int StaticMethodWithReturn<T>() => 42;
 
-        public static MethodInfo StaticMethodWithNoReturnInfo = typeof(TypeWithMethods).GetMethod("StaticMethodWithNoReturn", BindingFlags.Public | BindingFlags.Static);
-        public static MethodInfo MethodWithNoReturnInfo = typeof(TypeWithMethods).GetMethod("MethodWithNoReturn", BindingFlags.Public | BindingFlags.Instance);
-        public static MethodInfo MethodWithReturnInfo = typeof(TypeWithMethods).GetMethod("MethodWithReturn", BindingFlags.Public | BindingFlags.Instance);
-        public static MethodInfo StaticMethodWithReturnInfo = typeof(TypeWithMethods).GetMethod("StaticMethodWithReturn", BindingFlags.Public | BindingFlags.Static);
+        public static MethodInfo? StaticMethodWithNoReturnInfo = typeof(TypeWithMethods).GetMethod("StaticMethodWithNoReturn", BindingFlags.Public | BindingFlags.Static);
+        public static MethodInfo? MethodWithNoReturnInfo = typeof(TypeWithMethods).GetMethod("MethodWithNoReturn", BindingFlags.Public | BindingFlags.Instance);
+        public static MethodInfo? MethodWithReturnInfo = typeof(TypeWithMethods).GetMethod("MethodWithReturn", BindingFlags.Public | BindingFlags.Instance);
+        public static MethodInfo? StaticMethodWithReturnInfo = typeof(TypeWithMethods).GetMethod("StaticMethodWithReturn", BindingFlags.Public | BindingFlags.Static);
     }
 }

--- a/src/NServiceBus.Core.Tests/Utils/Reflection/TypeExtensionMethodsTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/Reflection/TypeExtensionMethodsTests.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Core.Utils.Reflection;
+﻿#nullable enable
+
+namespace NServiceBus.Core.Utils.Reflection;
 
 using System;
 using System.Collections.Generic;

--- a/src/NServiceBus.Core/Utils/FileVersionRetriever.cs
+++ b/src/NServiceBus.Core/Utils/FileVersionRetriever.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus;
+﻿#nullable enable
+
+namespace NServiceBus;
 
 using System;
 using System.Diagnostics;
@@ -19,11 +21,11 @@ static class FileVersionRetriever
 
         var fileVersionAttribute = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
 
-        if (Version.TryParse(fileVersionAttribute.Version, out var version))
+        if (Version.TryParse(fileVersionAttribute?.Version, out var version))
         {
             return version.ToString(3);
         }
 
-        return assembly.GetName().Version.ToString(3);
+        return assembly.GetName().Version?.ToString(3) ?? "0.0.0";
     }
 }

--- a/src/NServiceBus.Core/Utils/LazyArrayPoolBufferWriter.cs
+++ b/src/NServiceBus.Core/Utils/LazyArrayPoolBufferWriter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Utils/PathUtilities.cs
+++ b/src/NServiceBus.Core/Utils/PathUtilities.cs
@@ -1,11 +1,18 @@
-﻿namespace NServiceBus;
+﻿#nullable enable
+
+namespace NServiceBus;
 
 using System;
 
 static class PathUtilities
 {
-    public static string SanitizedPath(string commandLine)
+    public static string SanitizedPath(string? commandLine)
     {
+        if (commandLine is null)
+        {
+            return string.Empty;
+        }
+
         if (commandLine.StartsWith('"'))
         {
             var nextIndex = commandLine.IndexOf('"', 1);

--- a/src/NServiceBus.Core/Utils/PathUtilities.cs
+++ b/src/NServiceBus.Core/Utils/PathUtilities.cs
@@ -6,13 +6,8 @@ using System;
 
 static class PathUtilities
 {
-    public static string SanitizedPath(string? commandLine)
+    public static string SanitizedPath(string commandLine)
     {
-        if (commandLine is null)
-        {
-            return string.Empty;
-        }
-
         if (commandLine.StartsWith('"'))
         {
             var nextIndex = commandLine.IndexOf('"', 1);

--- a/src/NServiceBus.Core/Utils/Reflection/DelegateFactory.cs
+++ b/src/NServiceBus.Core/Utils/Reflection/DelegateFactory.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace NServiceBus;
 
 using System;
@@ -12,6 +14,8 @@ static class DelegateFactory
     {
         if (!PropertyInfoToLateBoundProperty.TryGetValue(property, out var lateBoundPropertyGet))
         {
+            ArgumentNullException.ThrowIfNull(property.DeclaringType);
+
             var instanceParameter = Expression.Parameter(typeof(object), "target");
 
             var member = Expression.Property(Expression.Convert(instanceParameter, property.DeclaringType), property);
@@ -32,6 +36,8 @@ static class DelegateFactory
     {
         if (!FieldInfoToLateBoundField.TryGetValue(field, out var lateBoundFieldGet))
         {
+            ArgumentNullException.ThrowIfNull(field.DeclaringType);
+
             var instanceParameter = Expression.Parameter(typeof(object), "target");
 
             var member = Expression.Field(Expression.Convert(instanceParameter, field.DeclaringType), field);
@@ -52,6 +58,8 @@ static class DelegateFactory
     {
         if (!FieldInfoToLateBoundFieldSet.TryGetValue(field, out var callback))
         {
+            ArgumentNullException.ThrowIfNull(field.DeclaringType);
+
             var sourceType = field.DeclaringType;
             var method = new DynamicMethod("Set" + field.Name, null, new[]
             {
@@ -87,6 +95,8 @@ static class DelegateFactory
     {
         if (!PropertyInfoToLateBoundPropertySet.TryGetValue(property, out var result))
         {
+            ArgumentNullException.ThrowIfNull(property.DeclaringType);
+
             var method = new DynamicMethod("Set" + property.Name, null, new[]
             {
                 typeof(object),
@@ -96,6 +106,7 @@ static class DelegateFactory
 
             var sourceType = property.DeclaringType;
             var setter = property.GetSetMethod(true);
+            ArgumentNullException.ThrowIfNull(setter); // setter cannot be null in the gen.Emit calls
 
             gen.Emit(OpCodes.Ldarg_0); // Load input to stack
 

--- a/src/NServiceBus.Core/Utils/Reflection/DelegateFactory.cs
+++ b/src/NServiceBus.Core/Utils/Reflection/DelegateFactory.cs
@@ -36,7 +36,7 @@ static class DelegateFactory
     {
         if (!FieldInfoToLateBoundField.TryGetValue(field, out var lateBoundFieldGet))
         {
-            ArgumentNullException.ThrowIfNull(field.DeclaringType);
+            ArgumentNullException.ThrowIfNull(field.DeclaringType, nameof(field));
 
             var instanceParameter = Expression.Parameter(typeof(object), "target");
 
@@ -58,7 +58,7 @@ static class DelegateFactory
     {
         if (!FieldInfoToLateBoundFieldSet.TryGetValue(field, out var callback))
         {
-            ArgumentNullException.ThrowIfNull(field.DeclaringType);
+            ArgumentNullException.ThrowIfNull(field.DeclaringType, nameof(field));
 
             var sourceType = field.DeclaringType;
             var method = new DynamicMethod("Set" + field.Name, null, new[]
@@ -95,7 +95,7 @@ static class DelegateFactory
     {
         if (!PropertyInfoToLateBoundPropertySet.TryGetValue(property, out var result))
         {
-            ArgumentNullException.ThrowIfNull(property.DeclaringType);
+            ArgumentNullException.ThrowIfNull(property.DeclaringType, nameof(property));
 
             var method = new DynamicMethod("Set" + property.Name, null, new[]
             {

--- a/src/NServiceBus.Core/Utils/Reflection/DelegateFactory.cs
+++ b/src/NServiceBus.Core/Utils/Reflection/DelegateFactory.cs
@@ -61,11 +61,11 @@ static class DelegateFactory
             ArgumentNullException.ThrowIfNull(field.DeclaringType, nameof(field));
 
             var sourceType = field.DeclaringType;
-            var method = new DynamicMethod("Set" + field.Name, null, new[]
-            {
+            var method = new DynamicMethod("Set" + field.Name, null,
+            [
                 typeof(object),
                 typeof(object)
-            }, true);
+            ], true);
             var gen = method.GetILGenerator();
 
             gen.Emit(OpCodes.Ldarg_0); // Load input to stack
@@ -97,11 +97,11 @@ static class DelegateFactory
         {
             ArgumentNullException.ThrowIfNull(property.DeclaringType, nameof(property));
 
-            var method = new DynamicMethod("Set" + property.Name, null, new[]
-            {
+            var method = new DynamicMethod("Set" + property.Name, null,
+            [
                 typeof(object),
                 typeof(object)
-            }, true);
+            ], true);
             var gen = method.GetILGenerator();
 
             var sourceType = property.DeclaringType;
@@ -140,8 +140,8 @@ static class DelegateFactory
         return result;
     }
 
-    static readonly ConcurrentDictionary<PropertyInfo, Func<object, object>> PropertyInfoToLateBoundProperty = new ConcurrentDictionary<PropertyInfo, Func<object, object>>();
-    static readonly ConcurrentDictionary<FieldInfo, Func<object, object>> FieldInfoToLateBoundField = new ConcurrentDictionary<FieldInfo, Func<object, object>>();
-    static readonly ConcurrentDictionary<PropertyInfo, Action<object, object>> PropertyInfoToLateBoundPropertySet = new ConcurrentDictionary<PropertyInfo, Action<object, object>>();
-    static readonly ConcurrentDictionary<FieldInfo, Action<object, object>> FieldInfoToLateBoundFieldSet = new ConcurrentDictionary<FieldInfo, Action<object, object>>();
+    static readonly ConcurrentDictionary<PropertyInfo, Func<object, object>> PropertyInfoToLateBoundProperty = new();
+    static readonly ConcurrentDictionary<FieldInfo, Func<object, object>> FieldInfoToLateBoundField = new();
+    static readonly ConcurrentDictionary<PropertyInfo, Action<object, object>> PropertyInfoToLateBoundPropertySet = new();
+    static readonly ConcurrentDictionary<FieldInfo, Action<object, object>> FieldInfoToLateBoundFieldSet = new();
 }

--- a/src/NServiceBus.Core/Utils/Reflection/DelegateFactory.cs
+++ b/src/NServiceBus.Core/Utils/Reflection/DelegateFactory.cs
@@ -106,7 +106,7 @@ static class DelegateFactory
 
             var sourceType = property.DeclaringType;
             var setter = property.GetSetMethod(true);
-            ArgumentNullException.ThrowIfNull(setter); // setter cannot be null in the gen.Emit calls
+            ArgumentNullException.ThrowIfNull(setter, nameof(property));
 
             gen.Emit(OpCodes.Ldarg_0); // Load input to stack
 

--- a/src/NServiceBus.Core/Utils/Reflection/DelegateFactory.cs
+++ b/src/NServiceBus.Core/Utils/Reflection/DelegateFactory.cs
@@ -14,7 +14,7 @@ static class DelegateFactory
     {
         if (!PropertyInfoToLateBoundProperty.TryGetValue(property, out var lateBoundPropertyGet))
         {
-            ArgumentNullException.ThrowIfNull(property.DeclaringType);
+            ArgumentNullException.ThrowIfNull(property.DeclaringType, nameof(property));
 
             var instanceParameter = Expression.Parameter(typeof(object), "target");
 

--- a/src/NServiceBus.Core/Utils/Reflection/TypeExtensionMethods.cs
+++ b/src/NServiceBus.Core/Utils/Reflection/TypeExtensionMethods.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace NServiceBus;
 
 using System;
@@ -82,14 +84,13 @@ static class TypeExtensionMethods
                     return result;
                 }
 
-                return Type.GetTypeFromHandle(typeHandle)?.Name;
+                return Type.GetTypeFromHandle(typeHandle)?.Name ?? t.Name;
             }, t);
     }
 
     static bool IsClrType(ReadOnlySpan<byte> publicKeyToken) => publicKeyToken.SequenceEqual(MsPublicKeyToken);
 
-    static readonly byte[] MsPublicKeyToken = typeof(string).Assembly.GetName().GetPublicKeyToken();
-
+    static readonly byte[] MsPublicKeyToken = typeof(string).Assembly.GetName().GetPublicKeyToken() ?? [];
     static readonly ConcurrentDictionary<RuntimeTypeHandle, bool> IsSystemTypeCache = new();
     static readonly ConcurrentDictionary<RuntimeTypeHandle, string> TypeToNameLookup = new();
 }

--- a/src/NServiceBus.Core/Utils/Reflection/TypeExtensionMethods.cs
+++ b/src/NServiceBus.Core/Utils/Reflection/TypeExtensionMethods.cs
@@ -5,7 +5,6 @@ namespace NServiceBus;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 static class TypeExtensionMethods
 {
@@ -48,16 +47,13 @@ static class TypeExtensionMethods
         }
 
         public bool IsFromParticularAssembly() => type.Assembly.IsParticularAssembly();
-    }
 
-    extension([NotNull] Type t)
-    {
         /// <summary>
         /// Takes the name of the given type and makes it friendly for serialization
         /// by removing problematic characters.
         /// </summary>
         public string SerializationFriendlyName() =>
-            TypeToNameLookup.GetOrAdd(t.TypeHandle, static (typeHandle, t) =>
+            TypeToNameLookup.GetOrAdd(type.TypeHandle, static (typeHandle, t) =>
             {
                 var index = t.Name.IndexOf('`');
                 if (index >= 0)
@@ -84,8 +80,8 @@ static class TypeExtensionMethods
                     return result;
                 }
 
-                return Type.GetTypeFromHandle(typeHandle)?.Name ?? t.Name;
-            }, t);
+                return t.Name;
+            }, type);
     }
 
     static bool IsClrType(ReadOnlySpan<byte> publicKeyToken) => publicKeyToken.SequenceEqual(MsPublicKeyToken);


### PR DESCRIPTION
#6257 

This PR add `#nullable enabled` for consistency with the rest of the folder.  New `ThrowIfArgumentNull` checks are now required that result in the null exception being thrown earlier up the stack.