### PR TITLE
Add blank line after #nullable enable to match repo convention

### DIFF
--- a/src/NServiceBus.Core/Features/FeatureFactory.cs
+++ b/src/NServiceBus.Core/Features/FeatureFactory.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus.Features;
 
 using System;

--- a/src/NServiceBus.Core/Features/IFeatureStartupTaskController.cs
+++ b/src/NServiceBus.Core/Features/IFeatureStartupTaskController.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus.Features;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/HostingComponent.Configuration.cs
+++ b/src/NServiceBus.Core/Hosting/HostingComponent.Configuration.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/HostingComponent.Settings.cs
+++ b/src/NServiceBus.Core/Hosting/HostingComponent.Settings.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/DiagnosticSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/DiagnosticSettingsExtensions.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/Host.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/Host.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriter.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriter.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriterFactory.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriterFactory.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/JsonPrettyPrinter.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/JsonPrettyPrinter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System.Text.Encodings.Web;

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/StartupDiagnosticEntries.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/StartupDiagnosticEntries.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System.Collections.Generic;

--- a/src/NServiceBus.Core/IdGeneration/CombGuid.cs
+++ b/src/NServiceBus.Core/IdGeneration/CombGuid.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/MessageInterfaces/IMessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/IMessageMapper.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus.MessageInterfaces;
 
 using System;

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/ConcreteProxyCreator.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/ConcreteProxyCreator.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection;
 
 using System;

--- a/src/NServiceBus.Core/Serializers/SystemJson/JsonMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/SystemJson/JsonMessageSerializer.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus.Serializers.SystemJson;
 
 using System;

--- a/src/NServiceBus.Core/Serializers/SystemJson/SystemJsonConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Serializers/SystemJson/SystemJsonConfigurationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Serializers/SystemJson/SystemJsonSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/SystemJson/SystemJsonSerializer.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus;
 
 using System;

--- a/src/NServiceBus.Core/Serializers/SystemJson/SystemJsonSerializerSettings.cs
+++ b/src/NServiceBus.Core/Serializers/SystemJson/SystemJsonSerializerSettings.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+
 namespace NServiceBus.Serializers.SystemJson;
 
 using System.Text.Json;

--- a/src/NServiceBus.Core/Unicast/Config/MessageHandlerRegistrationExtensions.cs
+++ b/src/NServiceBus.Core/Unicast/Config/MessageHandlerRegistrationExtensions.cs
@@ -1,4 +1,5 @@
 #nullable enable
+
 namespace NServiceBus;
 
 using System;


### PR DESCRIPTION
Several files had the #nullable enable annotation on line 1 but skipped the blank line before the namespace declaration that the rest of the codebase uses. Making this no-op change in this PR in preparation for a new test to check for #nullable enable in completed directories.