### PR TITLE
[Do not merge] Update nullable annotations for header dictionary value types

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -139,8 +139,8 @@ namespace NServiceBus
     }
     public class ConversationIdStrategyContext
     {
-        public ConversationIdStrategyContext(NServiceBus.Pipeline.OutgoingLogicalMessage message, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
-        public System.Collections.Generic.IReadOnlyDictionary<string, string> Headers { get; }
+        public ConversationIdStrategyContext(NServiceBus.Pipeline.OutgoingLogicalMessage message, System.Collections.Generic.IReadOnlyDictionary<string, string?> headers) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string?> Headers { get; }
         public NServiceBus.Pipeline.OutgoingLogicalMessage Message { get; }
     }
     public static class ConversationRoutingExtensions
@@ -358,8 +358,8 @@ namespace NServiceBus
     }
     public static class HeaderOptionExtensions
     {
-        public static System.Collections.Generic.IReadOnlyDictionary<string, string> GetHeaders(this NServiceBus.Extensibility.ExtendableOptions options) { }
-        public static void SetHeader(this NServiceBus.Extensibility.ExtendableOptions options, string key, string value) { }
+        public static System.Collections.Generic.IReadOnlyDictionary<string, string?> GetHeaders(this NServiceBus.Extensibility.ExtendableOptions options) { }
+        public static void SetHeader(this NServiceBus.Extensibility.ExtendableOptions options, string key, string? value) { }
     }
     public static class Headers
     {
@@ -1761,19 +1761,19 @@ namespace NServiceBus.MessageMutator
     }
     public class MutateOutgoingMessageContext : NServiceBus.ICancellableContext
     {
-        public MutateOutgoingMessageContext(object outgoingMessage, System.Collections.Generic.Dictionary<string, string> outgoingHeaders, object? incomingMessage, System.Collections.Generic.IReadOnlyDictionary<string, string>? incomingHeaders, System.Threading.CancellationToken cancellationToken = default) { }
+        public MutateOutgoingMessageContext(object outgoingMessage, System.Collections.Generic.Dictionary<string, string?> outgoingHeaders, object? incomingMessage, System.Collections.Generic.IReadOnlyDictionary<string, string>? incomingHeaders, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.CancellationToken CancellationToken { get; }
-        public System.Collections.Generic.Dictionary<string, string> OutgoingHeaders { get; }
+        public System.Collections.Generic.Dictionary<string, string?> OutgoingHeaders { get; }
         public object OutgoingMessage { get; set; }
         public bool TryGetIncomingHeaders([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Collections.Generic.IReadOnlyDictionary<string, string>? incomingHeaders) { }
         public bool TryGetIncomingMessage([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? incomingMessage) { }
     }
     public class MutateOutgoingTransportMessageContext : NServiceBus.ICancellableContext
     {
-        public MutateOutgoingTransportMessageContext(System.ReadOnlyMemory<byte> outgoingBody, object outgoingMessage, System.Collections.Generic.Dictionary<string, string> outgoingHeaders, object? incomingMessage, System.Collections.Generic.IReadOnlyDictionary<string, string>? incomingHeaders, System.Threading.CancellationToken cancellationToken = default) { }
+        public MutateOutgoingTransportMessageContext(System.ReadOnlyMemory<byte> outgoingBody, object outgoingMessage, System.Collections.Generic.Dictionary<string, string?> outgoingHeaders, object? incomingMessage, System.Collections.Generic.IReadOnlyDictionary<string, string>? incomingHeaders, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.CancellationToken CancellationToken { get; }
         public System.ReadOnlyMemory<byte> OutgoingBody { get; set; }
-        public System.Collections.Generic.Dictionary<string, string> OutgoingHeaders { get; }
+        public System.Collections.Generic.Dictionary<string, string?> OutgoingHeaders { get; }
         public object OutgoingMessage { get; }
         public bool TryGetIncomingHeaders([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Collections.Generic.IReadOnlyDictionary<string, string>? incomingHeaders) { }
         public bool TryGetIncomingMessage([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? incomingMessage) { }
@@ -1931,7 +1931,7 @@ namespace NServiceBus.Pipeline
     }
     public interface IOutgoingContext : NServiceBus.Extensibility.IExtendable, NServiceBus.ICancellableContext, NServiceBus.IPipelineContext, NServiceBus.Pipeline.IBehaviorContext
     {
-        System.Collections.Generic.Dictionary<string, string> Headers { get; }
+        System.Collections.Generic.Dictionary<string, string?> Headers { get; }
         string MessageId { get; }
     }
     public interface IOutgoingLogicalMessageContext : NServiceBus.Extensibility.IExtendable, NServiceBus.ICancellableContext, NServiceBus.IPipelineContext, NServiceBus.Pipeline.IBehaviorContext, NServiceBus.Pipeline.IOutgoingContext

--- a/src/NServiceBus.Core/Causation/ConversationIdStrategyContext.cs
+++ b/src/NServiceBus.Core/Causation/ConversationIdStrategyContext.cs
@@ -14,7 +14,7 @@ public class ConversationIdStrategyContext
     /// <summary>
     /// Creates a new context.
     /// </summary>
-    public ConversationIdStrategyContext(OutgoingLogicalMessage message, IReadOnlyDictionary<string, string> headers)
+    public ConversationIdStrategyContext(OutgoingLogicalMessage message, IReadOnlyDictionary<string, string?> headers)
     {
         ArgumentNullException.ThrowIfNull(message);
         ArgumentNullException.ThrowIfNull(headers);
@@ -32,5 +32,5 @@ public class ConversationIdStrategyContext
     /// <summary>
     /// The headers attached to the outgoing message.
     /// </summary>
-    public IReadOnlyDictionary<string, string> Headers { get; }
+    public IReadOnlyDictionary<string, string?> Headers { get; }
 }

--- a/src/NServiceBus.Core/Extensibility/ExtendableOptions.cs
+++ b/src/NServiceBus.Core/Extensibility/ExtendableOptions.cs
@@ -30,5 +30,5 @@ public abstract class ExtendableOptions
 
     internal string? UserDefinedMessageId { get; set; }
 
-    internal Dictionary<string, string> OutgoingHeaders { get; }
+    internal Dictionary<string, string?> OutgoingHeaders { get; }
 }

--- a/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateOutgoingMessageContext.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateOutgoingMessageContext.cs
@@ -15,7 +15,7 @@ public class MutateOutgoingMessageContext : ICancellableContext
     /// <summary>
     /// Initializes the context.
     /// </summary>
-    public MutateOutgoingMessageContext(object outgoingMessage, Dictionary<string, string> outgoingHeaders, object? incomingMessage, IReadOnlyDictionary<string, string>? incomingHeaders, CancellationToken cancellationToken = default)
+    public MutateOutgoingMessageContext(object outgoingMessage, Dictionary<string, string?> outgoingHeaders, object? incomingMessage, IReadOnlyDictionary<string, string>? incomingHeaders, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(outgoingHeaders);
         ArgumentNullException.ThrowIfNull(outgoingMessage);
@@ -43,7 +43,7 @@ public class MutateOutgoingMessageContext : ICancellableContext
     /// <summary>
     /// The current outgoing headers.
     /// </summary>
-    public Dictionary<string, string> OutgoingHeaders { get; }
+    public Dictionary<string, string?> OutgoingHeaders { get; }
 
     /// <summary>
     /// A <see cref="CancellationToken"/> to observe.

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateOutgoingTransportMessageContext.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateOutgoingTransportMessageContext.cs
@@ -15,7 +15,7 @@ public class MutateOutgoingTransportMessageContext : ICancellableContext
     /// <summary>
     /// Initializes a new instance of <see cref="MutateOutgoingTransportMessageContext" />.
     /// </summary>
-    public MutateOutgoingTransportMessageContext(ReadOnlyMemory<byte> outgoingBody, object outgoingMessage, Dictionary<string, string> outgoingHeaders, object? incomingMessage, IReadOnlyDictionary<string, string>? incomingHeaders, CancellationToken cancellationToken = default)
+    public MutateOutgoingTransportMessageContext(ReadOnlyMemory<byte> outgoingBody, object outgoingMessage, Dictionary<string, string?> outgoingHeaders, object? incomingMessage, IReadOnlyDictionary<string, string>? incomingHeaders, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(outgoingHeaders);
         ArgumentNullException.ThrowIfNull(outgoingMessage);
@@ -51,7 +51,7 @@ public class MutateOutgoingTransportMessageContext : ICancellableContext
     /// <summary>
     /// The current outgoing headers.
     /// </summary>
-    public Dictionary<string, string> OutgoingHeaders { get; }
+    public Dictionary<string, string?> OutgoingHeaders { get; }
 
     /// <summary>
     /// A <see cref="CancellationToken"/> to observe.

--- a/src/NServiceBus.Core/Pipeline/Outgoing/HeaderOptionExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/HeaderOptionExtensions.cs
@@ -18,7 +18,7 @@ public static class HeaderOptionExtensions
     /// <param name="options">The options to extend.</param>
     /// <param name="key">The header key.</param>
     /// <param name="value">The header value.</param>
-    public static void SetHeader(this ExtendableOptions options, string key, string value)
+    public static void SetHeader(this ExtendableOptions options, string key, string? value)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
@@ -29,10 +29,10 @@ public static class HeaderOptionExtensions
     /// <summary>
     /// Returns all headers set by <see cref="SetHeader" /> on the outgoing message.
     /// </summary>
-    public static IReadOnlyDictionary<string, string> GetHeaders(this ExtendableOptions options)
+    public static IReadOnlyDictionary<string, string?> GetHeaders(this ExtendableOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        return new ReadOnlyDictionary<string, string>(options.OutgoingHeaders);
+        return new ReadOnlyDictionary<string, string?>(options.OutgoingHeaders);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/IOutgoingContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/IOutgoingContext.cs
@@ -17,5 +17,5 @@ public interface IOutgoingContext : IBehaviorContext, IPipelineContext
     /// <summary>
     /// The headers of the outgoing message.
     /// </summary>
-    Dictionary<string, string> Headers { get; }
+    Dictionary<string, string?> Headers { get; }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingContext.cs
@@ -10,7 +10,7 @@ using Pipeline;
 
 abstract class OutgoingContext : BehaviorContext, IOutgoingContext
 {
-    protected OutgoingContext(string messageId, Dictionary<string, string> headers, IBehaviorContext parentContext)
+    protected OutgoingContext(string messageId, Dictionary<string, string?> headers, IBehaviorContext parentContext)
         : base(parentContext)
     {
         Headers = headers;
@@ -21,7 +21,7 @@ abstract class OutgoingContext : BehaviorContext, IOutgoingContext
 
     public string MessageId { get; }
 
-    public Dictionary<string, string> Headers { get; }
+    public Dictionary<string, string?> Headers { get; }
 
     public Task Send(object message, SendOptions options)
     {

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingLogicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingLogicalMessageContext.cs
@@ -9,7 +9,7 @@ using Routing;
 
 class OutgoingLogicalMessageContext : OutgoingContext, IOutgoingLogicalMessageContext
 {
-    public OutgoingLogicalMessageContext(string messageId, Dictionary<string, string> headers, OutgoingLogicalMessage message, IReadOnlyCollection<RoutingStrategy> routingStrategies, IBehaviorContext parentContext)
+    public OutgoingLogicalMessageContext(string messageId, Dictionary<string, string?> headers, OutgoingLogicalMessage message, IReadOnlyCollection<RoutingStrategy> routingStrategies, IBehaviorContext parentContext)
         : base(messageId, headers, parentContext)
     {
         Message = message;

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPublishContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPublishContext.cs
@@ -9,7 +9,7 @@ using Pipeline;
 
 class OutgoingPublishContext : OutgoingContext, IOutgoingPublishContext
 {
-    public OutgoingPublishContext(OutgoingLogicalMessage message, string messageId, Dictionary<string, string> headers, ContextBag extensions, IBehaviorContext parentContext)
+    public OutgoingPublishContext(OutgoingLogicalMessage message, string messageId, Dictionary<string, string?> headers, ContextBag extensions, IBehaviorContext parentContext)
         : base(messageId, headers, parentContext)
     {
         ArgumentNullException.ThrowIfNull(parentContext);

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingReplyContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingReplyContext.cs
@@ -9,7 +9,7 @@ using Pipeline;
 
 class OutgoingReplyContext : OutgoingContext, IOutgoingReplyContext
 {
-    public OutgoingReplyContext(OutgoingLogicalMessage message, string messageId, Dictionary<string, string> headers, ContextBag extensions, IBehaviorContext parentContext)
+    public OutgoingReplyContext(OutgoingLogicalMessage message, string messageId, Dictionary<string, string?> headers, ContextBag extensions, IBehaviorContext parentContext)
         : base(messageId, headers, parentContext)
     {
         ArgumentNullException.ThrowIfNull(parentContext);

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingSendContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingSendContext.cs
@@ -9,7 +9,7 @@ using Pipeline;
 
 class OutgoingSendContext : OutgoingContext, IOutgoingSendContext
 {
-    public OutgoingSendContext(OutgoingLogicalMessage message, string messageId, Dictionary<string, string> headers, ContextBag extensions, IBehaviorContext parentContext)
+    public OutgoingSendContext(OutgoingLogicalMessage message, string messageId, Dictionary<string, string?> headers, ContextBag extensions, IBehaviorContext parentContext)
         : base(messageId, headers, parentContext)
     {
         ArgumentNullException.ThrowIfNull(parentContext);

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -46,7 +46,7 @@ class MessageOperations
 
     public Task Publish(IBehaviorContext context, object message, PublishOptions options)
     {
-        var messageType = messageMapper.GetMappedTypeFor(message.GetType());
+        var messageType = messageMapper.GetMappedTypeFor(message.GetType()) ?? message.GetType();
 
         return Publish(context, messageType, message, options);
     }
@@ -113,7 +113,7 @@ class MessageOperations
 
     public Task Send(IBehaviorContext context, object message, SendOptions options)
     {
-        var messageType = messageMapper.GetMappedTypeFor(message.GetType());
+        var messageType = messageMapper.GetMappedTypeFor(message.GetType()) ?? message.GetType();
 
         return SendMessage(context, messageType, message, options);
     }
@@ -142,7 +142,7 @@ class MessageOperations
 
     public Task Reply(IBehaviorContext context, object message, ReplyOptions options)
     {
-        var messageType = messageMapper.GetMappedTypeFor(message.GetType());
+        var messageType = messageMapper.GetMappedTypeFor(message.GetType()) ?? message.GetType();
 
         return ReplyMessage(context, messageType, message, options);
     }

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -41,7 +41,7 @@ class MessageOperations
 
     public Task Publish<[DynamicallyAccessedMembers(IMessageCreator.CreatorMembersRequired)] T>(IBehaviorContext context, Action<T> messageConstructor, PublishOptions options)
     {
-        return Publish(context, typeof(T), messageMapper.CreateInstance(messageConstructor), options);
+        return Publish(context, typeof(T), messageMapper.CreateInstance(messageConstructor)!, options);
     }
 
     public Task Publish(IBehaviorContext context, object message, PublishOptions options)
@@ -108,7 +108,7 @@ class MessageOperations
 
     public Task Send<[DynamicallyAccessedMembers(IMessageCreator.CreatorMembersRequired)] T>(IBehaviorContext context, Action<T> messageConstructor, SendOptions options)
     {
-        return SendMessage(context, typeof(T), messageMapper.CreateInstance(messageConstructor), options);
+        return SendMessage(context, typeof(T), messageMapper.CreateInstance(messageConstructor)!, options);
     }
 
     public Task Send(IBehaviorContext context, object message, SendOptions options)
@@ -149,7 +149,7 @@ class MessageOperations
 
     public Task Reply<[DynamicallyAccessedMembers(IMessageCreator.CreatorMembersRequired)] T>(IBehaviorContext context, Action<T> messageConstructor, ReplyOptions options)
     {
-        return ReplyMessage(context, typeof(T), messageMapper.CreateInstance(messageConstructor), options);
+        return ReplyMessage(context, typeof(T), messageMapper.CreateInstance(messageConstructor)!, options);
     }
 
     async Task ReplyMessage(IBehaviorContext context, Type messageType, object message, ReplyOptions options)

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -52,7 +52,7 @@ class MessageOperations
     async Task Publish(IBehaviorContext context, Type messageType, object message, PublishOptions options)
     {
         var messageId = options.UserDefinedMessageId ?? CombGuid.Generate().ToString();
-        var headers = new Dictionary<string, string>(options.OutgoingHeaders)
+        var headers = new Dictionary<string, string?>(options.OutgoingHeaders)
         {
             [Headers.MessageId] = messageId
         };
@@ -119,7 +119,7 @@ class MessageOperations
     async Task SendMessage(IBehaviorContext context, Type messageType, object message, SendOptions options)
     {
         var messageId = options.UserDefinedMessageId ?? CombGuid.Generate().ToString();
-        var headers = new Dictionary<string, string>(options.OutgoingHeaders)
+        var headers = new Dictionary<string, string?>(options.OutgoingHeaders)
         {
             [Headers.MessageId] = messageId
         };
@@ -153,7 +153,7 @@ class MessageOperations
     async Task ReplyMessage(IBehaviorContext context, Type messageType, object message, ReplyOptions options)
     {
         var messageId = options.UserDefinedMessageId ?? CombGuid.Generate().ToString();
-        var headers = new Dictionary<string, string>(options.OutgoingHeaders)
+        var headers = new Dictionary<string, string?>(options.OutgoingHeaders)
         {
             [Headers.MessageId] = messageId
         };

--- a/src/NServiceBus.Testing.Fakes/TestableOutgoingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableOutgoingContext.cs
@@ -38,5 +38,5 @@ public partial class TestableOutgoingContext : TestablePipelineContext, IOutgoin
     /// <summary>
     /// The headers of the outgoing message.
     /// </summary>
-    public Dictionary<string, string> Headers { get; set; } = [];
+    public Dictionary<string, string?> Headers { get; set; } = [];
 }

--- a/src/NServiceBus.Testing.Fakes/TestableOutgoingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableOutgoingContext.cs
@@ -20,7 +20,7 @@ public partial class TestableOutgoingContext : TestablePipelineContext, IOutgoin
 
     IServiceProvider IBehaviorContext.Builder => GetBuilder();
 
-    IServiceProvider builder = null;
+    IServiceProvider? builder = null;
 
     /// <summary>
     /// Selects the builder returned by <see cref="IBehaviorContext.Builder" />. Override this method to provide your custom

--- a/src/NServiceBus.Testing.Fakes/TestableOutgoingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableOutgoingContext.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Testing;
+﻿#nullable enable
+
+namespace NServiceBus.Testing;
 
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
This PR updates nullable annotations across the codebase to consistently reflect that 
header dictionary values can be null. This aligns type annotations with the current runtime behavior and the public API contract.

Do not merge this PR 