### PR TITLE
Revert message headers to their original state before auditing

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ApprovalFiles/AcceptanceTestsShippedSourceFilesApproval.ApproveShippedSourceFiles.approved.txt
+++ b/src/NServiceBus.AcceptanceTests/ApprovalFiles/AcceptanceTestsShippedSourceFilesApproval.ApproveShippedSourceFiles.approved.txt
@@ -4,6 +4,7 @@ Audit/When_audit_is_overridden_in_code.cs
 Audit/When_audit_is_overridden_in_environment.cs
 Audit/When_auditing.cs
 Audit/When_auditing_message_with_TimeToBeReceived.cs
+Audit/When_headers_are_mutated.cs
 BehaviorBuilderRegistrationExtensions.cs
 ConfigureEndpointAcceptanceTestingPersistence.cs
 ConfigureEndpointAcceptanceTestingTransport.cs

--- a/src/NServiceBus.AcceptanceTests/Audit/When_headers_are_mutated.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_headers_are_mutated.cs
@@ -1,0 +1,75 @@
+namespace NServiceBus.AcceptanceTests.Audit;
+
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using AcceptanceTesting.Customization;
+using EndpointTemplates;
+using MessageMutator;
+using NUnit.Framework;
+
+public class When_headers_are_mutated : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_audit_original_headers()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<MutatingEndpoint>(b => b.When(session =>
+            {
+                var options = new SendOptions();
+                options.RouteToThisEndpoint();
+                options.SetHeader("AuditTestHeader", "original");
+                return session.Send(new MessageToBeAudited(), options);
+            }))
+            .WithEndpoint<AuditSpyEndpoint>()
+            .Run();
+
+        Assert.That(context.AuditedHeader, Is.EqualTo("original"));
+    }
+
+    public class Context : ScenarioContext
+    {
+        public string AuditedHeader { get; set; }
+    }
+
+    public class MutatingEndpoint : EndpointConfigurationBuilder
+    {
+        public MutatingEndpoint() => EndpointSetup<DefaultServer>(c =>
+        {
+            c.AuditProcessedMessagesTo<AuditSpyEndpoint>();
+            c.RegisterMessageMutator(new HeaderMutator());
+        });
+
+        class HeaderMutator : IMutateIncomingTransportMessages
+        {
+            public Task MutateIncoming(MutateIncomingTransportMessageContext context)
+            {
+                context.Headers["AuditTestHeader"] = "mutated";
+                return Task.CompletedTask;
+            }
+        }
+
+        [Handler]
+        public class MessageHandler : IHandleMessages<MessageToBeAudited>
+        {
+            public Task Handle(MessageToBeAudited message, IMessageHandlerContext context) => Task.CompletedTask;
+        }
+    }
+
+    public class AuditSpyEndpoint : EndpointConfigurationBuilder
+    {
+        public AuditSpyEndpoint() => EndpointSetup<DefaultServer>();
+
+        [Handler]
+        public class MessageHandler(Context testContext) : IHandleMessages<MessageToBeAudited>
+        {
+            public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
+            {
+                testContext.AuditedHeader = context.MessageHeaders["AuditTestHeader"];
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class MessageToBeAudited : IMessage;
+}

--- a/src/NServiceBus.Core.Tests/Transports/IncomingMessageTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/IncomingMessageTests.cs
@@ -52,4 +52,29 @@ public class IncomingMessageTests
             Assert.That(message.MessageId, Is.EqualTo("nativeId"));
         }
     }
+
+    [Test]
+    public void RevertToOriginalHeadersIfNeeded_should_restore_original_headers()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { Headers.MessageId, "id" },
+            { Headers.ContentType, "text/plain" },
+            { "RemovedHeader", "original" }
+        };
+        var message = new IncomingMessage("id", headers, System.Array.Empty<byte>());
+
+        message.Headers[Headers.ContentType] = "application/json";
+        message.Headers["AddedHeader"] = "added";
+        message.Headers.Remove("RemovedHeader");
+
+        message.RevertToOriginalHeadersIfNeeded();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(message.Headers[Headers.ContentType], Is.EqualTo("text/plain"));
+            Assert.That(message.Headers.ContainsKey("AddedHeader"), Is.False);
+            Assert.That(message.Headers["RemovedHeader"], Is.EqualTo("original"));
+        }
+    }
 }

--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -21,6 +21,7 @@ class InvokeAuditPipelineBehavior : IForkConnector<IIncomingPhysicalMessageConte
         await next(context).ConfigureAwait(false);
 
         context.Message.RevertToOriginalBodyIfNeeded();
+        context.Message.RevertToOriginalHeadersIfNeeded();
 
         var processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), context.Message.Body);
 

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -35,6 +35,7 @@ public class IncomingMessage
         NativeMessageId = nativeMessageId;
         MessageId = GetOrSetMessageIdFromHeaders(headers, nativeMessageId);
         Headers = headers;
+        originalHeaders = new Dictionary<string, string>(headers);
         Body = body;
         ReceiveProperties = receiveProperties;
     }
@@ -108,5 +109,18 @@ public class IncomingMessage
         }
     }
 
+    /// <summary>
+    /// Makes sure that the headers are reset to the exact state as they were when the message was created.
+    /// </summary>
+    internal void RevertToOriginalHeadersIfNeeded()
+    {
+        Headers.Clear();
+        foreach (var header in originalHeaders)
+        {
+            Headers.Add(header.Key, header.Value);
+        }
+    }
+
     ReadOnlyMemory<byte>? originalBody;
+    readonly Dictionary<string, string> originalHeaders;
 }


### PR DESCRIPTION
Closes: #7739
Built off PR: https://github.com/Particular/NServiceBus/pull/7860

### Problem

Mutations made to `IncomingMessage.Headers` during the incoming pipeline leak into the audit copy of the message. Anything that writes to the headers dictionary, e.g., a mutator, custom behavior, or core pipeline steps, mutates the same dictionary instance that `InvokeAuditPipelineBehavior` later snapshots into the `OutgoingMessage` sent to the audit queue.

The result is that the audit queue receives the *processed* headers rather than the headers as they arrived off the transport, so the audited message is not a faithful record of what was received.

`IncomingMessage` already guards against exactly this for the body: `UpdateBody` stashes the original and `RevertToOriginalBodyIfNeeded` restores it before the audit copy is taken. Headers had no equivalent.

### Solution

`IncomingMessage` now captures the headers as they were at construction time and exposes an internal `RevertToOriginalHeadersIfNeeded()` that restores the dictionary to that exact state, reverting changed values, dropping added keys, and reinstating removed ones.

`InvokeAuditPipelineBehavior` calls it alongside the existing `RevertToOriginalBodyIfNeeded()`, immediately before building the `OutgoingMessage`, so the audit copy always reflects the headers as received.

Note that the snapshot is taken *after* `GetOrSetMessageIdFromHeaders` runs, so a message arriving without a `NServiceBus.MessageId` header still gets that header populated from the native ID in the audit copy, matching existing behavior.

### Considerations

- **The allocation**. `IncomingMessage` is constructed once per received message, so this adds a dictionary copy to the receive hot path unconditionally. An alternative is snapshotting at the top of `InvokeAuditPipelineBehavior.Invoke` instead of in the constructor. The audit fork is the only consumer, and it's only active when auditing is enabled.
- `RevertToOriginalHeadersIfNeeded()` method name has no condition, its just a no-op so the name potentially overstates what it does.
- "Fixing" this might lead to unexpected behavioural changes to systems. Audit headers have worked this way for some time. Additionally the audit feature itself adds headers. It may be useful to be able to see headers as they were received and as they were processed, and that will be easier to accomplish once there is some kind of snapshotting dictionary in place, but it will require changes to the audit pipeline in NServiceBus as well as in ServiceControl and ServicePulse.

### Tests

- unit coverage for the three mutation shapes: value changed, key added, key removed.
- acceptance test registering an `IMutateIncomingTransportMessages` that overwrites a header, and asserting the audit spy endpoint observes the original value.