### PR TITLE
Make KeyedServiceCollectionAdapter trimming friendly

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/TrimmabilityWarnings.ApproveTrimmabilityWarnings.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/TrimmabilityWarnings.ApproveTrimmabilityWarnings.approved.txt
@@ -2,9 +2,6 @@ The following trimming warnings are present in NServiceBus.Core.
 Changes that make this list longer should not be approved.
 -----
 
-src/NServiceBus.Core/Hosting/KeyedServices/KeyedServiceCollectionAdapter.cs
-  IL2067: 'instanceType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateFactory(Type, Type[])'. The parameter 'type' of method 'lambda expression' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
-
 src/NServiceBus.Core/Hosting/StartupDiagnostics/Host.cs
   IL2026: Using member 'System.Reflection.Assembly.GetType(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types might be removed by trimming. If the type name is a string literal, consider using Type.GetType instead.
   IL2075: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String, BindingFlags)'. The return value of method 'System.Reflection.Assembly.GetType(String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

--- a/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServiceCollectionAdapter.cs
+++ b/src/NServiceBus.Core/Hosting/KeyedServices/KeyedServiceCollectionAdapter.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -157,7 +158,7 @@ class KeyedServiceCollectionAdapter : IServiceCollection
                         var resultingKey = key is null ? ServiceKey : key as KeyedServiceKey ?? new KeyedServiceKey(key);
                         var keyedProvider = new KeyedServiceProviderAdapter(serviceProvider, resultingKey, this);
                         return descriptor.Lifetime == ServiceLifetime.Singleton ? ActivatorUtilities.CreateInstance(keyedProvider, descriptor.KeyedImplementationType) :
-                            factories.GetOrAdd(descriptor.KeyedImplementationType, type => ActivatorUtilities.CreateFactory(type, Type.EmptyTypes))(keyedProvider, []);
+                            factories.GetOrAdd(new TypeKey { Type = descriptor.KeyedImplementationType }, static typeKey => ActivatorUtilities.CreateFactory(typeKey.Type, Type.EmptyTypes))(keyedProvider, []);
                     }, descriptor.Lifetime);
                 UnsafeAccessor.GetImplementationType(keyedDescriptor) = descriptor.KeyedImplementationType;
             }
@@ -189,7 +190,7 @@ class KeyedServiceCollectionAdapter : IServiceCollection
                         var resultingKey = key is null ? ServiceKey : key as KeyedServiceKey ?? new KeyedServiceKey(key);
                         var keyedProvider = new KeyedServiceProviderAdapter(serviceProvider, resultingKey, this);
                         return descriptor.Lifetime == ServiceLifetime.Singleton ? ActivatorUtilities.CreateInstance(keyedProvider, descriptor.ImplementationType) :
-                            factories.GetOrAdd(descriptor.ImplementationType, type => ActivatorUtilities.CreateFactory(type, Type.EmptyTypes))(keyedProvider, []);
+                            factories.GetOrAdd(new TypeKey { Type = descriptor.ImplementationType }, static typeKey => ActivatorUtilities.CreateFactory(typeKey.Type, Type.EmptyTypes))(keyedProvider, []);
                     }, descriptor.Lifetime);
                 UnsafeAccessor.GetImplementationType(keyedDescriptor) = descriptor.ImplementationType;
             }
@@ -208,7 +209,13 @@ class KeyedServiceCollectionAdapter : IServiceCollection
         public static extern ref Type GetImplementationType(ServiceDescriptor descriptor);
     }
 
+    readonly record struct TypeKey
+    {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+        public Type Type { get; init; }
+    }
+
     readonly List<ServiceDescriptor> originalDescriptors = [];
     readonly List<ServiceDescriptor> keyedDescriptors = [];
-    readonly ConcurrentDictionary<Type, ObjectFactory> factories = new();
+    readonly ConcurrentDictionary<TypeKey, ObjectFactory> factories = new();
 }


### PR DESCRIPTION
This leverages a simple trick by assigning the already annotated Implementation or KeyedImplementation Type to a property that has the same annotations. 