### PR TITLE
Trace mode settings for delayed sends, delayed retries, and error messages

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_message_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_message_moved_to_error_queue.cs
@@ -26,6 +26,36 @@ public class When_incoming_message_moved_to_error_queue : OpenTelemetryAcceptanc
         Assert.That(context.ErrorMessageHeaders[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
     }
 
+    [Test]
+    public async Task Should_not_add_start_new_trace_header_when_error_connector_is_child_span()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<FailingEndpointWithChildSpanConnector>(e => e
+                .When(s => s.SendLocal(new FailingMessage()))
+                .DoNotFailOnErrorMessages())
+            .WithEndpoint<ErrorSpy>()
+            .Run();
+
+        Assert.That(context.ErrorMessageHeaders[Headers.StartNewTrace], Is.EqualTo(bool.FalseString));
+    }
+
+    public class FailingEndpointWithChildSpanConnector : EndpointConfigurationBuilder
+    {
+        static readonly string ErrorQueueAddress = Conventions.EndpointNamingConvention(typeof(ErrorSpy));
+
+        public FailingEndpointWithChildSpanConnector() => EndpointSetup<DefaultServer>(c =>
+        {
+            c.SendFailedMessagesTo(ErrorQueueAddress);
+            c.Tracing().ErrorMessageTraceMode = TraceMode.ContinueExisting;
+        });
+
+        [Handler]
+        public class FailingMessageHandler() : IHandleMessages<FailingMessage>
+        {
+            public Task Handle(FailingMessage message, IMessageHandlerContext context) => throw new SimulatedException(ErrorMessage);
+        }
+    }
+
     public class Context : ScenarioContext
     {
         public Dictionary<string, string> ErrorMessageHeaders { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_message_was_delayed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_message_was_delayed.cs
@@ -152,6 +152,161 @@ public class When_incoming_message_was_delayed : OpenTelemetryAcceptanceTest // 
         }
     }
 
+    [Test]
+    public async Task By_sendoptions_Should_continue_trace_when_endpoint_connector_is_child_span()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<ChildSpanConnectorEndpoint>(b => b
+                .When(s =>
+                {
+                    var sendOptions = new SendOptions();
+                    sendOptions.DelayDeliveryWith(TimeSpan.FromMilliseconds(5));
+                    sendOptions.RouteToThisEndpoint();
+                    return s.Send(new DelayedMessage(), sendOptions);
+                }))
+            .Run();
+
+        var incomingMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
+        var outgoingMessageActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(incomingMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
+            Assert.That(outgoingMessageActivities, Has.Count.EqualTo(1), "1 message is sent as part of this test");
+        }
+
+        var sendRequest = outgoingMessageActivities[0];
+        var receiveRequest = incomingMessageActivities[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receiveRequest.RootId, Is.EqualTo(sendRequest.RootId), "delayed send and receive operations are part of the same root activity");
+            Assert.That(receiveRequest.ParentId, Is.Not.Null, "incoming delayed message does have a parent");
+        }
+
+        Assert.That(receiveRequest.Links, Is.Empty, "receive does not have links");
+    }
+
+    [Test]
+    public async Task By_sendoptions_Should_start_new_trace_when_option_overrides_child_span_connector()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<ChildSpanConnectorEndpoint>(b => b
+                .When(s =>
+                {
+                    var sendOptions = new SendOptions();
+                    sendOptions.DelayDeliveryWith(TimeSpan.FromMilliseconds(5));
+                    sendOptions.RouteToThisEndpoint();
+                    sendOptions.StartNewTraceOnReceive();
+                    return s.Send(new DelayedMessage(), sendOptions);
+                }))
+            .Run();
+
+        var incomingMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
+        var outgoingMessageActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(incomingMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
+            Assert.That(outgoingMessageActivities, Has.Count.EqualTo(1), "1 message is sent as part of this test");
+        }
+
+        var sendRequest = outgoingMessageActivities[0];
+        var receiveRequest = incomingMessageActivities[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receiveRequest.RootId, Is.Not.EqualTo(sendRequest.RootId), "per-message override wins: send and receive are different root activities");
+            Assert.That(receiveRequest.ParentId, Is.Null, "incoming message does not have a parent, it's a root");
+        }
+
+        ActivityLink link = receiveRequest.Links.FirstOrDefault();
+        Assert.That(link, Is.Not.Default, "receive has a link");
+        Assert.That(link.Context.TraceId, Is.EqualTo(sendRequest.TraceId), "receive is linked to the send operation");
+    }
+
+    [Test]
+    public void By_retry_Should_continue_trace_when_endpoint_connector_is_child_span()
+    {
+        _ = Assert.CatchAsync(async () =>
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<ChildSpanRetryConnectorEndpoint>(b => b
+                    .When(session => session.SendLocal(new MessageToBeRetried())))
+                .Run();
+        });
+
+        var incomingMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
+        var outgoingMessageActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(incomingMessageActivities, Has.Count.EqualTo(2), "2 messages are received as part of this test (2 attempts)");
+            Assert.That(outgoingMessageActivities, Has.Count.EqualTo(1), "1 message sent as part of this test");
+        }
+
+        var sendRequest = outgoingMessageActivities[0];
+        var firstAttemptReceiveRequest = incomingMessageActivities[0];
+        var secondAttemptReceiveRequest = incomingMessageActivities[1];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(firstAttemptReceiveRequest.RootId, Is.EqualTo(sendRequest.RootId), "first send operation is the root activity");
+            Assert.That(secondAttemptReceiveRequest.RootId, Is.EqualTo(sendRequest.RootId), "delayed retry stays in the same trace when connector is child span");
+            Assert.That(secondAttemptReceiveRequest.ParentId, Is.Not.Null, "second incoming message does have a parent");
+        }
+
+        Assert.That(secondAttemptReceiveRequest.Links, Is.Empty, "second receive does not have links");
+    }
+
+    public class ChildSpanConnectorEndpoint : EndpointConfigurationBuilder
+    {
+        public ChildSpanConnectorEndpoint()
+        {
+            var template = new DefaultServer
+            {
+                TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true)
+            };
+            EndpointSetup(
+                template,
+                (c, _) => c.Tracing().DelayedSendTraceMode = TraceMode.ContinueExisting,
+                metadata => { });
+        }
+
+        [Handler]
+        public class DelayedMessageHandler(Context testContext) : IHandleMessages<DelayedMessage>
+        {
+            public Task Handle(DelayedMessage message, IMessageHandlerContext context)
+            {
+                testContext.DelayedMessageReceived = true;
+                testContext.MaybeCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class ChildSpanRetryConnectorEndpoint : EndpointConfigurationBuilder
+    {
+        public ChildSpanRetryConnectorEndpoint()
+        {
+            var template = new DefaultServer
+            {
+                TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true)
+            };
+            EndpointSetup(
+                template,
+                (c, _) =>
+                {
+                    c.Tracing().DelayedRetryTraceMode = TraceMode.ContinueExisting;
+                    var recoverability = c.Recoverability();
+                    recoverability.Delayed(settings => settings.NumberOfRetries(1).TimeIncrease(TimeSpan.FromMilliseconds(1)));
+                }, metadata => { });
+        }
+
+        [Handler]
+        public class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+        {
+            public Task Handle(MessageToBeRetried message, IMessageHandlerContext context) => throw new SimulatedException();
+        }
+    }
+
     public class Context : ScenarioContext
     {
         public bool ReplyMessageReceived { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_message_was_delayed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_message_was_delayed.cs
@@ -249,6 +249,7 @@ public class When_incoming_message_was_delayed : OpenTelemetryAcceptanceTest // 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(firstAttemptReceiveRequest.RootId, Is.EqualTo(sendRequest.RootId), "first send operation is the root activity");
+            Assert.That(firstAttemptReceiveRequest.ParentId, Is.EqualTo(sendRequest.Id), "first incoming message is correlated to the first send operation");
             Assert.That(secondAttemptReceiveRequest.RootId, Is.EqualTo(sendRequest.RootId), "delayed retry stays in the same trace when connector is child span");
             Assert.That(secondAttemptReceiveRequest.ParentId, Is.Not.Null, "second incoming message does have a parent");
         }

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_publishing_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_publishing_messages.cs
@@ -328,7 +328,7 @@ public class When_publishing_messages : OpenTelemetryAcceptanceTest
         public PublisherWithChildSpanConnector() =>
             EndpointSetup<DefaultServer>(b =>
             {
-                b.Tracing().PublishedMessageTraceConnector = TraceConnector.ChildSpan;
+                b.Tracing().PublishTraceMode = TraceMode.ContinueExisting;
                 b.OnEndpointSubscribed<Context>((s, context) =>
                 {
                     if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(SubscriberForPublisherWithChildSpanConnector))))

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_publishing_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_publishing_messages.cs
@@ -242,5 +242,125 @@ public class When_publishing_messages : OpenTelemetryAcceptanceTest
         }
     }
 
+    [Test]
+    public async Task Should_create_child_on_receive_when_endpoint_defaults_to_child_span()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<PublisherWithChildSpanConnector>(b => b
+                .When(ctx => ctx.SomeEventSubscribed, s => s.Publish(new ThisIsAnEvent())))
+            .WithEndpoint<SubscriberForPublisherWithChildSpanConnector>(b => b.When((session, ctx) =>
+            {
+                if (ctx.HasNativePubSubSupport)
+                {
+                    ctx.SomeEventSubscribed = true;
+                }
+
+                return Task.CompletedTask;
+            }))
+            .Run();
+
+        var publishMessageActivities = NServiceBusActivityListener.CompletedActivities.GetPublishEventActivities();
+        var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(publishMessageActivities, Has.Count.EqualTo(1), "1 message is published as part of this test");
+            Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
+        }
+
+        var publishRequest = publishMessageActivities[0];
+        var receiveRequest = receiveMessageActivities[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receiveRequest.RootId, Is.EqualTo(publishRequest.RootId), "publish and receive operations are part the same root activity");
+            Assert.That(receiveRequest.ParentId, Is.Not.Null, "incoming message does have a parent");
+        }
+
+        Assert.That(receiveRequest.Links, Is.Empty, "receive does not have links");
+    }
+
+    [Test]
+    public async Task Should_create_new_linked_trace_on_receive_when_option_overrides_endpoint_connector()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<PublisherWithChildSpanConnector>(b => b
+                .When(ctx => ctx.SomeEventSubscribed, s =>
+                {
+                    var publishOptions = new PublishOptions();
+                    publishOptions.StartNewTraceOnReceive();
+                    return s.Publish(new ThisIsAnEvent(), publishOptions);
+                }))
+            .WithEndpoint<SubscriberForPublisherWithChildSpanConnector>(b => b.When((session, ctx) =>
+            {
+                if (ctx.HasNativePubSubSupport)
+                {
+                    ctx.SomeEventSubscribed = true;
+                }
+
+                return Task.CompletedTask;
+            }))
+            .Run();
+
+        var publishMessageActivities = NServiceBusActivityListener.CompletedActivities.GetPublishEventActivities();
+        var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(publishMessageActivities, Has.Count.EqualTo(1), "1 message is published as part of this test");
+            Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
+        }
+
+        var publishRequest = publishMessageActivities[0];
+        var receiveRequest = receiveMessageActivities[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receiveRequest.RootId, Is.Not.EqualTo(publishRequest.RootId), "publish and receive operations are part of different root activities");
+            Assert.That(receiveRequest.ParentId, Is.Null, "incoming message does not have a parent, it's a root");
+        }
+
+        ActivityLink link = receiveRequest.Links.FirstOrDefault();
+        Assert.That(link, Is.Not.EqualTo(default(ActivityLink)), "Receive has a link");
+        Assert.That(link.Context.TraceId, Is.EqualTo(publishRequest.TraceId), "receive is linked to publish operation");
+    }
+
+    public class PublisherWithChildSpanConnector : EndpointConfigurationBuilder
+    {
+        public PublisherWithChildSpanConnector() =>
+            EndpointSetup<DefaultServer>(b =>
+            {
+                b.Tracing().PublishedMessageTraceConnector = TraceConnector.ChildSpan;
+                b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(SubscriberForPublisherWithChildSpanConnector))))
+                    {
+                        if (s.MessageType == typeof(ThisIsAnEvent).AssemblyQualifiedName)
+                        {
+                            context.SomeEventSubscribed = true;
+                        }
+                    }
+                });
+            });
+    }
+
+    public class SubscriberForPublisherWithChildSpanConnector : EndpointConfigurationBuilder
+    {
+        public SubscriberForPublisherWithChildSpanConnector() =>
+            EndpointSetup<DefaultServer>(c => { },
+                metadata =>
+                {
+                    metadata.RegisterPublisherFor<ThisIsAnEvent, PublisherWithChildSpanConnector>();
+                });
+
+        [Handler]
+        public class ThisHandlesSomethingHandler(Context testContext) : IHandleMessages<ThisIsAnEvent>
+        {
+            public Task Handle(ThisIsAnEvent @event, IMessageHandlerContext context)
+            {
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
     public class ThisIsAnEvent : IEvent;
 }

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_messages.cs
@@ -163,5 +163,85 @@ public class When_sending_messages : OpenTelemetryAcceptanceTest
         }
     }
 
+    [Test]
+    public async Task Should_create_new_linked_trace_on_receive_when_endpoint_defaults_to_span_link()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<TestEndpointWithSpanLinkConnector>(b => b
+                .When(s => s.SendLocal(new OutgoingMessage())))
+            .Run();
+
+        var sendMessageActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
+        var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(sendMessageActivities, Has.Count.EqualTo(1), "1 message is sent as part of this test");
+            Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
+        }
+
+        var sendRequest = sendMessageActivities[0];
+        var receiveRequest = receiveMessageActivities[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receiveRequest.RootId, Is.Not.EqualTo(sendRequest.RootId), "send and receive operations are part of different root activities");
+            Assert.That(receiveRequest.ParentId, Is.Null, "incoming message does not have a parent, it's a root");
+        }
+
+        ActivityLink link = receiveRequest.Links.FirstOrDefault();
+        Assert.That(link, Is.Not.EqualTo(default(ActivityLink)), "Receive has a link");
+        Assert.That(link.Context.TraceId, Is.EqualTo(sendRequest.TraceId), "receive is linked to send operation");
+    }
+
+    [Test]
+    public async Task Should_create_child_on_receive_when_option_overrides_endpoint_connector()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<TestEndpointWithSpanLinkConnector>(b => b
+                .When(s =>
+                {
+                    var sendOptions = new SendOptions();
+                    sendOptions.RouteToThisEndpoint();
+                    sendOptions.ContinueExistingTraceOnReceive();
+                    return s.Send(new OutgoingMessage(), sendOptions);
+                }))
+            .Run();
+
+        var sendMessageActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
+        var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(sendMessageActivities, Has.Count.EqualTo(1), "1 message is sent as part of this test");
+            Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
+        }
+
+        var sendRequest = sendMessageActivities[0];
+        var receiveRequest = receiveMessageActivities[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receiveRequest.RootId, Is.EqualTo(sendRequest.RootId), "send and receive operations are part of the same root activity");
+            Assert.That(receiveRequest.ParentId, Is.Not.Null, "incoming message does have a parent");
+        }
+
+        Assert.That(receiveRequest.Links, Is.Empty, "receive does not have links");
+    }
+
+    public class TestEndpointWithSpanLinkConnector : EndpointConfigurationBuilder
+    {
+        public TestEndpointWithSpanLinkConnector() =>
+            EndpointSetup<DefaultServer>(b => b.Tracing().SentMessageTraceConnector = TraceConnector.SpanLink);
+
+        [Handler]
+        public class MessageHandler(Context testContext) : IHandleMessages<OutgoingMessage>
+        {
+            public Task Handle(OutgoingMessage message, IMessageHandlerContext context)
+            {
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
     public class OutgoingMessage : IMessage;
 }

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_messages.cs
@@ -230,7 +230,7 @@ public class When_sending_messages : OpenTelemetryAcceptanceTest
     public class TestEndpointWithSpanLinkConnector : EndpointConfigurationBuilder
     {
         public TestEndpointWithSpanLinkConnector() =>
-            EndpointSetup<DefaultServer>(b => b.Tracing().SentMessageTraceConnector = TraceConnector.SpanLink);
+            EndpointSetup<DefaultServer>(b => b.Tracing().SendTraceMode = TraceMode.StartNew);
 
         [Handler]
         public class MessageHandler(Context testContext) : IHandleMessages<OutgoingMessage>

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -635,8 +635,11 @@ namespace NServiceBus
     public class InstrumentationOptions
     {
         public InstrumentationOptions() { }
-        public NServiceBus.TraceConnector PublishedMessageTraceConnector { get; set; }
-        public NServiceBus.TraceConnector SentMessageTraceConnector { get; set; }
+        public NServiceBus.TraceMode DelayedRetryTraceMode { get; set; }
+        public NServiceBus.TraceMode DelayedSendTraceMode { get; set; }
+        public NServiceBus.TraceMode ErrorMessageTraceMode { get; set; }
+        public NServiceBus.TraceMode PublishTraceMode { get; set; }
+        public NServiceBus.TraceMode SendTraceMode { get; set; }
         public bool UseMessageDestinationInSpanNames { get; set; }
     }
     public sealed class KeyedServiceKey
@@ -1177,10 +1180,10 @@ namespace NServiceBus
         public ToSagaExpression(NServiceBus.IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration, System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
         public void ToSaga(System.Linq.Expressions.Expression<System.Func<TSagaData, object?>> sagaEntityProperty) { }
     }
-    public enum TraceConnector
+    public enum TraceMode
     {
-        ChildSpan = 0,
-        SpanLink = 1,
+        ContinueExisting = 0,
+        StartNew = 1,
     }
     public static class TransportConfig
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -635,6 +635,8 @@ namespace NServiceBus
     public class InstrumentationOptions
     {
         public InstrumentationOptions() { }
+        public NServiceBus.TraceConnector PublishedMessageTraceConnector { get; set; }
+        public NServiceBus.TraceConnector SentMessageTraceConnector { get; set; }
         public bool UseMessageDestinationInSpanNames { get; set; }
     }
     public sealed class KeyedServiceKey
@@ -776,6 +778,8 @@ namespace NServiceBus
     public static class OpenTelemetryExtensions
     {
         public static void ContinueExistingTraceOnReceive(this NServiceBus.PublishOptions publishOptions) { }
+        public static void ContinueExistingTraceOnReceive(this NServiceBus.SendOptions sendOptions) { }
+        public static void StartNewTraceOnReceive(this NServiceBus.PublishOptions publishOptions) { }
         public static void StartNewTraceOnReceive(this NServiceBus.SendOptions sendOptions) { }
         public static NServiceBus.InstrumentationOptions Tracing(this NServiceBus.EndpointConfiguration config) { }
     }
@@ -1172,6 +1176,11 @@ namespace NServiceBus
     {
         public ToSagaExpression(NServiceBus.IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration, System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
         public void ToSaga(System.Linq.Expressions.Expression<System.Func<TSagaData, object?>> sagaEntityProperty) { }
+    }
+    public enum TraceConnector
+    {
+        ChildSpan = 0,
+        SpanLink = 1,
     }
     public static class TransportConfig
     {

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/InstrumentationOptionsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/InstrumentationOptionsTests.cs
@@ -16,4 +16,17 @@ public class InstrumentationOptionsTests
             Assert.That(options.PublishTraceMode, Is.EqualTo(TraceMode.StartNew), "publishes start a new linked trace by default");
         }
     }
+
+    [Test]
+    public void Should_default_delayed_and_error_trace_connectors_to_span_link()
+    {
+        var options = new InstrumentationOptions();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(options.DelayedSendTraceMode, Is.EqualTo(TraceMode.StartNew), "delayed sends start a new linked trace by default");
+            Assert.That(options.DelayedRetryTraceMode, Is.EqualTo(TraceMode.StartNew), "delayed retries start a new linked trace by default");
+            Assert.That(options.ErrorMessageTraceMode, Is.EqualTo(TraceMode.StartNew), "messages moved to the error queue start a new linked trace by default");
+        }
+    }
 }

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/InstrumentationOptionsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/InstrumentationOptionsTests.cs
@@ -1,0 +1,19 @@
+namespace NServiceBus.Core.Tests.OpenTelemetry;
+
+using NUnit.Framework;
+
+[TestFixture]
+public class InstrumentationOptionsTests
+{
+    [Test]
+    public void Should_default_trace_connectors_to_current_behavior()
+    {
+        var options = new InstrumentationOptions();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(options.SentMessageTraceConnector, Is.EqualTo(TraceConnector.ChildSpan), "sends continue the trace by default");
+            Assert.That(options.PublishedMessageTraceConnector, Is.EqualTo(TraceConnector.SpanLink), "publishes start a new linked trace by default");
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/InstrumentationOptionsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/InstrumentationOptionsTests.cs
@@ -12,8 +12,8 @@ public class InstrumentationOptionsTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(options.SentMessageTraceConnector, Is.EqualTo(TraceConnector.ChildSpan), "sends continue the trace by default");
-            Assert.That(options.PublishedMessageTraceConnector, Is.EqualTo(TraceConnector.SpanLink), "publishes start a new linked trace by default");
+            Assert.That(options.SendTraceMode, Is.EqualTo(TraceMode.ContinueExisting), "sends continue the trace by default");
+            Assert.That(options.PublishTraceMode, Is.EqualTo(TraceMode.StartNew), "publishes start a new linked trace by default");
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryDelayedMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryDelayedMessageBehaviorTests.cs
@@ -1,0 +1,98 @@
+namespace NServiceBus.Core.Tests.OpenTelemetry;
+
+using System;
+using System.Threading.Tasks;
+using DelayedDelivery;
+using NServiceBus.Transport;
+using NUnit.Framework;
+using Testing;
+
+[TestFixture]
+public class OpenTelemetryDelayedMessageBehaviorTests
+{
+    [Test]
+    public async Task Should_not_set_context_entry_when_not_delayed()
+    {
+        var context = new TestableRoutingContext();
+
+        await InvokeBehavior(context, new InstrumentationOptions());
+
+        Assert.That(context.Extensions.TryGet<string>(Headers.StartNewTrace, out _), Is.False);
+    }
+
+    [Test]
+    public async Task Should_not_set_context_entry_when_dispatch_properties_carry_no_delay()
+    {
+        var context = new TestableRoutingContext();
+        context.Extensions.Set(new DispatchProperties());
+
+        await InvokeBehavior(context, new InstrumentationOptions());
+
+        Assert.That(context.Extensions.TryGet<string>(Headers.StartNewTrace, out _), Is.False);
+    }
+
+    [Test]
+    public async Task Should_start_new_trace_by_default_when_delayed_with_delay()
+    {
+        var context = new TestableRoutingContext();
+        context.Extensions.Set(new DispatchProperties { DelayDeliveryWith = new DelayDeliveryWith(TimeSpan.FromSeconds(5)) });
+
+        await InvokeBehavior(context, new InstrumentationOptions());
+
+        Assert.That(context.Extensions.TryGet<string>(Headers.StartNewTrace, out var startNewTrace), Is.True);
+        Assert.That(startNewTrace, Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public async Task Should_start_new_trace_by_default_when_delayed_with_do_not_deliver_before()
+    {
+        var context = new TestableRoutingContext();
+        context.Extensions.Set(new DispatchProperties { DoNotDeliverBefore = new DoNotDeliverBefore(DateTimeOffset.UtcNow.AddSeconds(5)) });
+
+        await InvokeBehavior(context, new InstrumentationOptions());
+
+        Assert.That(context.Extensions.TryGet<string>(Headers.StartNewTrace, out var startNewTrace), Is.True);
+        Assert.That(startNewTrace, Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public async Task Should_continue_trace_when_delayed_connector_is_child_span()
+    {
+        var context = new TestableRoutingContext();
+        context.Extensions.Set(new DispatchProperties { DelayDeliveryWith = new DelayDeliveryWith(TimeSpan.FromSeconds(5)) });
+
+        await InvokeBehavior(context, new InstrumentationOptions { DelayedSendTraceMode = TraceMode.ContinueExisting });
+
+        Assert.That(context.Extensions.TryGet<string>(Headers.StartNewTrace, out var startNewTrace), Is.True);
+        Assert.That(startNewTrace, Is.EqualTo(bool.FalseString));
+    }
+
+    [Test]
+    public async Task Should_not_set_context_entry_when_per_message_override_present()
+    {
+        var context = new TestableRoutingContext();
+        context.Extensions.Set(new DispatchProperties { DelayDeliveryWith = new DelayDeliveryWith(TimeSpan.FromSeconds(5)) });
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceMode.ContinueExisting);
+
+        await InvokeBehavior(context, new InstrumentationOptions());
+
+        Assert.That(context.Extensions.TryGet<string>(Headers.StartNewTrace, out _), Is.False,
+            "the send behavior already resolved the per-message override into the header");
+    }
+
+    [Test]
+    public async Task Should_not_set_context_entry_for_delayed_retries()
+    {
+        var context = new TestableRoutingContext();
+        context.Message.Headers[Headers.DelayedRetries] = "1";
+        context.Extensions.Set(new DispatchProperties { DelayDeliveryWith = new DelayDeliveryWith(TimeSpan.FromSeconds(5)) });
+
+        await InvokeBehavior(context, new InstrumentationOptions { DelayedSendTraceMode = TraceMode.ContinueExisting });
+
+        Assert.That(context.Extensions.TryGet<string>(Headers.StartNewTrace, out _), Is.False,
+            "recoverability already decided the trace boundary for delayed retries");
+    }
+
+    static Task InvokeBehavior(TestableRoutingContext context, InstrumentationOptions options) =>
+        new OpenTelemetryDelayedMessageBehavior(options).Invoke(context, _ => Task.CompletedTask);
+}

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryExtensionsTests.cs
@@ -12,8 +12,8 @@ public class OpenTelemetryExtensionsTests
 
         options.StartNewTraceOnReceive();
 
-        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
-        Assert.That(connector, Is.EqualTo(TraceConnector.SpanLink));
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceMode.StartNew));
     }
 
     [Test]
@@ -23,8 +23,8 @@ public class OpenTelemetryExtensionsTests
 
         options.ContinueExistingTraceOnReceive();
 
-        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
-        Assert.That(connector, Is.EqualTo(TraceConnector.ChildSpan));
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceMode.ContinueExisting));
     }
 
     [Test]
@@ -34,8 +34,8 @@ public class OpenTelemetryExtensionsTests
 
         options.StartNewTraceOnReceive();
 
-        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
-        Assert.That(connector, Is.EqualTo(TraceConnector.SpanLink));
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceMode.StartNew));
     }
 
     [Test]
@@ -45,8 +45,8 @@ public class OpenTelemetryExtensionsTests
 
         options.ContinueExistingTraceOnReceive();
 
-        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
-        Assert.That(connector, Is.EqualTo(TraceConnector.ChildSpan));
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceMode.ContinueExisting));
     }
 
     [Test]
@@ -57,7 +57,7 @@ public class OpenTelemetryExtensionsTests
         options.ContinueExistingTraceOnReceive();
         options.StartNewTraceOnReceive();
 
-        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
-        Assert.That(connector, Is.EqualTo(TraceConnector.SpanLink));
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceMode.StartNew));
     }
 }

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryExtensionsTests.cs
@@ -1,0 +1,63 @@
+namespace NServiceBus.Core.Tests.OpenTelemetry;
+
+using NUnit.Framework;
+
+[TestFixture]
+public class OpenTelemetryExtensionsTests
+{
+    [Test]
+    public void StartNewTraceOnReceive_should_set_span_link_override_on_send_options()
+    {
+        var options = new SendOptions();
+
+        options.StartNewTraceOnReceive();
+
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceConnector.SpanLink));
+    }
+
+    [Test]
+    public void ContinueExistingTraceOnReceive_should_set_child_span_override_on_send_options()
+    {
+        var options = new SendOptions();
+
+        options.ContinueExistingTraceOnReceive();
+
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceConnector.ChildSpan));
+    }
+
+    [Test]
+    public void StartNewTraceOnReceive_should_set_span_link_override_on_publish_options()
+    {
+        var options = new PublishOptions();
+
+        options.StartNewTraceOnReceive();
+
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceConnector.SpanLink));
+    }
+
+    [Test]
+    public void ContinueExistingTraceOnReceive_should_set_child_span_override_on_publish_options()
+    {
+        var options = new PublishOptions();
+
+        options.ContinueExistingTraceOnReceive();
+
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceConnector.ChildSpan));
+    }
+
+    [Test]
+    public void Last_override_call_wins()
+    {
+        var options = new PublishOptions();
+
+        options.ContinueExistingTraceOnReceive();
+        options.StartNewTraceOnReceive();
+
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceConnector.SpanLink));
+    }
+}

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryPublishBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryPublishBehaviorTests.cs
@@ -21,7 +21,7 @@ public class OpenTelemetryPublishBehaviorTests
     [Test]
     public async Task Should_continue_trace_on_receive_when_endpoint_connector_is_child_span()
     {
-        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishedMessageTraceConnector = TraceConnector.ChildSpan });
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishTraceMode = TraceMode.ContinueExisting });
         var context = new TestableOutgoingPublishContext();
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
@@ -32,9 +32,9 @@ public class OpenTelemetryPublishBehaviorTests
     [Test]
     public async Task Should_prefer_child_span_option_over_endpoint_connector()
     {
-        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishedMessageTraceConnector = TraceConnector.SpanLink });
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishTraceMode = TraceMode.StartNew });
         var context = new TestableOutgoingPublishContext();
-        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceMode.ContinueExisting);
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
 
@@ -44,9 +44,9 @@ public class OpenTelemetryPublishBehaviorTests
     [Test]
     public async Task Should_prefer_span_link_option_over_endpoint_connector()
     {
-        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishedMessageTraceConnector = TraceConnector.ChildSpan });
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishTraceMode = TraceMode.ContinueExisting });
         var context = new TestableOutgoingPublishContext();
-        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.SpanLink);
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceMode.StartNew);
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
 

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryPublishBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryPublishBehaviorTests.cs
@@ -1,0 +1,55 @@
+namespace NServiceBus.Core.Tests.OpenTelemetry;
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Testing;
+
+[TestFixture]
+public class OpenTelemetryPublishBehaviorTests
+{
+    [Test]
+    public async Task Should_start_new_trace_on_receive_by_default()
+    {
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions());
+        var context = new TestableOutgoingPublishContext();
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public async Task Should_continue_trace_on_receive_when_endpoint_connector_is_child_span()
+    {
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishedMessageTraceConnector = TraceConnector.ChildSpan });
+        var context = new TestableOutgoingPublishContext();
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.FalseString));
+    }
+
+    [Test]
+    public async Task Should_prefer_child_span_option_over_endpoint_connector()
+    {
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishedMessageTraceConnector = TraceConnector.SpanLink });
+        var context = new TestableOutgoingPublishContext();
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.FalseString));
+    }
+
+    [Test]
+    public async Task Should_prefer_span_link_option_over_endpoint_connector()
+    {
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishedMessageTraceConnector = TraceConnector.ChildSpan });
+        var context = new TestableOutgoingPublishContext();
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.SpanLink);
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
+    }
+}

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetrySendBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetrySendBehaviorTests.cs
@@ -1,0 +1,55 @@
+namespace NServiceBus.Core.Tests.OpenTelemetry;
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Testing;
+
+[TestFixture]
+public class OpenTelemetrySendBehaviorTests
+{
+    [Test]
+    public async Task Should_continue_trace_on_receive_by_default()
+    {
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions());
+        var context = new TestableOutgoingSendContext();
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.FalseString));
+    }
+
+    [Test]
+    public async Task Should_start_new_trace_on_receive_when_endpoint_connector_is_span_link()
+    {
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SentMessageTraceConnector = TraceConnector.SpanLink });
+        var context = new TestableOutgoingSendContext();
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public async Task Should_prefer_span_link_option_over_endpoint_connector()
+    {
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SentMessageTraceConnector = TraceConnector.ChildSpan });
+        var context = new TestableOutgoingSendContext();
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.SpanLink);
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public async Task Should_prefer_child_span_option_over_endpoint_connector()
+    {
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SentMessageTraceConnector = TraceConnector.SpanLink });
+        var context = new TestableOutgoingSendContext();
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.FalseString));
+    }
+}

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetrySendBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetrySendBehaviorTests.cs
@@ -21,7 +21,7 @@ public class OpenTelemetrySendBehaviorTests
     [Test]
     public async Task Should_start_new_trace_on_receive_when_endpoint_connector_is_span_link()
     {
-        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SentMessageTraceConnector = TraceConnector.SpanLink });
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SendTraceMode = TraceMode.StartNew });
         var context = new TestableOutgoingSendContext();
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
@@ -32,9 +32,9 @@ public class OpenTelemetrySendBehaviorTests
     [Test]
     public async Task Should_prefer_span_link_option_over_endpoint_connector()
     {
-        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SentMessageTraceConnector = TraceConnector.ChildSpan });
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SendTraceMode = TraceMode.ContinueExisting });
         var context = new TestableOutgoingSendContext();
-        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.SpanLink);
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceMode.StartNew);
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
 
@@ -44,9 +44,9 @@ public class OpenTelemetrySendBehaviorTests
     [Test]
     public async Task Should_prefer_child_span_option_over_endpoint_connector()
     {
-        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SentMessageTraceConnector = TraceConnector.SpanLink });
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SendTraceMode = TraceMode.StartNew });
         var context = new TestableOutgoingSendContext();
-        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceMode.ContinueExisting);
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
 

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/PopulateRecoverabilityTraceMetadataBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/PopulateRecoverabilityTraceMetadataBehaviorTests.cs
@@ -12,7 +12,7 @@ public class PopulateRecoverabilityTraceMetadataBehaviorTests
     [Test]
     public async Task Should_not_write_metadata_when_trace_not_present()
     {
-        var behavior = new PopulateRecoverabilityTraceMetadataBehavior();
+        var behavior = new PopulateRecoverabilityTraceMetadataBehavior(new InstrumentationOptions());
 
         var context = new TestableRecoverabilityContext();
         await behavior.Invoke(context, _ => Task.CompletedTask);
@@ -28,7 +28,7 @@ public class PopulateRecoverabilityTraceMetadataBehaviorTests
     [TestCaseSource(nameof(Actions))]
     public async Task Should_write_metadata_when_trace_present(RecoverabilityAction recoverabilityAction)
     {
-        var behavior = new PopulateRecoverabilityTraceMetadataBehavior();
+        var behavior = new PopulateRecoverabilityTraceMetadataBehavior(new InstrumentationOptions());
 
         var context = new TestableRecoverabilityContext
         {
@@ -42,7 +42,76 @@ public class PopulateRecoverabilityTraceMetadataBehaviorTests
         {
             Assert.That(context.Headers, Does.Not.ContainKey(Headers.StartNewTrace));
             Assert.That(context.Metadata, Does.ContainKey(Headers.StartNewTrace));
+            Assert.That(context.Metadata[Headers.StartNewTrace], Is.EqualTo(bool.TrueString), "defaults preserve current behavior");
         }
+    }
+
+    [Test]
+    public async Task Should_continue_trace_for_delayed_retry_when_connector_is_child_span()
+    {
+        var behavior = new PopulateRecoverabilityTraceMetadataBehavior(new InstrumentationOptions { DelayedRetryTraceMode = TraceMode.ContinueExisting });
+
+        var context = new TestableRecoverabilityContext
+        {
+            Headers = { { Headers.DiagnosticsTraceParent, "traceparent" } },
+            RecoverabilityAction = new DelayedRetry(TimeSpan.FromSeconds(10))
+        };
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Metadata[Headers.StartNewTrace], Is.EqualTo(bool.FalseString));
+    }
+
+    [Test]
+    public async Task Should_continue_trace_for_move_to_error_when_connector_is_child_span()
+    {
+        var behavior = new PopulateRecoverabilityTraceMetadataBehavior(new InstrumentationOptions { ErrorMessageTraceMode = TraceMode.ContinueExisting });
+
+        var context = new TestableRecoverabilityContext
+        {
+            Headers = { { Headers.DiagnosticsTraceParent, "traceparent" } },
+            RecoverabilityAction = new MoveToError("errorqueue")
+        };
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Metadata[Headers.StartNewTrace], Is.EqualTo(bool.FalseString));
+    }
+
+    [Test]
+    public async Task Should_not_apply_error_connector_to_delayed_retries()
+    {
+        var behavior = new PopulateRecoverabilityTraceMetadataBehavior(new InstrumentationOptions { ErrorMessageTraceMode = TraceMode.ContinueExisting });
+
+        var context = new TestableRecoverabilityContext
+        {
+            Headers = { { Headers.DiagnosticsTraceParent, "traceparent" } },
+            RecoverabilityAction = new DelayedRetry(TimeSpan.FromSeconds(10))
+        };
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Metadata[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public async Task Should_start_new_trace_for_other_actions_regardless_of_connectors()
+    {
+        var behavior = new PopulateRecoverabilityTraceMetadataBehavior(new InstrumentationOptions
+        {
+            DelayedRetryTraceMode = TraceMode.ContinueExisting,
+            ErrorMessageTraceMode = TraceMode.ContinueExisting
+        });
+
+        var context = new TestableRecoverabilityContext
+        {
+            Headers = { { Headers.DiagnosticsTraceParent, "traceparent" } },
+            RecoverabilityAction = new ImmediateRetry()
+        };
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Metadata[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
     }
 
     static IEnumerable<RecoverabilityAction> Actions()

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/PopulateRecoverabilityTraceMetadataBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/PopulateRecoverabilityTraceMetadataBehaviorTests.cs
@@ -95,6 +95,22 @@ public class PopulateRecoverabilityTraceMetadataBehaviorTests
     }
 
     [Test]
+    public async Task Should_not_apply_delayed_retry_connector_to_move_to_error()
+    {
+        var behavior = new PopulateRecoverabilityTraceMetadataBehavior(new InstrumentationOptions { DelayedRetryTraceMode = TraceMode.ContinueExisting });
+
+        var context = new TestableRecoverabilityContext
+        {
+            Headers = { { Headers.DiagnosticsTraceParent, "traceparent" } },
+            RecoverabilityAction = new MoveToError("errorqueue")
+        };
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Metadata[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
     public async Task Should_start_new_trace_for_other_actions_regardless_of_connectors()
     {
         var behavior = new PopulateRecoverabilityTraceMetadataBehavior(new InstrumentationOptions

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageTests.cs
@@ -109,6 +109,23 @@ public class AttachSenderRelatedInfoOnMessageTests
         }
     }
 
+    [Test]
+    public async Task Should_not_set_start_new_trace_context_entry()
+    {
+        var message = new OutgoingMessage("id", [], null);
+        var stash = new ContextBag();
+        stash.Set(new DispatchProperties
+        {
+            DelayDeliveryWith = new DelayDeliveryWith(TimeSpan.FromSeconds(2))
+        });
+        var context = new TestableRoutingContext { Message = message, Extensions = stash, RoutingStrategies = new List<UnicastRoutingStrategy> { new UnicastRoutingStrategy("_") } };
+
+        await new AttachSenderRelatedInfoOnMessageBehavior().Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Extensions.TryGet<string>(Headers.StartNewTrace, out _), Is.False,
+            "the trace boundary decision for delayed messages is owned by OpenTelemetryDelayedMessageBehavior");
+    }
+
     static async Task<OutgoingMessage> InvokeBehaviorAsync(Dictionary<string, string> headers = null, DispatchProperties dispatchProperties = null, CancellationToken cancellationToken = default)
     {
         var message = new OutgoingMessage("id", headers ?? [], null);

--- a/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
@@ -14,4 +14,20 @@ public class InstrumentationOptions
     /// Disabled by default for backward compatibility.
     /// </summary>
     public bool UseMessageDestinationInSpanNames { get; set; }
+
+    /// <summary>
+    /// Controls how the receive-side processing span relates to the send span for messages sent by this endpoint.
+    /// Defaults to <see cref="TraceConnector.ChildSpan"/>: receivers continue the trace.
+    /// Can be overridden per message via <c>StartNewTraceOnReceive</c>
+    /// or <c>ContinueExistingTraceOnReceive</c>.
+    /// </summary>
+    public TraceConnector SentMessageTraceConnector { get; set; } = TraceConnector.ChildSpan;
+
+    /// <summary>
+    /// Controls how the receive-side processing span relates to the publish span for events published by this endpoint.
+    /// Defaults to <see cref="TraceConnector.SpanLink"/>: receivers start a new trace linked back to the publish span.
+    /// Can be overridden per message via <c>StartNewTraceOnReceive</c>
+    /// or <c>ContinueExistingTraceOnReceive</c>.
+    /// </summary>
+    public TraceConnector PublishedMessageTraceConnector { get; set; } = TraceConnector.SpanLink;
 }

--- a/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
@@ -17,17 +17,17 @@ public class InstrumentationOptions
 
     /// <summary>
     /// Controls how the receive-side processing span relates to the send span for messages sent by this endpoint.
-    /// Defaults to <see cref="TraceConnector.ChildSpan"/>: receivers continue the trace.
+    /// Defaults to <see cref="TraceMode.ContinueExisting"/>: receivers continue the trace.
     /// Can be overridden per message via <see cref="OpenTelemetryExtensions.StartNewTraceOnReceive(SendOptions)"/>
     /// or <see cref="OpenTelemetryExtensions.ContinueExistingTraceOnReceive(SendOptions)"/>.
     /// </summary>
-    public TraceConnector SentMessageTraceConnector { get; set; } = TraceConnector.ChildSpan;
+    public TraceMode SendTraceMode { get; set; } = TraceMode.ContinueExisting;
 
     /// <summary>
     /// Controls how the receive-side processing span relates to the publish span for events published by this endpoint.
-    /// Defaults to <see cref="TraceConnector.SpanLink"/>: receivers start a new trace linked back to the publish span.
+    /// Defaults to <see cref="TraceMode.StartNew"/>: receivers start a new trace linked back to the publish span.
     /// Can be overridden per message via <see cref="OpenTelemetryExtensions.StartNewTraceOnReceive(PublishOptions)"/>
     /// or <see cref="OpenTelemetryExtensions.ContinueExistingTraceOnReceive(PublishOptions)"/>.
     /// </summary>
-    public TraceConnector PublishedMessageTraceConnector { get; set; } = TraceConnector.SpanLink;
+    public TraceMode PublishTraceMode { get; set; } = TraceMode.StartNew;
 }

--- a/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
@@ -30,4 +30,25 @@ public class InstrumentationOptions
     /// or <see cref="OpenTelemetryExtensions.ContinueExistingTraceOnReceive(PublishOptions)"/>.
     /// </summary>
     public TraceMode PublishTraceMode { get; set; } = TraceMode.StartNew;
+
+    /// <summary>
+    /// Controls how the receive-side processing span relates to the send span for delayed messages
+    /// (messages sent with a delivery delay, including saga timeouts).
+    /// Defaults to <see cref="TraceMode.StartNew"/>: receivers start a new trace linked back to the send span.
+    /// Can be overridden per message via <see cref="OpenTelemetryExtensions.StartNewTraceOnReceive(SendOptions)"/>
+    /// or <see cref="OpenTelemetryExtensions.ContinueExistingTraceOnReceive(SendOptions)"/>.
+    /// </summary>
+    public TraceMode DelayedSendTraceMode { get; set; } = TraceMode.StartNew;
+
+    /// <summary>
+    /// Controls how the processing span of a delayed retry relates to the trace of the failed attempt.
+    /// Defaults to <see cref="TraceMode.StartNew"/>: the retry starts a new trace linked back to the failed attempt.
+    /// </summary>
+    public TraceMode DelayedRetryTraceMode { get; set; } = TraceMode.StartNew;
+
+    /// <summary>
+    /// Controls how the processing span of a message retried from the error queue relates to the trace of the failed attempt.
+    /// Defaults to <see cref="TraceMode.StartNew"/>: reprocessing starts a new trace linked back to the failed attempt.
+    /// </summary>
+    public TraceMode ErrorMessageTraceMode { get; set; } = TraceMode.StartNew;
 }

--- a/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
@@ -18,16 +18,16 @@ public class InstrumentationOptions
     /// <summary>
     /// Controls how the receive-side processing span relates to the send span for messages sent by this endpoint.
     /// Defaults to <see cref="TraceConnector.ChildSpan"/>: receivers continue the trace.
-    /// Can be overridden per message via <c>StartNewTraceOnReceive</c>
-    /// or <c>ContinueExistingTraceOnReceive</c>.
+    /// Can be overridden per message via <see cref="OpenTelemetryExtensions.StartNewTraceOnReceive(SendOptions)"/>
+    /// or <see cref="OpenTelemetryExtensions.ContinueExistingTraceOnReceive(SendOptions)"/>.
     /// </summary>
     public TraceConnector SentMessageTraceConnector { get; set; } = TraceConnector.ChildSpan;
 
     /// <summary>
     /// Controls how the receive-side processing span relates to the publish span for events published by this endpoint.
     /// Defaults to <see cref="TraceConnector.SpanLink"/>: receivers start a new trace linked back to the publish span.
-    /// Can be overridden per message via <c>StartNewTraceOnReceive</c>
-    /// or <c>ContinueExistingTraceOnReceive</c>.
+    /// Can be overridden per message via <see cref="OpenTelemetryExtensions.StartNewTraceOnReceive(PublishOptions)"/>
+    /// or <see cref="OpenTelemetryExtensions.ContinueExistingTraceOnReceive(PublishOptions)"/>.
     /// </summary>
     public TraceConnector PublishedMessageTraceConnector { get; set; } = TraceConnector.SpanLink;
 }

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryDelayedMessageBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryDelayedMessageBehavior.cs
@@ -15,6 +15,8 @@ class OpenTelemetryDelayedMessageBehavior(InstrumentationOptions instrumentation
         // carries the decision in its headers, copied from recoverability metadata before the routing
         // context is created. The DelayedRetries header identifies that dispatch path — the StartNewTrace
         // header itself cannot be used because the send behavior stamps it on every outgoing message.
+        // This assumes the DelayedRetries header only appears on recoverability-generated retries; a user
+        // manually copying framework-internal incoming headers onto a new delayed send would skip this behavior.
         if (context.Message.Headers.ContainsKey(Headers.DelayedRetries))
         {
             return next(context);

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryDelayedMessageBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryDelayedMessageBehavior.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+namespace NServiceBus;
+
+using System;
+using System.Threading.Tasks;
+using Pipeline;
+using Transport;
+
+class OpenTelemetryDelayedMessageBehavior(InstrumentationOptions instrumentationOptions) : IBehavior<IRoutingContext, IRoutingContext>
+{
+    public Task Invoke(IRoutingContext context, Func<IRoutingContext, Task> next)
+    {
+        // Recoverability already decided the trace boundary for delayed retries: the retried message
+        // carries the decision in its headers, copied from recoverability metadata before the routing
+        // context is created. The DelayedRetries header identifies that dispatch path — the StartNewTrace
+        // header itself cannot be used because the send behavior stamps it on every outgoing message.
+        if (context.Message.Headers.ContainsKey(Headers.DelayedRetries))
+        {
+            return next(context);
+        }
+
+        bool isDelayed = context.Extensions.TryGet<DispatchProperties>(out var dispatchProperties)
+                         && (dispatchProperties.DelayDeliveryWith != null || dispatchProperties.DoNotDeliverBefore != null);
+
+        if (!isDelayed)
+        {
+            return next(context);
+        }
+
+        // A per-message override was already resolved into the header by the send behavior.
+        if (context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode _))
+        {
+            return next(context);
+        }
+
+        context.Extensions.Set(Headers.StartNewTrace,
+            instrumentationOptions.DelayedSendTraceMode == TraceMode.StartNew ? bool.TrueString : bool.FalseString);
+
+        return next(context);
+    }
+}

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryExtensions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryExtensions.cs
@@ -22,46 +22,46 @@ public static class OpenTelemetryExtensions
 
     /// <summary>
     /// Start a new OpenTelemetry trace on receive of this message, linked back to the send span.
-    /// Overrides <see cref="InstrumentationOptions.SentMessageTraceConnector"/> for this message.
+    /// Overrides <see cref="InstrumentationOptions.SendTraceMode"/> for this message.
     /// </summary>
     /// <param name="sendOptions">The option being extended.</param>
     public static void StartNewTraceOnReceive(this SendOptions sendOptions)
     {
         ArgumentNullException.ThrowIfNull(sendOptions);
-        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.SpanLink);
+        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceMode.StartNew);
     }
 
     /// <summary>
     /// Continue the existing OpenTelemetry trace on receive of this message.
-    /// Overrides <see cref="InstrumentationOptions.SentMessageTraceConnector"/> for this message.
+    /// Overrides <see cref="InstrumentationOptions.SendTraceMode"/> for this message.
     /// </summary>
     /// <param name="sendOptions">The option being extended.</param>
     public static void ContinueExistingTraceOnReceive(this SendOptions sendOptions)
     {
         ArgumentNullException.ThrowIfNull(sendOptions);
-        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceMode.ContinueExisting);
     }
 
     /// <summary>
     /// Start a new OpenTelemetry trace on receive of this event, linked back to the publish span.
-    /// Overrides <see cref="InstrumentationOptions.PublishedMessageTraceConnector"/> for this message.
+    /// Overrides <see cref="InstrumentationOptions.PublishTraceMode"/> for this message.
     /// </summary>
     /// <param name="publishOptions">The option being extended.</param>
     public static void StartNewTraceOnReceive(this PublishOptions publishOptions)
     {
         ArgumentNullException.ThrowIfNull(publishOptions);
-        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.SpanLink);
+        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceMode.StartNew);
     }
 
     /// <summary>
     /// Continue the existing OpenTelemetry trace on receive of this event.
-    /// Overrides <see cref="InstrumentationOptions.PublishedMessageTraceConnector"/> for this message.
+    /// Overrides <see cref="InstrumentationOptions.PublishTraceMode"/> for this message.
     /// </summary>
     /// <param name="publishOptions">The option being extended.</param>
     public static void ContinueExistingTraceOnReceive(this PublishOptions publishOptions)
     {
         ArgumentNullException.ThrowIfNull(publishOptions);
-        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceMode.ContinueExisting);
     }
 
     internal const string TraceConnectorOverrideKey = "NServiceBus.OpenTelemetry.TraceConnectorOverride";

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryExtensions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryExtensions.cs
@@ -21,20 +21,48 @@ public static class OpenTelemetryExtensions
     }
 
     /// <summary>
-    /// Start a new OpenTelemetry trace conversation.
+    /// Start a new OpenTelemetry trace on receive of this message, linked back to the send span.
+    /// Overrides <see cref="InstrumentationOptions.SentMessageTraceConnector"/> for this message.
     /// </summary>
     /// <param name="sendOptions">The option being extended.</param>
     public static void StartNewTraceOnReceive(this SendOptions sendOptions)
     {
-        sendOptions.Context.Set(OpenTelemetrySendBehavior.StartNewTraceOnReceive, true);
+        ArgumentNullException.ThrowIfNull(sendOptions);
+        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.SpanLink);
     }
 
     /// <summary>
-    /// Start a new OpenTelemetry trace conversation.
+    /// Continue the existing OpenTelemetry trace on receive of this message.
+    /// Overrides <see cref="InstrumentationOptions.SentMessageTraceConnector"/> for this message.
+    /// </summary>
+    /// <param name="sendOptions">The option being extended.</param>
+    public static void ContinueExistingTraceOnReceive(this SendOptions sendOptions)
+    {
+        ArgumentNullException.ThrowIfNull(sendOptions);
+        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.ChildSpan);
+    }
+
+    /// <summary>
+    /// Start a new OpenTelemetry trace on receive of this event, linked back to the publish span.
+    /// Overrides <see cref="InstrumentationOptions.PublishedMessageTraceConnector"/> for this message.
+    /// </summary>
+    /// <param name="publishOptions">The option being extended.</param>
+    public static void StartNewTraceOnReceive(this PublishOptions publishOptions)
+    {
+        ArgumentNullException.ThrowIfNull(publishOptions);
+        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.SpanLink);
+    }
+
+    /// <summary>
+    /// Continue the existing OpenTelemetry trace on receive of this event.
+    /// Overrides <see cref="InstrumentationOptions.PublishedMessageTraceConnector"/> for this message.
     /// </summary>
     /// <param name="publishOptions">The option being extended.</param>
     public static void ContinueExistingTraceOnReceive(this PublishOptions publishOptions)
     {
-        publishOptions.Context.Set(OpenTelemetryPublishBehavior.ContinueTraceOnReceive, true);
+        ArgumentNullException.ThrowIfNull(publishOptions);
+        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceConnector.ChildSpan);
     }
+
+    internal const string TraceConnectorOverrideKey = "NServiceBus.OpenTelemetry.TraceConnectorOverride";
 }

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryFeature.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryFeature.cs
@@ -21,6 +21,11 @@ sealed class OpenTelemetryFeature : Feature
         );
 
         context.Pipeline.Register(
+            new OpenTelemetryDelayedMessageBehavior(instrumentationOptions),
+            "Manages the depth of the trace for delayed messages"
+        );
+
+        context.Pipeline.Register(
             new PopulateRecoverabilityTraceMetadataBehavior(),
             "Populates the recoverability metadata"
         );

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryFeature.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryFeature.cs
@@ -8,13 +8,15 @@ sealed class OpenTelemetryFeature : Feature
 {
     protected override void Setup(FeatureConfigurationContext context)
     {
+        var instrumentationOptions = context.Settings.GetOrDefault<InstrumentationOptions>() ?? new InstrumentationOptions();
+
         context.Pipeline.Register(
-            new OpenTelemetryPublishBehavior(),
+            new OpenTelemetryPublishBehavior(instrumentationOptions),
             "Manages the depth of the trace for publishes"
         );
 
         context.Pipeline.Register(
-            new OpenTelemetrySendBehavior(),
+            new OpenTelemetrySendBehavior(instrumentationOptions),
             "Manages the depth of the trace for sends"
         );
 

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryFeature.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryFeature.cs
@@ -26,7 +26,7 @@ sealed class OpenTelemetryFeature : Feature
         );
 
         context.Pipeline.Register(
-            new PopulateRecoverabilityTraceMetadataBehavior(),
+            new PopulateRecoverabilityTraceMetadataBehavior(instrumentationOptions),
             "Populates the recoverability metadata"
         );
     }

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryPublishBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryPublishBehavior.cs
@@ -6,22 +6,17 @@ using System;
 using System.Threading.Tasks;
 using Pipeline;
 
-class OpenTelemetryPublishBehavior : IBehavior<IOutgoingPublishContext, IOutgoingPublishContext>
+class OpenTelemetryPublishBehavior(InstrumentationOptions instrumentationOptions) : IBehavior<IOutgoingPublishContext, IOutgoingPublishContext>
 {
     public Task Invoke(IOutgoingPublishContext context, Func<IOutgoingPublishContext, Task> next)
     {
-        // publishes always start a new trace on receive
-        context.Headers[Headers.StartNewTrace] = bool.TrueString;
+        // the per-message override wins over the endpoint-level default
+        var connector = context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector requestedConnector)
+            ? requestedConnector
+            : instrumentationOptions.PublishedMessageTraceConnector;
 
-        // unless the user explicitly requests to continue the trace
-        bool continueTraceWasSet = context.Extensions.TryGet<bool>(ContinueTraceOnReceive, out var continueTraceRequested);
-        if (continueTraceWasSet && continueTraceRequested)
-        {
-            context.Headers[Headers.StartNewTrace] = bool.FalseString;
-        }
+        context.Headers[Headers.StartNewTrace] = connector == TraceConnector.SpanLink ? bool.TrueString : bool.FalseString;
 
         return next(context);
     }
-
-    public const string ContinueTraceOnReceive = "ContinueTraceRequested";
 }

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryPublishBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryPublishBehavior.cs
@@ -11,11 +11,11 @@ class OpenTelemetryPublishBehavior(InstrumentationOptions instrumentationOptions
     public Task Invoke(IOutgoingPublishContext context, Func<IOutgoingPublishContext, Task> next)
     {
         // the per-message override wins over the endpoint-level default
-        var connector = context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector requestedConnector)
+        var connector = context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode requestedConnector)
             ? requestedConnector
-            : instrumentationOptions.PublishedMessageTraceConnector;
+            : instrumentationOptions.PublishTraceMode;
 
-        context.Headers[Headers.StartNewTrace] = connector == TraceConnector.SpanLink ? bool.TrueString : bool.FalseString;
+        context.Headers[Headers.StartNewTrace] = connector == TraceMode.StartNew ? bool.TrueString : bool.FalseString;
 
         return next(context);
     }

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetrySendBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetrySendBehavior.cs
@@ -6,22 +6,17 @@ using System;
 using System.Threading.Tasks;
 using Pipeline;
 
-class OpenTelemetrySendBehavior : IBehavior<IOutgoingSendContext, IOutgoingSendContext>
+class OpenTelemetrySendBehavior(InstrumentationOptions instrumentationOptions) : IBehavior<IOutgoingSendContext, IOutgoingSendContext>
 {
     public Task Invoke(IOutgoingSendContext context, Func<IOutgoingSendContext, Task> next)
     {
-        // sends never start a new trace on receive
-        context.Headers[Headers.StartNewTrace] = bool.FalseString;
+        // the per-message override wins over the endpoint-level default
+        var connector = context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector requestedConnector)
+            ? requestedConnector
+            : instrumentationOptions.SentMessageTraceConnector;
 
-        // unless the user explicitly requests to start a new trace
-        bool breakTraceWasSet = context.Extensions.TryGet<bool>(StartNewTraceOnReceive, out var breakTraceWasRequested);
-        if (breakTraceWasSet && breakTraceWasRequested)
-        {
-            context.Headers[Headers.StartNewTrace] = bool.TrueString;
-        }
+        context.Headers[Headers.StartNewTrace] = connector == TraceConnector.SpanLink ? bool.TrueString : bool.FalseString;
 
         return next(context);
     }
-
-    public const string StartNewTraceOnReceive = "BreakTraceRequested";
 }

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetrySendBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetrySendBehavior.cs
@@ -11,11 +11,11 @@ class OpenTelemetrySendBehavior(InstrumentationOptions instrumentationOptions) :
     public Task Invoke(IOutgoingSendContext context, Func<IOutgoingSendContext, Task> next)
     {
         // the per-message override wins over the endpoint-level default
-        var connector = context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceConnector requestedConnector)
+        var connector = context.Extensions.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode requestedConnector)
             ? requestedConnector
-            : instrumentationOptions.SentMessageTraceConnector;
+            : instrumentationOptions.SendTraceMode;
 
-        context.Headers[Headers.StartNewTrace] = connector == TraceConnector.SpanLink ? bool.TrueString : bool.FalseString;
+        context.Headers[Headers.StartNewTrace] = connector == TraceMode.StartNew ? bool.TrueString : bool.FalseString;
 
         return next(context);
     }

--- a/src/NServiceBus.Core/OpenTelemetry/TraceConnector.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/TraceConnector.cs
@@ -1,0 +1,19 @@
+#nullable enable
+
+namespace NServiceBus;
+
+/// <summary>
+/// Controls how the receive-side processing span relates to the outgoing send or publish span.
+/// </summary>
+public enum TraceConnector
+{
+    /// <summary>
+    /// The receiving endpoint continues the trace: the processing span becomes a child of the outgoing span.
+    /// </summary>
+    ChildSpan,
+
+    /// <summary>
+    /// The receiving endpoint starts a new trace: the processing span becomes the root of a new trace with a link back to the outgoing span.
+    /// </summary>
+    SpanLink
+}

--- a/src/NServiceBus.Core/OpenTelemetry/TraceMode.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/TraceMode.cs
@@ -5,15 +5,15 @@ namespace NServiceBus;
 /// <summary>
 /// Controls how the receive-side processing span relates to the outgoing send or publish span.
 /// </summary>
-public enum TraceConnector
+public enum TraceMode
 {
     /// <summary>
     /// The receiving endpoint continues the trace: the processing span becomes a child of the outgoing span.
     /// </summary>
-    ChildSpan,
+    ContinueExisting,
 
     /// <summary>
     /// The receiving endpoint starts a new trace: the processing span becomes the root of a new trace with a link back to the outgoing span.
     /// </summary>
-    SpanLink
+    StartNew
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/PopulateRecoverabilityTraceMetadataBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/PopulateRecoverabilityTraceMetadataBehavior.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading.Tasks;
 using Pipeline;
 
-class PopulateRecoverabilityTraceMetadataBehavior : IBehavior<IRecoverabilityContext, IRecoverabilityContext>
+class PopulateRecoverabilityTraceMetadataBehavior(InstrumentationOptions instrumentationOptions) : IBehavior<IRecoverabilityContext, IRecoverabilityContext>
 {
     public Task Invoke(IRecoverabilityContext context, Func<IRecoverabilityContext, Task> next)
     {
@@ -13,9 +13,17 @@ class PopulateRecoverabilityTraceMetadataBehavior : IBehavior<IRecoverabilityCon
             return next(context);
         }
 
+        var connector = context.RecoverabilityAction switch
+        {
+            DelayedRetry => instrumentationOptions.DelayedRetryTraceMode,
+            MoveToError => instrumentationOptions.ErrorMessageTraceMode,
+            // custom recoverability actions keep the pre-existing behavior of always starting a new trace
+            _ => TraceMode.StartNew
+        };
+
         // Setting it to the metadata makes sure it is propagated to the headers
         // even in more advanced scenarios like native dead-lettering
-        context.Metadata[Headers.StartNewTrace] = bool.TrueString;
+        context.Metadata[Headers.StartNewTrace] = connector == TraceMode.StartNew ? bool.TrueString : bool.FalseString;
 
         return next(context);
     }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageBehavior.cs
@@ -35,12 +35,10 @@ class AttachSenderRelatedInfoOnMessageBehavior : IBehavior<IRoutingContext, IRou
                 {
                     var timeDelay = dispatchProperties.DelayDeliveryWith.Delay;
                     message.Headers[Headers.DeliverAt] = DateTimeOffsetHelper.ToWireFormattedString(utcNow.Add(timeDelay));
-                    context.Extensions.Set(Headers.StartNewTrace, bool.TrueString);
                 }
                 else if (dispatchProperties.DoNotDeliverBefore != null)
                 {
                     message.Headers[Headers.DeliverAt] = DateTimeOffsetHelper.ToWireFormattedString(dispatchProperties.DoNotDeliverBefore.At);
-                    context.Extensions.Set(Headers.StartNewTrace, bool.TrueString);
                 }
             }
         }


### PR DESCRIPTION
> [!IMPORTANT]
> - Stacked on #7867
> **Merge that first**, then retarget this PR to `otel`.

- Resolves: #7205

----

- `Tracing().DelayedSendTraceMode` — delayed sends incl. saga timeouts
- `Tracing().DelayedRetryTraceMode` — recoverability delayed retries
- `Tracing().ErrorMessageTraceMode` — messages moved to the error queue

All default to `TraceMode.StartNew` (current behavior). Per-message overrides now also win on delayed sends.