### PR TITLE
Add support for nullable reference types - ServicePlatform

### DIFF
--- a/src/NServiceBus.Core.Tests/ServicePlatform/Retries/RetryAcknowledgementBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/ServicePlatform/Retries/RetryAcknowledgementBehaviorTests.cs
@@ -38,16 +38,16 @@ public class RetryAcknowledgementBehaviorTests
 
             Assert.That(outgoingMessage.Message.Headers.ContainsKey("ServiceControl.Retry.Successful"), Is.True);
 
-            Assert.That(outgoingMessage.Message.Body.Length, Is.EqualTo(0));
+            Assert.That(outgoingMessage.Message.Body.Length, Is.Zero);
 
             Assert.That(outgoingMessage.Message.Headers[Headers.ControlMessageHeader], Is.EqualTo(bool.TrueString));
         }
 
         var addressTag = outgoingMessage.RoutingStrategies.Single().Apply([]) as UnicastAddressTag;
+        Assert.That(addressTag, Is.Not.Null);
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(addressTag, Is.Not.Null);
-            Assert.That(addressTag?.Destination, Is.EqualTo(acknowledgementQueue));
+            Assert.That(addressTag.Destination, Is.EqualTo(acknowledgementQueue));
 
             Assert.That(context.Extensions.TryGet<MarkAsAcknowledgedBehavior.State>(out _), Is.True);
         }
@@ -70,7 +70,7 @@ public class RetryAcknowledgementBehaviorTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(exception, Is.SameAs(thrownException));
-            Assert.That(routingPipeline.ForkInvocations.Count, Is.EqualTo(0));
+            Assert.That(routingPipeline.ForkInvocations, Is.Empty);
         }
     }
 
@@ -88,7 +88,7 @@ public class RetryAcknowledgementBehaviorTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(routingPipeline.ForkInvocations.Count, Is.EqualTo(0));
+            Assert.That(routingPipeline.ForkInvocations, Is.Empty);
             Assert.That(context.Extensions.TryGet<MarkAsAcknowledgedBehavior.State>(out _), Is.False);
         }
     }
@@ -106,7 +106,7 @@ public class RetryAcknowledgementBehaviorTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(routingPipeline.ForkInvocations.Count, Is.EqualTo(0));
+            Assert.That(routingPipeline.ForkInvocations, Is.Empty);
             Assert.That(context.Extensions.TryGet<MarkAsAcknowledgedBehavior.State>(out _), Is.False);
         }
     }

--- a/src/NServiceBus.Core.Tests/ServicePlatform/Retries/RetryAcknowledgementBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/ServicePlatform/Retries/RetryAcknowledgementBehaviorTests.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Core.Tests.ServicePlatform.Retries;
+﻿#nullable enable
+
+namespace NServiceBus.Core.Tests.ServicePlatform.Retries;
 
 using System;
 using System.Collections.Generic;

--- a/src/NServiceBus.Core.Tests/ServicePlatform/Retries/RetryAcknowledgementBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/ServicePlatform/Retries/RetryAcknowledgementBehaviorTests.cs
@@ -46,7 +46,8 @@ public class RetryAcknowledgementBehaviorTests
         var addressTag = outgoingMessage.RoutingStrategies.Single().Apply([]) as UnicastAddressTag;
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(addressTag.Destination, Is.EqualTo(acknowledgementQueue));
+            Assert.That(addressTag is not null);
+            Assert.That(addressTag!.Destination, Is.EqualTo(acknowledgementQueue));
 
             Assert.That(context.Extensions.TryGet<MarkAsAcknowledgedBehavior.State>(out _), Is.True);
         }

--- a/src/NServiceBus.Core.Tests/ServicePlatform/Retries/RetryAcknowledgementBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/ServicePlatform/Retries/RetryAcknowledgementBehaviorTests.cs
@@ -47,7 +47,7 @@ public class RetryAcknowledgementBehaviorTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(addressTag is not null);
-            Assert.That(addressTag!.Destination, Is.EqualTo(acknowledgementQueue));
+            Assert.That(addressTag?.Destination, Is.EqualTo(acknowledgementQueue));
 
             Assert.That(context.Extensions.TryGet<MarkAsAcknowledgedBehavior.State>(out _), Is.True);
         }

--- a/src/NServiceBus.Core.Tests/ServicePlatform/Retries/RetryAcknowledgementBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/ServicePlatform/Retries/RetryAcknowledgementBehaviorTests.cs
@@ -46,7 +46,7 @@ public class RetryAcknowledgementBehaviorTests
         var addressTag = outgoingMessage.RoutingStrategies.Single().Apply([]) as UnicastAddressTag;
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(addressTag is not null);
+            Assert.That(addressTag, Is.Not.Null);
             Assert.That(addressTag?.Destination, Is.EqualTo(acknowledgementQueue));
 
             Assert.That(context.Extensions.TryGet<MarkAsAcknowledgedBehavior.State>(out _), Is.True);

--- a/src/NServiceBus.Core/ServicePlatform/Retries/PlatformRetryNotifications.cs
+++ b/src/NServiceBus.Core/ServicePlatform/Retries/PlatformRetryNotifications.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Features;
+﻿#nullable enable
+
+namespace NServiceBus.Features;
 
 /// <summary>
 /// Provides notifications to ServiceControl about successfully retried messages.

--- a/src/NServiceBus.Core/ServicePlatform/Retries/RetryAcknowledgementBehavior.cs
+++ b/src/NServiceBus.Core/ServicePlatform/Retries/RetryAcknowledgementBehavior.cs
@@ -4,6 +4,7 @@ namespace NServiceBus;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Pipeline;
 using Routing;
@@ -47,7 +48,7 @@ class RetryAcknowledgementBehavior : IForkConnector<ITransportReceiveContext, IT
         }
     }
 
-    static bool IsRetriedMessage(ITransportReceiveContext context, out string? retryUniqueMessageId, out string? retryAcknowledgementQueue)
+    static bool IsRetriedMessage(ITransportReceiveContext context, [NotNullWhen(true)] out string? retryUniqueMessageId, [NotNullWhen(true)] out string? retryAcknowledgementQueue)
     {
         // check if the message is coming from a manual retry attempt
         if (context.Message.Headers.TryGetValue(RetryUniqueMessageIdHeaderKey, out var uniqueMessageId) &&

--- a/src/NServiceBus.Core/ServicePlatform/Retries/RetryAcknowledgementBehavior.cs
+++ b/src/NServiceBus.Core/ServicePlatform/Retries/RetryAcknowledgementBehavior.cs
@@ -17,33 +17,30 @@ class RetryAcknowledgementBehavior : IForkConnector<ITransportReceiveContext, IT
 
     public async Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
     {
-        var useRetryAcknowledgement = IsRetriedMessage(context, out var id, out var acknowledgementQueue);
+        RoutingContext? routingContext = null;
 
-        if (useRetryAcknowledgement)
+        if (IsRetriedMessage(context, out var id, out var acknowledgementQueue))
         {
             // notify the ServiceControl audit instance that the retry has already been acknowledged by the endpoint
             context.Extensions.Set(MarkAsAcknowledgedBehavior.State.Instance);
-        }
 
-        await next(context).ConfigureAwait(false);
-
-        if (useRetryAcknowledgement)
-        {
-            await ConfirmSuccessfulRetry().ConfigureAwait(false);
-        }
-
-        async Task ConfirmSuccessfulRetry()
-        {
             var messageToDispatch = new OutgoingMessage(
                 CombGuid.Generate().ToString(),
                 new Dictionary<string, string>
                 {
                     { "ServiceControl.Retry.Successful", DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow) },
-                    { RetryUniqueMessageIdHeaderKey, id! },
+                    { RetryUniqueMessageIdHeaderKey, id },
                     { Headers.ControlMessageHeader, bool.TrueString }
                 },
                 Array.Empty<byte>());
-            var routingContext = new RoutingContext(messageToDispatch, new UnicastRoutingStrategy(acknowledgementQueue), context);
+
+            routingContext = new RoutingContext(messageToDispatch, new UnicastRoutingStrategy(acknowledgementQueue), context);
+        }
+
+        await next(context).ConfigureAwait(false);
+
+        if (routingContext is not null)
+        {
             await this.Fork(routingContext).ConfigureAwait(false);
         }
     }

--- a/src/NServiceBus.Core/ServicePlatform/Retries/RetryAcknowledgementBehavior.cs
+++ b/src/NServiceBus.Core/ServicePlatform/Retries/RetryAcknowledgementBehavior.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus;
+﻿#nullable enable
+
+namespace NServiceBus;
 
 using System;
 using System.Collections.Generic;
@@ -36,7 +38,7 @@ class RetryAcknowledgementBehavior : IForkConnector<ITransportReceiveContext, IT
                 new Dictionary<string, string>
                 {
                     { "ServiceControl.Retry.Successful", DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow) },
-                    { RetryUniqueMessageIdHeaderKey, id },
+                    { RetryUniqueMessageIdHeaderKey, id! },
                     { Headers.ControlMessageHeader, bool.TrueString }
                 },
                 Array.Empty<byte>());
@@ -45,7 +47,7 @@ class RetryAcknowledgementBehavior : IForkConnector<ITransportReceiveContext, IT
         }
     }
 
-    static bool IsRetriedMessage(ITransportReceiveContext context, out string retryUniqueMessageId, out string retryAcknowledgementQueue)
+    static bool IsRetriedMessage(ITransportReceiveContext context, out string? retryUniqueMessageId, out string? retryAcknowledgementQueue)
     {
         // check if the message is coming from a manual retry attempt
         if (context.Message.Headers.TryGetValue(RetryUniqueMessageIdHeaderKey, out var uniqueMessageId) &&


### PR DESCRIPTION
#6257 

This PR adds `#nullable enable` to the `ServicePlatform` folder.