### PR TITLE
Endpoint-level trace connector defaults for sends and publishes

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_publishing_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_publishing_messages.cs
@@ -328,7 +328,7 @@ public class When_publishing_messages : OpenTelemetryAcceptanceTest
         public PublisherWithChildSpanConnector() =>
             EndpointSetup<DefaultServer>(b =>
             {
-                b.Tracing().PublishedMessageTraceConnector = TraceConnector.ChildSpan;
+                b.Tracing().PublishTraceMode = TraceMode.ContinueExisting;
                 b.OnEndpointSubscribed<Context>((s, context) =>
                 {
                     if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(SubscriberForPublisherWithChildSpanConnector))))

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_publishing_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_publishing_messages.cs
@@ -242,5 +242,125 @@ public class When_publishing_messages : OpenTelemetryAcceptanceTest
         }
     }
 
+    [Test]
+    public async Task Should_create_child_on_receive_when_endpoint_defaults_to_child_span()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<PublisherWithChildSpanConnector>(b => b
+                .When(ctx => ctx.SomeEventSubscribed, s => s.Publish(new ThisIsAnEvent())))
+            .WithEndpoint<SubscriberForPublisherWithChildSpanConnector>(b => b.When((session, ctx) =>
+            {
+                if (ctx.HasNativePubSubSupport)
+                {
+                    ctx.SomeEventSubscribed = true;
+                }
+
+                return Task.CompletedTask;
+            }))
+            .Run();
+
+        var publishMessageActivities = NServiceBusActivityListener.CompletedActivities.GetPublishEventActivities();
+        var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(publishMessageActivities, Has.Count.EqualTo(1), "1 message is published as part of this test");
+            Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
+        }
+
+        var publishRequest = publishMessageActivities[0];
+        var receiveRequest = receiveMessageActivities[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receiveRequest.RootId, Is.EqualTo(publishRequest.RootId), "publish and receive operations are part the same root activity");
+            Assert.That(receiveRequest.ParentId, Is.Not.Null, "incoming message does have a parent");
+        }
+
+        Assert.That(receiveRequest.Links, Is.Empty, "receive does not have links");
+    }
+
+    [Test]
+    public async Task Should_create_new_linked_trace_on_receive_when_option_overrides_endpoint_connector()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<PublisherWithChildSpanConnector>(b => b
+                .When(ctx => ctx.SomeEventSubscribed, s =>
+                {
+                    var publishOptions = new PublishOptions();
+                    publishOptions.StartNewTraceOnReceive();
+                    return s.Publish(new ThisIsAnEvent(), publishOptions);
+                }))
+            .WithEndpoint<SubscriberForPublisherWithChildSpanConnector>(b => b.When((session, ctx) =>
+            {
+                if (ctx.HasNativePubSubSupport)
+                {
+                    ctx.SomeEventSubscribed = true;
+                }
+
+                return Task.CompletedTask;
+            }))
+            .Run();
+
+        var publishMessageActivities = NServiceBusActivityListener.CompletedActivities.GetPublishEventActivities();
+        var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(publishMessageActivities, Has.Count.EqualTo(1), "1 message is published as part of this test");
+            Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
+        }
+
+        var publishRequest = publishMessageActivities[0];
+        var receiveRequest = receiveMessageActivities[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receiveRequest.RootId, Is.Not.EqualTo(publishRequest.RootId), "publish and receive operations are part of different root activities");
+            Assert.That(receiveRequest.ParentId, Is.Null, "incoming message does not have a parent, it's a root");
+        }
+
+        ActivityLink link = receiveRequest.Links.FirstOrDefault();
+        Assert.That(link, Is.Not.EqualTo(default(ActivityLink)), "Receive has a link");
+        Assert.That(link.Context.TraceId, Is.EqualTo(publishRequest.TraceId), "receive is linked to publish operation");
+    }
+
+    public class PublisherWithChildSpanConnector : EndpointConfigurationBuilder
+    {
+        public PublisherWithChildSpanConnector() =>
+            EndpointSetup<DefaultServer>(b =>
+            {
+                b.Tracing().PublishedMessageTraceConnector = TraceConnector.ChildSpan;
+                b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(SubscriberForPublisherWithChildSpanConnector))))
+                    {
+                        if (s.MessageType == typeof(ThisIsAnEvent).AssemblyQualifiedName)
+                        {
+                            context.SomeEventSubscribed = true;
+                        }
+                    }
+                });
+            });
+    }
+
+    public class SubscriberForPublisherWithChildSpanConnector : EndpointConfigurationBuilder
+    {
+        public SubscriberForPublisherWithChildSpanConnector() =>
+            EndpointSetup<DefaultServer>(c => { },
+                metadata =>
+                {
+                    metadata.RegisterPublisherFor<ThisIsAnEvent, PublisherWithChildSpanConnector>();
+                });
+
+        [Handler]
+        public class ThisHandlesSomethingHandler(Context testContext) : IHandleMessages<ThisIsAnEvent>
+        {
+            public Task Handle(ThisIsAnEvent @event, IMessageHandlerContext context)
+            {
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
     public class ThisIsAnEvent : IEvent;
 }

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_messages.cs
@@ -163,5 +163,85 @@ public class When_sending_messages : OpenTelemetryAcceptanceTest
         }
     }
 
+    [Test]
+    public async Task Should_create_new_linked_trace_on_receive_when_endpoint_defaults_to_span_link()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<TestEndpointWithSpanLinkConnector>(b => b
+                .When(s => s.SendLocal(new OutgoingMessage())))
+            .Run();
+
+        var sendMessageActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
+        var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(sendMessageActivities, Has.Count.EqualTo(1), "1 message is sent as part of this test");
+            Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
+        }
+
+        var sendRequest = sendMessageActivities[0];
+        var receiveRequest = receiveMessageActivities[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receiveRequest.RootId, Is.Not.EqualTo(sendRequest.RootId), "send and receive operations are part of different root activities");
+            Assert.That(receiveRequest.ParentId, Is.Null, "incoming message does not have a parent, it's a root");
+        }
+
+        ActivityLink link = receiveRequest.Links.FirstOrDefault();
+        Assert.That(link, Is.Not.EqualTo(default(ActivityLink)), "Receive has a link");
+        Assert.That(link.Context.TraceId, Is.EqualTo(sendRequest.TraceId), "receive is linked to send operation");
+    }
+
+    [Test]
+    public async Task Should_create_child_on_receive_when_option_overrides_endpoint_connector()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<TestEndpointWithSpanLinkConnector>(b => b
+                .When(s =>
+                {
+                    var sendOptions = new SendOptions();
+                    sendOptions.RouteToThisEndpoint();
+                    sendOptions.ContinueExistingTraceOnReceive();
+                    return s.Send(new OutgoingMessage(), sendOptions);
+                }))
+            .Run();
+
+        var sendMessageActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
+        var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(sendMessageActivities, Has.Count.EqualTo(1), "1 message is sent as part of this test");
+            Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
+        }
+
+        var sendRequest = sendMessageActivities[0];
+        var receiveRequest = receiveMessageActivities[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receiveRequest.RootId, Is.EqualTo(sendRequest.RootId), "send and receive operations are part of the same root activity");
+            Assert.That(receiveRequest.ParentId, Is.Not.Null, "incoming message does have a parent");
+        }
+
+        Assert.That(receiveRequest.Links, Is.Empty, "receive does not have links");
+    }
+
+    public class TestEndpointWithSpanLinkConnector : EndpointConfigurationBuilder
+    {
+        public TestEndpointWithSpanLinkConnector() =>
+            EndpointSetup<DefaultServer>(b => b.Tracing().SentMessageTraceConnector = TraceConnector.SpanLink);
+
+        [Handler]
+        public class MessageHandler(Context testContext) : IHandleMessages<OutgoingMessage>
+        {
+            public Task Handle(OutgoingMessage message, IMessageHandlerContext context)
+            {
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
     public class OutgoingMessage : IMessage;
 }

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_messages.cs
@@ -230,7 +230,7 @@ public class When_sending_messages : OpenTelemetryAcceptanceTest
     public class TestEndpointWithSpanLinkConnector : EndpointConfigurationBuilder
     {
         public TestEndpointWithSpanLinkConnector() =>
-            EndpointSetup<DefaultServer>(b => b.Tracing().SentMessageTraceConnector = TraceConnector.SpanLink);
+            EndpointSetup<DefaultServer>(b => b.Tracing().SendTraceMode = TraceMode.StartNew);
 
         [Handler]
         public class MessageHandler(Context testContext) : IHandleMessages<OutgoingMessage>

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -636,8 +636,8 @@ namespace NServiceBus
     {
         public InstrumentationOptions() { }
         public bool EmitMessageDispatchingEvents { get; set; }
-        public NServiceBus.TraceConnector PublishedMessageTraceConnector { get; set; }
-        public NServiceBus.TraceConnector SentMessageTraceConnector { get; set; }
+        public NServiceBus.TraceMode PublishTraceMode { get; set; }
+        public NServiceBus.TraceMode SendTraceMode { get; set; }
         public bool UseMessageDestinationInSpanNames { get; set; }
     }
     public sealed class KeyedServiceKey
@@ -1178,10 +1178,10 @@ namespace NServiceBus
         public ToSagaExpression(NServiceBus.IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration, System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
         public void ToSaga(System.Linq.Expressions.Expression<System.Func<TSagaData, object?>> sagaEntityProperty) { }
     }
-    public enum TraceConnector
+    public enum TraceMode
     {
-        ChildSpan = 0,
-        SpanLink = 1,
+        ContinueExisting = 0,
+        StartNew = 1,
     }
     public static class TransportConfig
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -635,6 +635,8 @@ namespace NServiceBus
     public class InstrumentationOptions
     {
         public InstrumentationOptions() { }
+        public NServiceBus.TraceConnector PublishedMessageTraceConnector { get; set; }
+        public NServiceBus.TraceConnector SentMessageTraceConnector { get; set; }
         public bool UseMessageDestinationInSpanNames { get; set; }
     }
     public sealed class KeyedServiceKey
@@ -776,6 +778,8 @@ namespace NServiceBus
     public static class OpenTelemetryExtensions
     {
         public static void ContinueExistingTraceOnReceive(this NServiceBus.PublishOptions publishOptions) { }
+        public static void ContinueExistingTraceOnReceive(this NServiceBus.SendOptions sendOptions) { }
+        public static void StartNewTraceOnReceive(this NServiceBus.PublishOptions publishOptions) { }
         public static void StartNewTraceOnReceive(this NServiceBus.SendOptions sendOptions) { }
         public static NServiceBus.InstrumentationOptions Tracing(this NServiceBus.EndpointConfiguration config) { }
     }
@@ -1172,6 +1176,11 @@ namespace NServiceBus
     {
         public ToSagaExpression(NServiceBus.IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration, System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
         public void ToSaga(System.Linq.Expressions.Expression<System.Func<TSagaData, object?>> sagaEntityProperty) { }
+    }
+    public enum TraceConnector
+    {
+        ChildSpan = 0,
+        SpanLink = 1,
     }
     public static class TransportConfig
     {

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/InstrumentationOptionsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/InstrumentationOptionsTests.cs
@@ -1,0 +1,19 @@
+namespace NServiceBus.Core.Tests.OpenTelemetry;
+
+using NUnit.Framework;
+
+[TestFixture]
+public class InstrumentationOptionsTests
+{
+    [Test]
+    public void Should_default_trace_connectors_to_current_behavior()
+    {
+        var options = new InstrumentationOptions();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(options.SentMessageTraceConnector, Is.EqualTo(TraceConnector.ChildSpan), "sends continue the trace by default");
+            Assert.That(options.PublishedMessageTraceConnector, Is.EqualTo(TraceConnector.SpanLink), "publishes start a new linked trace by default");
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/InstrumentationOptionsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/InstrumentationOptionsTests.cs
@@ -12,8 +12,8 @@ public class InstrumentationOptionsTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(options.SentMessageTraceConnector, Is.EqualTo(TraceConnector.ChildSpan), "sends continue the trace by default");
-            Assert.That(options.PublishedMessageTraceConnector, Is.EqualTo(TraceConnector.SpanLink), "publishes start a new linked trace by default");
+            Assert.That(options.SendTraceMode, Is.EqualTo(TraceMode.ContinueExisting), "sends continue the trace by default");
+            Assert.That(options.PublishTraceMode, Is.EqualTo(TraceMode.StartNew), "publishes start a new linked trace by default");
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryExtensionsTests.cs
@@ -12,8 +12,8 @@ public class OpenTelemetryExtensionsTests
 
         options.StartNewTraceOnReceive();
 
-        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
-        Assert.That(connector, Is.EqualTo(TraceConnector.SpanLink));
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceMode.StartNew));
     }
 
     [Test]
@@ -23,8 +23,8 @@ public class OpenTelemetryExtensionsTests
 
         options.ContinueExistingTraceOnReceive();
 
-        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
-        Assert.That(connector, Is.EqualTo(TraceConnector.ChildSpan));
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceMode.ContinueExisting));
     }
 
     [Test]
@@ -34,8 +34,8 @@ public class OpenTelemetryExtensionsTests
 
         options.StartNewTraceOnReceive();
 
-        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
-        Assert.That(connector, Is.EqualTo(TraceConnector.SpanLink));
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceMode.StartNew));
     }
 
     [Test]
@@ -45,8 +45,8 @@ public class OpenTelemetryExtensionsTests
 
         options.ContinueExistingTraceOnReceive();
 
-        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
-        Assert.That(connector, Is.EqualTo(TraceConnector.ChildSpan));
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceMode.ContinueExisting));
     }
 
     [Test]
@@ -57,7 +57,7 @@ public class OpenTelemetryExtensionsTests
         options.ContinueExistingTraceOnReceive();
         options.StartNewTraceOnReceive();
 
-        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
-        Assert.That(connector, Is.EqualTo(TraceConnector.SpanLink));
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceMode.StartNew));
     }
 }

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryExtensionsTests.cs
@@ -1,0 +1,63 @@
+namespace NServiceBus.Core.Tests.OpenTelemetry;
+
+using NUnit.Framework;
+
+[TestFixture]
+public class OpenTelemetryExtensionsTests
+{
+    [Test]
+    public void StartNewTraceOnReceive_should_set_span_link_override_on_send_options()
+    {
+        var options = new SendOptions();
+
+        options.StartNewTraceOnReceive();
+
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceConnector.SpanLink));
+    }
+
+    [Test]
+    public void ContinueExistingTraceOnReceive_should_set_child_span_override_on_send_options()
+    {
+        var options = new SendOptions();
+
+        options.ContinueExistingTraceOnReceive();
+
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceConnector.ChildSpan));
+    }
+
+    [Test]
+    public void StartNewTraceOnReceive_should_set_span_link_override_on_publish_options()
+    {
+        var options = new PublishOptions();
+
+        options.StartNewTraceOnReceive();
+
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceConnector.SpanLink));
+    }
+
+    [Test]
+    public void ContinueExistingTraceOnReceive_should_set_child_span_override_on_publish_options()
+    {
+        var options = new PublishOptions();
+
+        options.ContinueExistingTraceOnReceive();
+
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceConnector.ChildSpan));
+    }
+
+    [Test]
+    public void Last_override_call_wins()
+    {
+        var options = new PublishOptions();
+
+        options.ContinueExistingTraceOnReceive();
+        options.StartNewTraceOnReceive();
+
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceConnector.SpanLink));
+    }
+}

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryPublishBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryPublishBehaviorTests.cs
@@ -21,7 +21,7 @@ public class OpenTelemetryPublishBehaviorTests
     [Test]
     public async Task Should_continue_trace_on_receive_when_endpoint_connector_is_child_span()
     {
-        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishedMessageTraceConnector = TraceConnector.ChildSpan });
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishTraceMode = TraceMode.ContinueExisting });
         var context = new TestableOutgoingPublishContext();
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
@@ -32,9 +32,9 @@ public class OpenTelemetryPublishBehaviorTests
     [Test]
     public async Task Should_prefer_child_span_option_over_endpoint_connector()
     {
-        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishedMessageTraceConnector = TraceConnector.SpanLink });
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishTraceMode = TraceMode.StartNew });
         var context = new TestableOutgoingPublishContext();
-        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceMode.ContinueExisting);
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
 
@@ -44,9 +44,9 @@ public class OpenTelemetryPublishBehaviorTests
     [Test]
     public async Task Should_prefer_span_link_option_over_endpoint_connector()
     {
-        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishedMessageTraceConnector = TraceConnector.ChildSpan });
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishTraceMode = TraceMode.ContinueExisting });
         var context = new TestableOutgoingPublishContext();
-        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.SpanLink);
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceMode.StartNew);
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
 

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryPublishBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryPublishBehaviorTests.cs
@@ -1,0 +1,55 @@
+namespace NServiceBus.Core.Tests.OpenTelemetry;
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Testing;
+
+[TestFixture]
+public class OpenTelemetryPublishBehaviorTests
+{
+    [Test]
+    public async Task Should_start_new_trace_on_receive_by_default()
+    {
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions());
+        var context = new TestableOutgoingPublishContext();
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public async Task Should_continue_trace_on_receive_when_endpoint_connector_is_child_span()
+    {
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishedMessageTraceConnector = TraceConnector.ChildSpan });
+        var context = new TestableOutgoingPublishContext();
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.FalseString));
+    }
+
+    [Test]
+    public async Task Should_prefer_child_span_option_over_endpoint_connector()
+    {
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishedMessageTraceConnector = TraceConnector.SpanLink });
+        var context = new TestableOutgoingPublishContext();
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.FalseString));
+    }
+
+    [Test]
+    public async Task Should_prefer_span_link_option_over_endpoint_connector()
+    {
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishedMessageTraceConnector = TraceConnector.ChildSpan });
+        var context = new TestableOutgoingPublishContext();
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.SpanLink);
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
+    }
+}

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetrySendBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetrySendBehaviorTests.cs
@@ -1,0 +1,55 @@
+namespace NServiceBus.Core.Tests.OpenTelemetry;
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Testing;
+
+[TestFixture]
+public class OpenTelemetrySendBehaviorTests
+{
+    [Test]
+    public async Task Should_continue_trace_on_receive_by_default()
+    {
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions());
+        var context = new TestableOutgoingSendContext();
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.FalseString));
+    }
+
+    [Test]
+    public async Task Should_start_new_trace_on_receive_when_endpoint_connector_is_span_link()
+    {
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SentMessageTraceConnector = TraceConnector.SpanLink });
+        var context = new TestableOutgoingSendContext();
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public async Task Should_prefer_span_link_option_over_endpoint_connector()
+    {
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SentMessageTraceConnector = TraceConnector.ChildSpan });
+        var context = new TestableOutgoingSendContext();
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.SpanLink);
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public async Task Should_prefer_child_span_option_over_endpoint_connector()
+    {
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SentMessageTraceConnector = TraceConnector.SpanLink });
+        var context = new TestableOutgoingSendContext();
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.FalseString));
+    }
+}

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetrySendBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetrySendBehaviorTests.cs
@@ -21,7 +21,7 @@ public class OpenTelemetrySendBehaviorTests
     [Test]
     public async Task Should_start_new_trace_on_receive_when_endpoint_connector_is_span_link()
     {
-        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SentMessageTraceConnector = TraceConnector.SpanLink });
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SendTraceMode = TraceMode.StartNew });
         var context = new TestableOutgoingSendContext();
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
@@ -32,9 +32,9 @@ public class OpenTelemetrySendBehaviorTests
     [Test]
     public async Task Should_prefer_span_link_option_over_endpoint_connector()
     {
-        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SentMessageTraceConnector = TraceConnector.ChildSpan });
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SendTraceMode = TraceMode.ContinueExisting });
         var context = new TestableOutgoingSendContext();
-        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.SpanLink);
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceMode.StartNew);
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
 
@@ -44,9 +44,9 @@ public class OpenTelemetrySendBehaviorTests
     [Test]
     public async Task Should_prefer_child_span_option_over_endpoint_connector()
     {
-        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SentMessageTraceConnector = TraceConnector.SpanLink });
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SendTraceMode = TraceMode.StartNew });
         var context = new TestableOutgoingSendContext();
-        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceMode.ContinueExisting);
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
 

--- a/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
@@ -14,4 +14,20 @@ public class InstrumentationOptions
     /// Disabled by default for backward compatibility.
     /// </summary>
     public bool UseMessageDestinationInSpanNames { get; set; }
+
+    /// <summary>
+    /// Controls how the receive-side processing span relates to the send span for messages sent by this endpoint.
+    /// Defaults to <see cref="TraceConnector.ChildSpan"/>: receivers continue the trace.
+    /// Can be overridden per message via <c>StartNewTraceOnReceive</c>
+    /// or <c>ContinueExistingTraceOnReceive</c>.
+    /// </summary>
+    public TraceConnector SentMessageTraceConnector { get; set; } = TraceConnector.ChildSpan;
+
+    /// <summary>
+    /// Controls how the receive-side processing span relates to the publish span for events published by this endpoint.
+    /// Defaults to <see cref="TraceConnector.SpanLink"/>: receivers start a new trace linked back to the publish span.
+    /// Can be overridden per message via <c>StartNewTraceOnReceive</c>
+    /// or <c>ContinueExistingTraceOnReceive</c>.
+    /// </summary>
+    public TraceConnector PublishedMessageTraceConnector { get; set; } = TraceConnector.SpanLink;
 }

--- a/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
@@ -17,17 +17,17 @@ public class InstrumentationOptions
 
     /// <summary>
     /// Controls how the receive-side processing span relates to the send span for messages sent by this endpoint.
-    /// Defaults to <see cref="TraceConnector.ChildSpan"/>: receivers continue the trace.
+    /// Defaults to <see cref="TraceMode.ContinueExisting"/>: receivers continue the trace.
     /// Can be overridden per message via <see cref="OpenTelemetryExtensions.StartNewTraceOnReceive(SendOptions)"/>
     /// or <see cref="OpenTelemetryExtensions.ContinueExistingTraceOnReceive(SendOptions)"/>.
     /// </summary>
-    public TraceConnector SentMessageTraceConnector { get; set; } = TraceConnector.ChildSpan;
+    public TraceMode SendTraceMode { get; set; } = TraceMode.ContinueExisting;
 
     /// <summary>
     /// Controls how the receive-side processing span relates to the publish span for events published by this endpoint.
-    /// Defaults to <see cref="TraceConnector.SpanLink"/>: receivers start a new trace linked back to the publish span.
+    /// Defaults to <see cref="TraceMode.StartNew"/>: receivers start a new trace linked back to the publish span.
     /// Can be overridden per message via <see cref="OpenTelemetryExtensions.StartNewTraceOnReceive(PublishOptions)"/>
     /// or <see cref="OpenTelemetryExtensions.ContinueExistingTraceOnReceive(PublishOptions)"/>.
     /// </summary>
-    public TraceConnector PublishedMessageTraceConnector { get; set; } = TraceConnector.SpanLink;
+    public TraceMode PublishTraceMode { get; set; } = TraceMode.StartNew;
 }

--- a/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
@@ -18,16 +18,16 @@ public class InstrumentationOptions
     /// <summary>
     /// Controls how the receive-side processing span relates to the send span for messages sent by this endpoint.
     /// Defaults to <see cref="TraceConnector.ChildSpan"/>: receivers continue the trace.
-    /// Can be overridden per message via <c>StartNewTraceOnReceive</c>
-    /// or <c>ContinueExistingTraceOnReceive</c>.
+    /// Can be overridden per message via <see cref="OpenTelemetryExtensions.StartNewTraceOnReceive(SendOptions)"/>
+    /// or <see cref="OpenTelemetryExtensions.ContinueExistingTraceOnReceive(SendOptions)"/>.
     /// </summary>
     public TraceConnector SentMessageTraceConnector { get; set; } = TraceConnector.ChildSpan;
 
     /// <summary>
     /// Controls how the receive-side processing span relates to the publish span for events published by this endpoint.
     /// Defaults to <see cref="TraceConnector.SpanLink"/>: receivers start a new trace linked back to the publish span.
-    /// Can be overridden per message via <c>StartNewTraceOnReceive</c>
-    /// or <c>ContinueExistingTraceOnReceive</c>.
+    /// Can be overridden per message via <see cref="OpenTelemetryExtensions.StartNewTraceOnReceive(PublishOptions)"/>
+    /// or <see cref="OpenTelemetryExtensions.ContinueExistingTraceOnReceive(PublishOptions)"/>.
     /// </summary>
     public TraceConnector PublishedMessageTraceConnector { get; set; } = TraceConnector.SpanLink;
 }

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryExtensions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryExtensions.cs
@@ -22,46 +22,46 @@ public static class OpenTelemetryExtensions
 
     /// <summary>
     /// Start a new OpenTelemetry trace on receive of this message, linked back to the send span.
-    /// Overrides <see cref="InstrumentationOptions.SentMessageTraceConnector"/> for this message.
+    /// Overrides <see cref="InstrumentationOptions.SendTraceMode"/> for this message.
     /// </summary>
     /// <param name="sendOptions">The option being extended.</param>
     public static void StartNewTraceOnReceive(this SendOptions sendOptions)
     {
         ArgumentNullException.ThrowIfNull(sendOptions);
-        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.SpanLink);
+        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceMode.StartNew);
     }
 
     /// <summary>
     /// Continue the existing OpenTelemetry trace on receive of this message.
-    /// Overrides <see cref="InstrumentationOptions.SentMessageTraceConnector"/> for this message.
+    /// Overrides <see cref="InstrumentationOptions.SendTraceMode"/> for this message.
     /// </summary>
     /// <param name="sendOptions">The option being extended.</param>
     public static void ContinueExistingTraceOnReceive(this SendOptions sendOptions)
     {
         ArgumentNullException.ThrowIfNull(sendOptions);
-        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceMode.ContinueExisting);
     }
 
     /// <summary>
     /// Start a new OpenTelemetry trace on receive of this event, linked back to the publish span.
-    /// Overrides <see cref="InstrumentationOptions.PublishedMessageTraceConnector"/> for this message.
+    /// Overrides <see cref="InstrumentationOptions.PublishTraceMode"/> for this message.
     /// </summary>
     /// <param name="publishOptions">The option being extended.</param>
     public static void StartNewTraceOnReceive(this PublishOptions publishOptions)
     {
         ArgumentNullException.ThrowIfNull(publishOptions);
-        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.SpanLink);
+        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceMode.StartNew);
     }
 
     /// <summary>
     /// Continue the existing OpenTelemetry trace on receive of this event.
-    /// Overrides <see cref="InstrumentationOptions.PublishedMessageTraceConnector"/> for this message.
+    /// Overrides <see cref="InstrumentationOptions.PublishTraceMode"/> for this message.
     /// </summary>
     /// <param name="publishOptions">The option being extended.</param>
     public static void ContinueExistingTraceOnReceive(this PublishOptions publishOptions)
     {
         ArgumentNullException.ThrowIfNull(publishOptions);
-        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceMode.ContinueExisting);
     }
 
     internal const string TraceConnectorOverrideKey = "NServiceBus.OpenTelemetry.TraceConnectorOverride";

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryExtensions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryExtensions.cs
@@ -21,20 +21,48 @@ public static class OpenTelemetryExtensions
     }
 
     /// <summary>
-    /// Start a new OpenTelemetry trace conversation.
+    /// Start a new OpenTelemetry trace on receive of this message, linked back to the send span.
+    /// Overrides <see cref="InstrumentationOptions.SentMessageTraceConnector"/> for this message.
     /// </summary>
     /// <param name="sendOptions">The option being extended.</param>
     public static void StartNewTraceOnReceive(this SendOptions sendOptions)
     {
-        sendOptions.Context.Set(OpenTelemetrySendBehavior.StartNewTraceOnReceive, true);
+        ArgumentNullException.ThrowIfNull(sendOptions);
+        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.SpanLink);
     }
 
     /// <summary>
-    /// Start a new OpenTelemetry trace conversation.
+    /// Continue the existing OpenTelemetry trace on receive of this message.
+    /// Overrides <see cref="InstrumentationOptions.SentMessageTraceConnector"/> for this message.
+    /// </summary>
+    /// <param name="sendOptions">The option being extended.</param>
+    public static void ContinueExistingTraceOnReceive(this SendOptions sendOptions)
+    {
+        ArgumentNullException.ThrowIfNull(sendOptions);
+        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+    }
+
+    /// <summary>
+    /// Start a new OpenTelemetry trace on receive of this event, linked back to the publish span.
+    /// Overrides <see cref="InstrumentationOptions.PublishedMessageTraceConnector"/> for this message.
+    /// </summary>
+    /// <param name="publishOptions">The option being extended.</param>
+    public static void StartNewTraceOnReceive(this PublishOptions publishOptions)
+    {
+        ArgumentNullException.ThrowIfNull(publishOptions);
+        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.SpanLink);
+    }
+
+    /// <summary>
+    /// Continue the existing OpenTelemetry trace on receive of this event.
+    /// Overrides <see cref="InstrumentationOptions.PublishedMessageTraceConnector"/> for this message.
     /// </summary>
     /// <param name="publishOptions">The option being extended.</param>
     public static void ContinueExistingTraceOnReceive(this PublishOptions publishOptions)
     {
-        publishOptions.Context.Set(OpenTelemetryPublishBehavior.ContinueTraceOnReceive, true);
+        ArgumentNullException.ThrowIfNull(publishOptions);
+        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.ChildSpan);
     }
+
+    internal const string TraceConnectorOverrideKey = "NServiceBus.OpenTelemetry.TraceConnectorOverride";
 }

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryFeature.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryFeature.cs
@@ -8,13 +8,15 @@ sealed class OpenTelemetryFeature : Feature
 {
     protected override void Setup(FeatureConfigurationContext context)
     {
+        var instrumentationOptions = context.Settings.GetOrDefault<InstrumentationOptions>() ?? new InstrumentationOptions();
+
         context.Pipeline.Register(
-            new OpenTelemetryPublishBehavior(),
+            new OpenTelemetryPublishBehavior(instrumentationOptions),
             "Manages the depth of the trace for publishes"
         );
 
         context.Pipeline.Register(
-            new OpenTelemetrySendBehavior(),
+            new OpenTelemetrySendBehavior(instrumentationOptions),
             "Manages the depth of the trace for sends"
         );
 

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryPublishBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryPublishBehavior.cs
@@ -6,22 +6,17 @@ using System;
 using System.Threading.Tasks;
 using Pipeline;
 
-class OpenTelemetryPublishBehavior : IBehavior<IOutgoingPublishContext, IOutgoingPublishContext>
+class OpenTelemetryPublishBehavior(InstrumentationOptions instrumentationOptions) : IBehavior<IOutgoingPublishContext, IOutgoingPublishContext>
 {
     public Task Invoke(IOutgoingPublishContext context, Func<IOutgoingPublishContext, Task> next)
     {
-        // publishes always start a new trace on receive
-        context.Headers[Headers.StartNewTrace] = bool.TrueString;
+        // the per-message override wins over the endpoint-level default
+        var connector = context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector requestedConnector)
+            ? requestedConnector
+            : instrumentationOptions.PublishedMessageTraceConnector;
 
-        // unless the user explicitly requests to continue the trace
-        bool continueTraceWasSet = context.Extensions.TryGet<bool>(ContinueTraceOnReceive, out var continueTraceRequested);
-        if (continueTraceWasSet && continueTraceRequested)
-        {
-            context.Headers[Headers.StartNewTrace] = bool.FalseString;
-        }
+        context.Headers[Headers.StartNewTrace] = connector == TraceConnector.SpanLink ? bool.TrueString : bool.FalseString;
 
         return next(context);
     }
-
-    public const string ContinueTraceOnReceive = "ContinueTraceRequested";
 }

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryPublishBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryPublishBehavior.cs
@@ -11,11 +11,11 @@ class OpenTelemetryPublishBehavior(InstrumentationOptions instrumentationOptions
     public Task Invoke(IOutgoingPublishContext context, Func<IOutgoingPublishContext, Task> next)
     {
         // the per-message override wins over the endpoint-level default
-        var connector = context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector requestedConnector)
+        var connector = context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode requestedConnector)
             ? requestedConnector
-            : instrumentationOptions.PublishedMessageTraceConnector;
+            : instrumentationOptions.PublishTraceMode;
 
-        context.Headers[Headers.StartNewTrace] = connector == TraceConnector.SpanLink ? bool.TrueString : bool.FalseString;
+        context.Headers[Headers.StartNewTrace] = connector == TraceMode.StartNew ? bool.TrueString : bool.FalseString;
 
         return next(context);
     }

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetrySendBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetrySendBehavior.cs
@@ -6,22 +6,17 @@ using System;
 using System.Threading.Tasks;
 using Pipeline;
 
-class OpenTelemetrySendBehavior : IBehavior<IOutgoingSendContext, IOutgoingSendContext>
+class OpenTelemetrySendBehavior(InstrumentationOptions instrumentationOptions) : IBehavior<IOutgoingSendContext, IOutgoingSendContext>
 {
     public Task Invoke(IOutgoingSendContext context, Func<IOutgoingSendContext, Task> next)
     {
-        // sends never start a new trace on receive
-        context.Headers[Headers.StartNewTrace] = bool.FalseString;
+        // the per-message override wins over the endpoint-level default
+        var connector = context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector requestedConnector)
+            ? requestedConnector
+            : instrumentationOptions.SentMessageTraceConnector;
 
-        // unless the user explicitly requests to start a new trace
-        bool breakTraceWasSet = context.Extensions.TryGet<bool>(StartNewTraceOnReceive, out var breakTraceWasRequested);
-        if (breakTraceWasSet && breakTraceWasRequested)
-        {
-            context.Headers[Headers.StartNewTrace] = bool.TrueString;
-        }
+        context.Headers[Headers.StartNewTrace] = connector == TraceConnector.SpanLink ? bool.TrueString : bool.FalseString;
 
         return next(context);
     }
-
-    public const string StartNewTraceOnReceive = "BreakTraceRequested";
 }

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetrySendBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetrySendBehavior.cs
@@ -11,11 +11,11 @@ class OpenTelemetrySendBehavior(InstrumentationOptions instrumentationOptions) :
     public Task Invoke(IOutgoingSendContext context, Func<IOutgoingSendContext, Task> next)
     {
         // the per-message override wins over the endpoint-level default
-        var connector = context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector requestedConnector)
+        var connector = context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode requestedConnector)
             ? requestedConnector
-            : instrumentationOptions.SentMessageTraceConnector;
+            : instrumentationOptions.SendTraceMode;
 
-        context.Headers[Headers.StartNewTrace] = connector == TraceConnector.SpanLink ? bool.TrueString : bool.FalseString;
+        context.Headers[Headers.StartNewTrace] = connector == TraceMode.StartNew ? bool.TrueString : bool.FalseString;
 
         return next(context);
     }

--- a/src/NServiceBus.Core/OpenTelemetry/TraceConnector.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/TraceConnector.cs
@@ -1,0 +1,19 @@
+#nullable enable
+
+namespace NServiceBus;
+
+/// <summary>
+/// Controls how the receive-side processing span relates to the outgoing send or publish span.
+/// </summary>
+public enum TraceConnector
+{
+    /// <summary>
+    /// The receiving endpoint continues the trace: the processing span becomes a child of the outgoing span.
+    /// </summary>
+    ChildSpan,
+
+    /// <summary>
+    /// The receiving endpoint starts a new trace: the processing span becomes the root of a new trace with a link back to the outgoing span.
+    /// </summary>
+    SpanLink
+}

--- a/src/NServiceBus.Core/OpenTelemetry/TraceMode.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/TraceMode.cs
@@ -5,15 +5,15 @@ namespace NServiceBus;
 /// <summary>
 /// Controls how the receive-side processing span relates to the outgoing send or publish span.
 /// </summary>
-public enum TraceConnector
+public enum TraceMode
 {
     /// <summary>
     /// The receiving endpoint continues the trace: the processing span becomes a child of the outgoing span.
     /// </summary>
-    ChildSpan,
+    ContinueExisting,
 
     /// <summary>
     /// The receiving endpoint starts a new trace: the processing span becomes the root of a new trace with a link back to the outgoing span.
     /// </summary>
-    SpanLink
+    StartNew
 }


### PR DESCRIPTION
Adds endpoint-level configuration for how receivers connect their process span to the outgoing operation (#7229):

- `Tracing().SentMessageTraceConnector` (default `ChildSpan`)
- `Tracing().PublishedMessageTraceConnector` (default `SpanLink`)
- Per-message overrides on `SendOptions`/`PublishOptions` win over the endpoint default

Defaults preserve existing behavior.