### PR TITLE
Spans for recoverability actions

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/OpenTelemetryAcceptanceTest.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/OpenTelemetryAcceptanceTest.cs
@@ -9,7 +9,7 @@ public abstract class OpenTelemetryAcceptanceTest : NServiceBusAcceptanceTest
     protected TestingActivityListener NServiceBusActivityListener { get; private set; }
 
     [SetUp]
-    public void Setup() => NServiceBusActivityListener = TestingActivityListener.SetupDiagnosticListener("NServiceBus.Core");
+    public void Setup() => NServiceBusActivityListener = TestingActivityListener.SetupDiagnosticListener("NServiceBus.Core", "NServiceBus.Core.Recoverability");
 
     [TearDown]
     public void Cleanup()

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/TestingActivityListener.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/TestingActivityListener.cs
@@ -11,19 +11,19 @@ public class TestingActivityListener : IDisposable
 {
     readonly ActivityListener activityListener;
 
-    public static TestingActivityListener SetupDiagnosticListener(string sourceName)
+    public static TestingActivityListener SetupDiagnosticListener(params string[] sourceNames)
     {
-        var testingListener = new TestingActivityListener(sourceName);
+        var testingListener = new TestingActivityListener(sourceNames);
 
         ActivitySource.AddActivityListener(testingListener.activityListener);
         return testingListener;
     }
 
-    TestingActivityListener(string sourceName = null)
+    TestingActivityListener(params string[] sourceNames)
     {
         activityListener = new ActivityListener
         {
-            ShouldListenTo = source => string.IsNullOrEmpty(sourceName) || source.Name == sourceName,
+            ShouldListenTo = source => sourceNames.Length == 0 || sourceNames.Contains(source.Name),
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
             SampleUsingParentId = (ref ActivityCreationOptions<string> options) => ActivitySamplingResult.AllData
         };
@@ -62,4 +62,5 @@ static class ActivityExtensions
     public static List<Activity> GetSendMessageActivities(this ConcurrentQueue<Activity> activities) => activities.Where(a => a.OperationName == "NServiceBus.Diagnostics.SendMessage").ToList();
     public static List<Activity> GetPublishEventActivities(this ConcurrentQueue<Activity> activities) => activities.Where(a => a.OperationName == "NServiceBus.Diagnostics.PublishMessage").ToList();
     public static List<Activity> GetInvokedHandlerActivities(this ConcurrentQueue<Activity> activities) => activities.Where(a => a.OperationName == "NServiceBus.Diagnostics.InvokeHandler").ToList();
+    public static List<Activity> GetRecoverabilityActivities(this ConcurrentQueue<Activity> activities) => activities.Where(a => a.OperationName == "NServiceBus.Diagnostics.Recoverability").ToList();
 }

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_recoverability_action_occurs.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_recoverability_action_occurs.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry.Traces;
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus.AcceptanceTesting;
@@ -14,15 +15,12 @@ public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
     public async Task Should_create_span_for_immediate_retry()
     {
         await Scenario.Define<Context>()
-            .WithEndpoint<ImmediateRetryEndpoint>(b => b
+            .WithEndpoint<RecoverabilityEndpoint>(b => b
                 .CustomConfig(c => c.Recoverability().Immediate(i => i.NumberOfRetries(1)))
                 .When(s => s.SendLocal(new FailingMessage())))
             .Run();
 
-        var recoverabilityActivities = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities();
-        Assert.That(recoverabilityActivities, Has.Count.EqualTo(1), "only the first (failing) attempt triggers a recoverability decision");
-
-        var activity = recoverabilityActivities.Single();
+        var activity = GetSingleRecoverabilityActivity();
         using (Assert.EnterMultipleScope())
         {
             Assert.That(activity.DisplayName, Is.EqualTo("immediate retry"));
@@ -34,15 +32,14 @@ public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
     public async Task Should_create_span_for_delayed_retry()
     {
         await Scenario.Define<Context>()
-            .WithEndpoint<DelayedRetryEndpoint>(b => b
-                .CustomConfig(c => c.Recoverability().Delayed(i => i.NumberOfRetries(1).TimeIncrease(TimeSpan.FromMilliseconds(1))))
+            .WithEndpoint<RecoverabilityEndpoint>(b => b
+                .CustomConfig(c => c.Recoverability()
+                    .Immediate(i => i.NumberOfRetries(0))
+                    .Delayed(i => i.NumberOfRetries(1).TimeIncrease(TimeSpan.FromMilliseconds(1))))
                 .When(s => s.SendLocal(new FailingMessage())))
             .Run();
 
-        var recoverabilityActivities = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities();
-        Assert.That(recoverabilityActivities, Has.Count.EqualTo(1), "only the first (failing) attempt triggers a recoverability decision");
-
-        var activity = recoverabilityActivities.Single();
+        var activity = GetSingleRecoverabilityActivity();
         using (Assert.EnterMultipleScope())
         {
             Assert.That(activity.DisplayName, Is.EqualTo("delayed retry"));
@@ -54,17 +51,14 @@ public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
     public async Task Should_create_span_for_move_to_error()
     {
         await Scenario.Define<Context>()
-            .WithEndpoint<AlwaysFailingEndpoint>(b => b
+            .WithEndpoint<RecoverabilityEndpoint>(b => b
                 .CustomConfig(c => c.Recoverability().Immediate(i => i.NumberOfRetries(0)).Delayed(i => i.NumberOfRetries(0)))
                 .DoNotFailOnErrorMessages()
                 .When(s => s.SendLocal(new FailingMessage())))
-            .WithEndpoint<ErrorSpy>()
+            .Done(_ => NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities().Count == 1)
             .Run();
 
-        var recoverabilityActivities = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities();
-        Assert.That(recoverabilityActivities, Has.Count.EqualTo(1));
-
-        var activity = recoverabilityActivities.Single();
+        var activity = GetSingleRecoverabilityActivity();
         using (Assert.EnterMultipleScope())
         {
             Assert.That(activity.DisplayName, Does.StartWith("move to "));
@@ -76,14 +70,14 @@ public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
     public async Task Should_create_span_for_discard()
     {
         await Scenario.Define<Context>()
-            .WithEndpoint<DiscardingEndpoint>(b => b
+            .WithEndpoint<RecoverabilityEndpoint>(b => b
+                .CustomConfig(c => c.Recoverability().CustomPolicy((_, _) => RecoverabilityAction.Discard("test discard reason")))
+                .DoNotFailOnErrorMessages()
                 .When(s => s.SendLocal(new FailingMessage())))
+            .Done(_ => NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities().Count == 1)
             .Run();
 
-        var recoverabilityActivities = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities();
-        Assert.That(recoverabilityActivities, Has.Count.EqualTo(1));
-
-        var activity = recoverabilityActivities.Single();
+        var activity = GetSingleRecoverabilityActivity();
         using (Assert.EnterMultipleScope())
         {
             Assert.That(activity.DisplayName, Is.EqualTo("discard"));
@@ -95,17 +89,22 @@ public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
     public async Task Should_include_destination_in_display_name_when_opted_in()
     {
         await Scenario.Define<Context>()
-            .WithEndpoint<ImmediateRetryEndpointWithDestinationNaming>(b => b
-                .CustomConfig(c => c.Recoverability().Immediate(i => i.NumberOfRetries(1)))
+            .WithEndpoint<RecoverabilityEndpoint>(b => b
+                .CustomConfig(c =>
+                {
+                    c.Recoverability().Immediate(i => i.NumberOfRetries(1));
+                    c.Tracing().UseMessageDestinationInSpanNames = true;
+                })
                 .When(s => s.SendLocal(new FailingMessage())))
             .Run();
 
-        var recoverabilityActivities = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities();
-        var activity = recoverabilityActivities.Single();
-
-        var expectedEndpointName = Conventions.EndpointNamingConvention(typeof(ImmediateRetryEndpointWithDestinationNaming));
+        var activity = GetSingleRecoverabilityActivity();
+        var expectedEndpointName = Conventions.EndpointNamingConvention(typeof(RecoverabilityEndpoint));
         Assert.That(activity.DisplayName, Is.EqualTo($"immediate retry {expectedEndpointName}"));
     }
+
+    Activity GetSingleRecoverabilityActivity() =>
+        NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities().Single();
 
     const string ActivityTagName = "nservicebus.recoverability_action";
 
@@ -114,54 +113,9 @@ public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
         public int InvocationCounter { get; set; }
     }
 
-    public class ImmediateRetryEndpoint : EndpointConfigurationBuilder
+    public class RecoverabilityEndpoint : EndpointConfigurationBuilder
     {
-        public ImmediateRetryEndpoint() => EndpointSetup<DefaultServer>();
-
-        [Handler]
-        public class Handler(Context testContext) : IHandleMessages<FailingMessage>
-        {
-            public Task Handle(FailingMessage message, IMessageHandlerContext context)
-            {
-                testContext.InvocationCounter++;
-
-                if (testContext.InvocationCounter == 1)
-                {
-                    throw new SimulatedException("first attempt fails");
-                }
-
-                testContext.MarkAsCompleted();
-                return Task.CompletedTask;
-            }
-        }
-    }
-
-    public class ImmediateRetryEndpointWithDestinationNaming : EndpointConfigurationBuilder
-    {
-        public ImmediateRetryEndpointWithDestinationNaming() =>
-            EndpointSetup<DefaultServer>(b => b.Tracing().UseMessageDestinationInSpanNames = true);
-
-        [Handler]
-        public class Handler(Context testContext) : IHandleMessages<FailingMessage>
-        {
-            public Task Handle(FailingMessage message, IMessageHandlerContext context)
-            {
-                testContext.InvocationCounter++;
-
-                if (testContext.InvocationCounter == 1)
-                {
-                    throw new SimulatedException("first attempt fails");
-                }
-
-                testContext.MarkAsCompleted();
-                return Task.CompletedTask;
-            }
-        }
-    }
-
-    public class DelayedRetryEndpoint : EndpointConfigurationBuilder
-    {
-        public DelayedRetryEndpoint()
+        public RecoverabilityEndpoint()
         {
             var template = new DefaultServer
             {
@@ -185,55 +139,6 @@ public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
                 testContext.MarkAsCompleted();
                 return Task.CompletedTask;
             }
-        }
-    }
-
-    public class AlwaysFailingEndpoint : EndpointConfigurationBuilder
-    {
-        static readonly string ErrorQueueAddress = Conventions.EndpointNamingConvention(typeof(ErrorSpy));
-
-        public AlwaysFailingEndpoint() => EndpointSetup<DefaultServer>(c => c.SendFailedMessagesTo(ErrorQueueAddress));
-
-        [Handler]
-        public class Handler : IHandleMessages<FailingMessage>
-        {
-            public Task Handle(FailingMessage message, IMessageHandlerContext context) => throw new SimulatedException("always fails");
-        }
-    }
-
-    public class ErrorSpy : EndpointConfigurationBuilder
-    {
-        public ErrorSpy() => EndpointSetup<DefaultServer>();
-
-        [Handler]
-        public class Handler(Context testContext) : IHandleMessages<FailingMessage>
-        {
-            public Task Handle(FailingMessage message, IMessageHandlerContext context)
-            {
-                testContext.MarkAsCompleted();
-                return Task.CompletedTask;
-            }
-        }
-    }
-
-    public class DiscardingEndpoint : EndpointConfigurationBuilder
-    {
-        public DiscardingEndpoint() =>
-            EndpointSetup<DefaultServer>((config, context) =>
-            {
-                var testContext = (Context)context.ScenarioContext;
-                config.Recoverability().CustomPolicy((_, _) =>
-                {
-                    var action = RecoverabilityAction.Discard("test discard reason");
-                    testContext.MarkAsCompleted();
-                    return action;
-                });
-            });
-
-        [Handler]
-        public class Handler : IHandleMessages<FailingMessage>
-        {
-            public Task Handle(FailingMessage message, IMessageHandlerContext context) => throw new SimulatedException("always fails");
         }
     }
 

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_recoverability_action_occurs.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_recoverability_action_occurs.cs
@@ -1,0 +1,241 @@
+namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry.Traces;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTesting.Customization;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NUnit.Framework;
+
+public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
+{
+    [Test]
+    public async Task Should_create_span_for_immediate_retry()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<ImmediateRetryEndpoint>(b => b
+                .CustomConfig(c => c.Recoverability().Immediate(i => i.NumberOfRetries(1)))
+                .When(s => s.SendLocal(new FailingMessage())))
+            .Run();
+
+        var recoverabilityActivities = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities();
+        Assert.That(recoverabilityActivities, Has.Count.EqualTo(1), "only the first (failing) attempt triggers a recoverability decision");
+
+        var activity = recoverabilityActivities.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(activity.DisplayName, Is.EqualTo("immediate retry"));
+            Assert.That(activity.GetTagItem(ActivityTagName), Is.EqualTo("immediate_retry"));
+        }
+    }
+
+    [Test]
+    public async Task Should_create_span_for_delayed_retry()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<DelayedRetryEndpoint>(b => b
+                .CustomConfig(c => c.Recoverability().Delayed(i => i.NumberOfRetries(1).TimeIncrease(TimeSpan.FromMilliseconds(1))))
+                .When(s => s.SendLocal(new FailingMessage())))
+            .Run();
+
+        var recoverabilityActivities = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities();
+        Assert.That(recoverabilityActivities, Has.Count.EqualTo(1), "only the first (failing) attempt triggers a recoverability decision");
+
+        var activity = recoverabilityActivities.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(activity.DisplayName, Is.EqualTo("delayed retry"));
+            Assert.That(activity.GetTagItem(ActivityTagName), Is.EqualTo("delayed_retry"));
+        }
+    }
+
+    [Test]
+    public async Task Should_create_span_for_move_to_error()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<AlwaysFailingEndpoint>(b => b
+                .CustomConfig(c => c.Recoverability().Immediate(i => i.NumberOfRetries(0)).Delayed(i => i.NumberOfRetries(0)))
+                .DoNotFailOnErrorMessages()
+                .When(s => s.SendLocal(new FailingMessage())))
+            .WithEndpoint<ErrorSpy>()
+            .Run();
+
+        var recoverabilityActivities = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities();
+        Assert.That(recoverabilityActivities, Has.Count.EqualTo(1));
+
+        var activity = recoverabilityActivities.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(activity.DisplayName, Does.StartWith("move to "));
+            Assert.That(activity.GetTagItem(ActivityTagName), Is.EqualTo("move_to_error"));
+        }
+    }
+
+    [Test]
+    public async Task Should_create_span_for_discard()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<DiscardingEndpoint>(b => b
+                .When(s => s.SendLocal(new FailingMessage())))
+            .Run();
+
+        var recoverabilityActivities = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities();
+        Assert.That(recoverabilityActivities, Has.Count.EqualTo(1));
+
+        var activity = recoverabilityActivities.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(activity.DisplayName, Is.EqualTo("discard"));
+            Assert.That(activity.GetTagItem(ActivityTagName), Is.EqualTo("discard"));
+        }
+    }
+
+    [Test]
+    public async Task Should_include_destination_in_display_name_when_opted_in()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<ImmediateRetryEndpointWithDestinationNaming>(b => b
+                .CustomConfig(c => c.Recoverability().Immediate(i => i.NumberOfRetries(1)))
+                .When(s => s.SendLocal(new FailingMessage())))
+            .Run();
+
+        var recoverabilityActivities = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities();
+        var activity = recoverabilityActivities.Single();
+
+        var expectedEndpointName = Conventions.EndpointNamingConvention(typeof(ImmediateRetryEndpointWithDestinationNaming));
+        Assert.That(activity.DisplayName, Is.EqualTo($"immediate retry {expectedEndpointName}"));
+    }
+
+    const string ActivityTagName = "nservicebus.recoverability_action";
+
+    public class Context : ScenarioContext
+    {
+        public int InvocationCounter { get; set; }
+    }
+
+    public class ImmediateRetryEndpoint : EndpointConfigurationBuilder
+    {
+        public ImmediateRetryEndpoint() => EndpointSetup<DefaultServer>();
+
+        [Handler]
+        public class Handler(Context testContext) : IHandleMessages<FailingMessage>
+        {
+            public Task Handle(FailingMessage message, IMessageHandlerContext context)
+            {
+                testContext.InvocationCounter++;
+
+                if (testContext.InvocationCounter == 1)
+                {
+                    throw new SimulatedException("first attempt fails");
+                }
+
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class ImmediateRetryEndpointWithDestinationNaming : EndpointConfigurationBuilder
+    {
+        public ImmediateRetryEndpointWithDestinationNaming() =>
+            EndpointSetup<DefaultServer>(b => b.Tracing().UseMessageDestinationInSpanNames = true);
+
+        [Handler]
+        public class Handler(Context testContext) : IHandleMessages<FailingMessage>
+        {
+            public Task Handle(FailingMessage message, IMessageHandlerContext context)
+            {
+                testContext.InvocationCounter++;
+
+                if (testContext.InvocationCounter == 1)
+                {
+                    throw new SimulatedException("first attempt fails");
+                }
+
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class DelayedRetryEndpoint : EndpointConfigurationBuilder
+    {
+        public DelayedRetryEndpoint()
+        {
+            var template = new DefaultServer
+            {
+                TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true)
+            };
+            EndpointSetup(template, (c, _) => { }, metadata => { });
+        }
+
+        [Handler]
+        public class Handler(Context testContext) : IHandleMessages<FailingMessage>
+        {
+            public Task Handle(FailingMessage message, IMessageHandlerContext context)
+            {
+                testContext.InvocationCounter++;
+
+                if (testContext.InvocationCounter == 1)
+                {
+                    throw new SimulatedException("first attempt fails");
+                }
+
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class AlwaysFailingEndpoint : EndpointConfigurationBuilder
+    {
+        static readonly string ErrorQueueAddress = Conventions.EndpointNamingConvention(typeof(ErrorSpy));
+
+        public AlwaysFailingEndpoint() => EndpointSetup<DefaultServer>(c => c.SendFailedMessagesTo(ErrorQueueAddress));
+
+        [Handler]
+        public class Handler : IHandleMessages<FailingMessage>
+        {
+            public Task Handle(FailingMessage message, IMessageHandlerContext context) => throw new SimulatedException("always fails");
+        }
+    }
+
+    public class ErrorSpy : EndpointConfigurationBuilder
+    {
+        public ErrorSpy() => EndpointSetup<DefaultServer>();
+
+        [Handler]
+        public class Handler(Context testContext) : IHandleMessages<FailingMessage>
+        {
+            public Task Handle(FailingMessage message, IMessageHandlerContext context)
+            {
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class DiscardingEndpoint : EndpointConfigurationBuilder
+    {
+        public DiscardingEndpoint() =>
+            EndpointSetup<DefaultServer>((config, context) =>
+            {
+                var testContext = (Context)context.ScenarioContext;
+                config.Recoverability().CustomPolicy((_, _) =>
+                {
+                    var action = RecoverabilityAction.Discard("test discard reason");
+                    testContext.MarkAsCompleted();
+                    return action;
+                });
+            });
+
+        [Handler]
+        public class Handler : IHandleMessages<FailingMessage>
+        {
+            public Task Handle(FailingMessage message, IMessageHandlerContext context) => throw new SimulatedException("always fails");
+        }
+    }
+
+    public class FailingMessage : IMessage;
+}

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_recoverability_action_occurs.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_recoverability_action_occurs.cs
@@ -41,10 +41,10 @@ public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
         using (Assert.EnterMultipleScope())
         {
             Assert.That(immediateRetry, Is.Not.Null, "expected at least one immediate retry span");
-            Assert.That(immediateRetry?.DisplayName, Is.EqualTo("immediate retry"));
+            Assert.That(immediateRetry.DisplayName, Is.EqualTo("immediate retry"));
 
             Assert.That(delayedRetry, Is.Not.Null, "expected at least one delayed retry span");
-            Assert.That(delayedRetry?.DisplayName, Is.EqualTo("delayed retry"));
+            Assert.That(delayedRetry.DisplayName, Is.EqualTo("delayed retry"));
 
             Assert.That(moveToError.DisplayName, Does.StartWith("move to "));
             Assert.That(discard.DisplayName, Is.EqualTo("discard"));
@@ -69,8 +69,8 @@ public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
         var immediateRetry = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities()
             .First(a => (string)a.GetTagItem(ActivityTagName) == "immediate_retry");
 
-        var expectedEndpointName = Conventions.EndpointNamingConvention(typeof(RecoverabilityEndpoint));
-        Assert.That(immediateRetry.DisplayName, Is.EqualTo($"immediate retry {expectedEndpointName}"));
+        var endpointName = Conventions.EndpointNamingConvention(typeof(RecoverabilityEndpoint));
+        Assert.That(immediateRetry.DisplayName, Is.EqualTo($"immediate retry {endpointName}"));
     }
 
     string[] ActionTags() =>

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_recoverability_action_occurs.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_recoverability_action_occurs.cs
@@ -1,87 +1,53 @@
 namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry.Traces;
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using NServiceBus.AcceptanceTesting;
-using NServiceBus.AcceptanceTesting.Customization;
-using NServiceBus.AcceptanceTests.EndpointTemplates;
+using AcceptanceTesting;
+using AcceptanceTesting.Customization;
+using EndpointTemplates;
 using NUnit.Framework;
 
 public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
 {
     [Test]
-    public async Task Should_create_span_for_immediate_retry()
-    {
-        await Scenario.Define<Context>()
-            .WithEndpoint<RecoverabilityEndpoint>(b => b
-                .CustomConfig(c => c.Recoverability().Immediate(i => i.NumberOfRetries(1)))
-                .When(s => s.SendLocal(new FailingMessage())))
-            .Run();
-
-        var activity = GetSingleRecoverabilityActivity();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(activity.DisplayName, Is.EqualTo("immediate retry"));
-            Assert.That(activity.GetTagItem(ActivityTagName), Is.EqualTo("immediate_retry"));
-        }
-    }
-
-    [Test]
-    public async Task Should_create_span_for_delayed_retry()
+    public async Task Should_create_spans_for_all_recoverability_actions()
     {
         await Scenario.Define<Context>()
             .WithEndpoint<RecoverabilityEndpoint>(b => b
                 .CustomConfig(c => c.Recoverability()
-                    .Immediate(i => i.NumberOfRetries(0))
-                    .Delayed(i => i.NumberOfRetries(1).TimeIncrease(TimeSpan.FromMilliseconds(1))))
-                .When(s => s.SendLocal(new FailingMessage())))
-            .Run();
-
-        var activity = GetSingleRecoverabilityActivity();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(activity.DisplayName, Is.EqualTo("delayed retry"));
-            Assert.That(activity.GetTagItem(ActivityTagName), Is.EqualTo("delayed_retry"));
-        }
-    }
-
-    [Test]
-    public async Task Should_create_span_for_move_to_error()
-    {
-        await Scenario.Define<Context>()
-            .WithEndpoint<RecoverabilityEndpoint>(b => b
-                .CustomConfig(c => c.Recoverability().Immediate(i => i.NumberOfRetries(0)).Delayed(i => i.NumberOfRetries(0)))
+                    .Immediate(i => i.NumberOfRetries(1))
+                    .Delayed(i => i.NumberOfRetries(1).TimeIncrease(TimeSpan.FromMilliseconds(1)))
+                    .CustomPolicy((cfg, errorContext) =>
+                        errorContext.Headers[Headers.EnclosedMessageTypes].Contains(nameof(DiscardMessage))
+                            ? RecoverabilityAction.Discard("test discard reason")
+                            : DefaultRecoverabilityPolicy.Invoke(cfg, errorContext)))
                 .DoNotFailOnErrorMessages()
-                .When(s => s.SendLocal(new FailingMessage())))
-            .Done(_ => NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities().Count == 1)
+                .When(async s =>
+                {
+                    await s.SendLocal(new FailingMessage());
+                    await s.SendLocal(new DiscardMessage());
+                }))
+            .Done(_ => ActionTags().Contains("move_to_error") && ActionTags().Contains("discard"))
             .Run();
 
-        var activity = GetSingleRecoverabilityActivity();
+        var activities = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities();
+
+        var immediateRetry = activities.FirstOrDefault(a => (string)a.GetTagItem(ActivityTagName) == "immediate_retry");
+        var delayedRetry = activities.FirstOrDefault(a => (string)a.GetTagItem(ActivityTagName) == "delayed_retry");
+        var moveToError = activities.Single(a => (string)a.GetTagItem(ActivityTagName) == "move_to_error");
+        var discard = activities.Single(a => (string)a.GetTagItem(ActivityTagName) == "discard");
+
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(activity.DisplayName, Does.StartWith("move to "));
-            Assert.That(activity.GetTagItem(ActivityTagName), Is.EqualTo("move_to_error"));
-        }
-    }
+            Assert.That(immediateRetry, Is.Not.Null, "expected at least one immediate retry span");
+            Assert.That(immediateRetry?.DisplayName, Is.EqualTo("immediate retry"));
 
-    [Test]
-    public async Task Should_create_span_for_discard()
-    {
-        await Scenario.Define<Context>()
-            .WithEndpoint<RecoverabilityEndpoint>(b => b
-                .CustomConfig(c => c.Recoverability().CustomPolicy((_, _) => RecoverabilityAction.Discard("test discard reason")))
-                .DoNotFailOnErrorMessages()
-                .When(s => s.SendLocal(new FailingMessage())))
-            .Done(_ => NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities().Count == 1)
-            .Run();
+            Assert.That(delayedRetry, Is.Not.Null, "expected at least one delayed retry span");
+            Assert.That(delayedRetry?.DisplayName, Is.EqualTo("delayed retry"));
 
-        var activity = GetSingleRecoverabilityActivity();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(activity.DisplayName, Is.EqualTo("discard"));
-            Assert.That(activity.GetTagItem(ActivityTagName), Is.EqualTo("discard"));
+            Assert.That(moveToError.DisplayName, Does.StartWith("move to "));
+            Assert.That(discard.DisplayName, Is.EqualTo("discard"));
         }
     }
 
@@ -92,26 +58,29 @@ public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
             .WithEndpoint<RecoverabilityEndpoint>(b => b
                 .CustomConfig(c =>
                 {
-                    c.Recoverability().Immediate(i => i.NumberOfRetries(1));
+                    c.Recoverability().Immediate(i => i.NumberOfRetries(1)).Delayed(i => i.NumberOfRetries(0));
                     c.Tracing().UseMessageDestinationInSpanNames = true;
                 })
+                .DoNotFailOnErrorMessages()
                 .When(s => s.SendLocal(new FailingMessage())))
+            .Done(_ => ActionTags().Contains("move_to_error"))
             .Run();
 
-        var activity = GetSingleRecoverabilityActivity();
+        var immediateRetry = NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities()
+            .First(a => (string)a.GetTagItem(ActivityTagName) == "immediate_retry");
+
         var expectedEndpointName = Conventions.EndpointNamingConvention(typeof(RecoverabilityEndpoint));
-        Assert.That(activity.DisplayName, Is.EqualTo($"immediate retry {expectedEndpointName}"));
+        Assert.That(immediateRetry.DisplayName, Is.EqualTo($"immediate retry {expectedEndpointName}"));
     }
 
-    Activity GetSingleRecoverabilityActivity() =>
-        NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities().Single();
+    string[] ActionTags() =>
+        NServiceBusActivityListener.CompletedActivities.GetRecoverabilityActivities()
+            .Select(a => (string)a.GetTagItem(ActivityTagName))
+            .ToArray();
 
     const string ActivityTagName = "nservicebus.recoverability_action";
 
-    public class Context : ScenarioContext
-    {
-        public int InvocationCounter { get; set; }
-    }
+    public class Context : ScenarioContext;
 
     public class RecoverabilityEndpoint : EndpointConfigurationBuilder
     {
@@ -125,22 +94,19 @@ public class When_recoverability_action_occurs : OpenTelemetryAcceptanceTest
         }
 
         [Handler]
-        public class Handler(Context testContext) : IHandleMessages<FailingMessage>
+        public class FailingMessageHandler : IHandleMessages<FailingMessage>
         {
-            public Task Handle(FailingMessage message, IMessageHandlerContext context)
-            {
-                testContext.InvocationCounter++;
+            public Task Handle(FailingMessage message, IMessageHandlerContext context) => throw new SimulatedException("always fails");
+        }
 
-                if (testContext.InvocationCounter == 1)
-                {
-                    throw new SimulatedException("first attempt fails");
-                }
-
-                testContext.MarkAsCompleted();
-                return Task.CompletedTask;
-            }
+        [Handler]
+        public class DiscardMessageHandler : IHandleMessages<DiscardMessage>
+        {
+            public Task Handle(DiscardMessage message, IMessageHandlerContext context) => throw new SimulatedException("always fails");
         }
     }
 
     public class FailingMessage : IMessage;
+
+    public class DiscardMessage : IMessage;
 }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/ActivityTagsTests.Verify_ActivityTags.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/ActivityTagsTests.Verify_ActivityTags.approved.txt
@@ -1,6 +1,6 @@
 {
   "Note": "Changes to activity tags should result in ActivitySource version updates",
-  "ActivitySourceVersion": "0.2.0",
+  "ActivitySourceVersion": "1.0.0",
   "Tags": [
     "SagaId => nservicebus.saga.saga_id",
     "MessageId => nservicebus.message_id",

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/ActivityTagsTests.Verify_ActivityTags.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/ActivityTagsTests.Verify_ActivityTags.approved.txt
@@ -1,6 +1,5 @@
 {
   "Note": "Changes to activity tags should result in ActivitySource version updates",
-  "ActivitySourceVersion": "0.2.0",
   "Tags": [
     "SagaId => nservicebus.saga.saga_id",
     "MessageId => nservicebus.message_id",
@@ -41,5 +40,19 @@
     "CancelledTask => nservicebus.cancelled",
     "ErrorType => error.type",
     "RecoverabilityAction => nservicebus.recoverability_action"
+  ],
+  "ActivitySourceVersions": [
+    {
+      "Name": "Main",
+      "Version": "0.1.0"
+    },
+    {
+      "Name": "Handler",
+      "Version": "0.1.0"
+    },
+    {
+      "Name": "Recoverability",
+      "Version": "0.1.0"
+    }
   ]
 }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/ActivityTagsTests.Verify_ActivityTags.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/ActivityTagsTests.Verify_ActivityTags.approved.txt
@@ -1,6 +1,6 @@
 {
   "Note": "Changes to activity tags should result in ActivitySource version updates",
-  "ActivitySourceVersion": "0.1.0",
+  "ActivitySourceVersion": "0.2.0",
   "Tags": [
     "SagaId => nservicebus.saga.saga_id",
     "MessageId => nservicebus.message_id",
@@ -40,5 +40,6 @@
     "EventTypes => nservicebus.event_types",
     "CancelledTask => nservicebus.cancelled",
     "ErrorType => error.type"
+    "RecoverabilityAction => nservicebus.recoverability_action"
   ]
 }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/ActivityTagsTests.Verify_ActivityTags.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/ActivityTagsTests.Verify_ActivityTags.approved.txt
@@ -1,6 +1,6 @@
 {
   "Note": "Changes to activity tags should result in ActivitySource version updates",
-  "ActivitySourceVersion": "1.0.0",
+  "ActivitySourceVersion": "0.2.0",
   "Tags": [
     "SagaId => nservicebus.saga.saga_id",
     "MessageId => nservicebus.message_id",
@@ -39,7 +39,7 @@
     "HandlerSagaId => nservicebus.handler.saga_id",
     "EventTypes => nservicebus.event_types",
     "CancelledTask => nservicebus.cancelled",
-    "ErrorType => error.type"
+    "ErrorType => error.type",
     "RecoverabilityAction => nservicebus.recoverability_action"
   ]
 }

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityTagsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityTagsTests.cs
@@ -14,14 +14,17 @@ public class ActivityTagsTests
         var activityTags = typeof(ActivityTags)
             .GetFields(BindingFlags.Public | BindingFlags.Static)
             .Where(fi => fi.IsLiteral && !fi.IsInitOnly)
-            .Select(x => $"{x.Name} => {x.GetRawConstantValue()}")
-            .ToList();
+            .Select(x => $"{x.Name} => {x.GetRawConstantValue()}");
 
         Approver.Verify(new
         {
             Note = "Changes to activity tags should result in ActivitySource version updates",
-            ActivitySourceVersion = ActivitySources.Main.Version,
-            Tags = activityTags
-        });
+            Tags = activityTags,
+            ActivitySourceVersions = new[]
+            {
+                new { Name = nameof(ActivitySources.Main), ActivitySources.Main.Version },
+                new { Name = nameof(ActivitySources.Handler), ActivitySources.Handler.Version },
+                new { Name = nameof(ActivitySources.Recoverability), ActivitySources.Recoverability.Version }
+            }});
     }
 }

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityTagsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityTagsTests.cs
@@ -25,6 +25,7 @@ public class ActivityTagsTests
                 new { Name = nameof(ActivitySources.Main), ActivitySources.Main.Version },
                 new { Name = nameof(ActivitySources.Handler), ActivitySources.Handler.Version },
                 new { Name = nameof(ActivitySources.Recoverability), ActivitySources.Recoverability.Version }
-            }});
+            }
+        });
     }
 }

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -67,10 +67,13 @@ public class RecoverabilityExecutorTests
             new ServiceCollection().BuildServiceProvider(), // TODO: Does not get disposed
             new ThrowingPipelineCache(),
             new TestableMessageOperations(),
-            null, (_, _) => RecoverabilityAction.Discard("test"),
+            null,
+            (_, _) => RecoverabilityAction.Discard("test"),
             recoverabilityPipeline,
             new FaultMetadataExtractor([], _ => { }),
-            null);
+            null,
+            NoOpActivityFactory.Instance
+            );
         return executor;
     }
 

--- a/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
@@ -17,7 +17,7 @@ public class RoutingToDispatchConnectorTests
     [Test]
     public async Task Should_preserve_message_state_for_one_routing_strategy_for_allocation_reasons()
     {
-        var behavior = new RoutingToDispatchConnector(new NoOpActivityFactory());
+        var behavior = new RoutingToDispatchConnector(NoOpActivityFactory.Instance);
         IEnumerable<TransportOperation> operations = null;
         var testableRoutingContext = new TestableRoutingContext
         {
@@ -59,7 +59,7 @@ public class RoutingToDispatchConnectorTests
     [Test]
     public async Task Should_copy_message_state_for_multiple_routing_strategies()
     {
-        var behavior = new RoutingToDispatchConnector(new NoOpActivityFactory());
+        var behavior = new RoutingToDispatchConnector(NoOpActivityFactory.Instance);
         List<TransportOperation> operations = null;
         var testableRoutingContext = new TestableRoutingContext
         {
@@ -135,7 +135,7 @@ public class RoutingToDispatchConnectorTests
     [Test]
     public async Task Should_preserve_headers_generated_by_custom_routing_strategy()
     {
-        var behavior = new RoutingToDispatchConnector(new NoOpActivityFactory());
+        var behavior = new RoutingToDispatchConnector(NoOpActivityFactory.Instance);
         Dictionary<string, string> headers = null;
         await behavior.Invoke(new TestableRoutingContext { RoutingStrategies = [new HeaderModifyingRoutingStrategy()] }, context =>
             {
@@ -153,7 +153,7 @@ public class RoutingToDispatchConnectorTests
         options.RequireImmediateDispatch();
 
         var dispatched = false;
-        var behavior = new RoutingToDispatchConnector(new NoOpActivityFactory());
+        var behavior = new RoutingToDispatchConnector(NoOpActivityFactory.Instance);
         var message = new OutgoingMessage("ID", [], Array.Empty<byte>());
 
         await behavior.Invoke(new RoutingContext(message,
@@ -170,7 +170,7 @@ public class RoutingToDispatchConnectorTests
     public async Task Should_dispatch_immediately_if_not_sending_from_a_handler()
     {
         var dispatched = false;
-        var behavior = new RoutingToDispatchConnector(new NoOpActivityFactory());
+        var behavior = new RoutingToDispatchConnector(NoOpActivityFactory.Instance);
         var message = new OutgoingMessage("ID", [], Array.Empty<byte>());
 
         await behavior.Invoke(new RoutingContext(message,
@@ -187,7 +187,7 @@ public class RoutingToDispatchConnectorTests
     public async Task Should_not_dispatch_by_default()
     {
         var dispatched = false;
-        var behavior = new RoutingToDispatchConnector(new NoOpActivityFactory());
+        var behavior = new RoutingToDispatchConnector(NoOpActivityFactory.Instance);
         var message = new OutgoingMessage("ID", [], Array.Empty<byte>());
 
         await behavior.Invoke(new RoutingContext(message,
@@ -203,7 +203,7 @@ public class RoutingToDispatchConnectorTests
     [Test]
     public async Task Should_promote_message_headers_to_pipeline_activity()
     {
-        var behavior = new RoutingToDispatchConnector(new NoOpActivityFactory());
+        var behavior = new RoutingToDispatchConnector(NoOpActivityFactory.Instance);
         var routingContext = new TestableRoutingContext();
         routingContext.Message.Headers[Headers.ContentType] = "test content type"; // one of the headers that will be mapped to tags
 
@@ -257,7 +257,7 @@ public class RoutingToDispatchConnectorTests
     [Test]
     public async Task Should_merge_receive_properties_when_declared_by_transport()
     {
-        var behavior = new RoutingToDispatchConnector(new NoOpActivityFactory());
+        var behavior = new RoutingToDispatchConnector(NoOpActivityFactory.Instance);
 
         var receiveProperties = new ReceiveProperties(new Dictionary<string, string>
         {
@@ -290,7 +290,7 @@ public class RoutingToDispatchConnectorTests
     [Test]
     public async Task Should_not_override_user_set_dispatch_property()
     {
-        var behavior = new RoutingToDispatchConnector(new NoOpActivityFactory());
+        var behavior = new RoutingToDispatchConnector(NoOpActivityFactory.Instance);
 
         var receiveProperties = new ReceiveProperties(new Dictionary<string, string>
         {
@@ -324,7 +324,7 @@ public class RoutingToDispatchConnectorTests
     [Test]
     public async Task Should_preserve_user_dispatch_properties_even_with_receive_properties()
     {
-        var behavior = new RoutingToDispatchConnector(new NoOpActivityFactory());
+        var behavior = new RoutingToDispatchConnector(NoOpActivityFactory.Instance);
 
         var receiveProperties = new ReceiveProperties(new Dictionary<string, string>
         {

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersConnectorTests.cs
@@ -16,7 +16,7 @@ public class LoadHandlersConnectorTests
     [Test]
     public void Should_throw_when_there_are_no_registered_message_handlers()
     {
-        var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(), new NoOpActivityFactory());
+        var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(), NoOpActivityFactory.Instance);
 
         var context = new TestableIncomingLogicalMessageContext();
 
@@ -29,7 +29,7 @@ public class LoadHandlersConnectorTests
     [Test]
     public void Should_throw_if_ambient_transaction_is_different_from_scope_used_by_transport()
     {
-        var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(), new NoOpActivityFactory());
+        var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(), NoOpActivityFactory.Instance);
 
         var context = new TestableIncomingLogicalMessageContext();
 
@@ -49,7 +49,7 @@ public class LoadHandlersConnectorTests
     [Test]
     public void Should_throw_if_ambient_transaction_suppressed_when_transport_uses_a_scope()
     {
-        var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(), new NoOpActivityFactory());
+        var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(), NoOpActivityFactory.Instance);
 
         var context = new TestableIncomingLogicalMessageContext();
 
@@ -77,7 +77,7 @@ public class LoadHandlersConnectorTests
         context.Services.AddSingleton<FakeHandler>();
         context.Extensions.Set<IOutboxTransaction>(new NoOpOutboxTransaction());
 
-        var behavior = new LoadHandlersConnector(messageHandlerRegistry, new NoOpActivityFactory());
+        var behavior = new LoadHandlersConnector(messageHandlerRegistry, NoOpActivityFactory.Instance);
 
         using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
         {

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityDisplayNames.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityDisplayNames.cs
@@ -10,6 +10,7 @@ static class ActivityDisplayNames
     public const string UnsubscribeEvent = "unsubscribe event";
     public const string SendMessage = "send message";
     public const string ReplyMessage = "reply";
+    public const string Recoverability = "recoverability";
 
     // Operation-only prefixes used when UseMessageDestinationInSpanNames is enabled
     internal const string ProcessOperation = "process";

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityDisplayNames.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityDisplayNames.cs
@@ -17,7 +17,7 @@ static class ActivityDisplayNames
     internal const string PublishOperation = "publish";
     internal const string SendOperation = "send";
     internal const string ImmediateRetryOperation = "immediate retry";
-    internal const string DelayedRetryOperation = "dealyed retry";
+    internal const string DelayedRetryOperation = "delayed retry";
     internal const string MoveToErrorOperation = "move to";
     internal const string DiscardOperation = "discard";
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityDisplayNames.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityDisplayNames.cs
@@ -10,10 +10,14 @@ static class ActivityDisplayNames
     public const string UnsubscribeEvent = "unsubscribe event";
     public const string SendMessage = "send message";
     public const string ReplyMessage = "reply";
-    public const string Recoverability = "recoverability";
+    public const string Recoverability = "recover";
 
     // Operation-only prefixes used when UseMessageDestinationInSpanNames is enabled
     internal const string ProcessOperation = "process";
     internal const string PublishOperation = "publish";
     internal const string SendOperation = "send";
+    internal const string ImmediateRetryOperation = "immediate retry";
+    internal const string DelayedRetryOperation = "dealyed retry";
+    internal const string MoveToErrorOperation = "move to";
+    internal const string DiscardOperation = "discard";
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
@@ -189,9 +189,7 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
 
         ContextPropagation.PropagateContextFromHeaders(activity, context.Headers);
 
-        activity.DisplayName = Options.UseMessageDestinationInSpanNames
-            ? $"{ActivityDisplayNames.ProcessOperation} {context.ReceiveAddress}"
-            : ActivityDisplayNames.ProcessMessage;
+        activity.DisplayName = $"{ActivityDisplayNames.Recoverability} {context.ReceiveAddress}";
         activity.SetIdFormat(ActivityIdFormat.W3C);
         activity.AddTag(ActivityTags.NativeMessageId, context.NativeMessageId);
 

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
@@ -123,4 +123,82 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
         activity.AddTag(ActivityTags.HandlerType, messageHandler.HandlerType.FullName);
         return activity;
     }
+
+    public Activity? StartRecoverabilityActivity(ErrorContext context)
+    {
+        // CreateActivity is a no-op if there are no listeners but we are doing a fast path check
+        // here nonetheless to avoid having to parse headers, access the extension bag, etc.
+        if (!ActivitySources.Main.HasListeners())
+        {
+            return null;
+        }
+
+        Activity? activity;
+        var incomingTraceParentExists = context.Headers.TryGetValue(Headers.DiagnosticsTraceParent, out var sendSpanId);
+        var activityContextCreatedFromIncomingTraceParent = ActivityContext.TryParse(sendSpanId, null, out var sendSpanContext);
+
+        ActivityKind activityKind = ActivityKind.Consumer;
+
+        if (context.Extensions.TryGet<Activity>(out var transportActivity)) // attach to transport span but link receive pipeline span to send pipeline span
+        {
+            ActivityLink[]? links = null;
+            if (incomingTraceParentExists && sendSpanId != transportActivity.Id)
+            {
+                if (activityContextCreatedFromIncomingTraceParent)
+                {
+                    links = [new ActivityLink(sendSpanContext)];
+                }
+            }
+
+            activity = ActivitySources.Main.CreateActivity(
+                name: ActivityNames.RecoverabilityActivityName,
+                activityKind,
+                transportActivity.Context,
+                links: links,
+                idFormat: ActivityIdFormat.W3C
+                );
+        }
+        else if (incomingTraceParentExists && activityContextCreatedFromIncomingTraceParent) // otherwise directly create child from logical send
+        {
+            var isStartNewTraceHeaderAvailable = context.Headers.TryGetValue(Headers.StartNewTrace, out var shouldStartNewTrace);
+            if (isStartNewTraceHeaderAvailable && shouldStartNewTrace?.Equals(bool.TrueString) is true)
+            {
+                // create a new trace or root activity
+                ActivityLink[] links = [new ActivityLink(sendSpanContext)];
+                //null the current activity so that the new one is created as root https://github.com/dotnet/runtime/issues/65528#issuecomment-2613486896
+                Activity.Current = null;
+                activity = ActivitySources.Main.StartActivity(name: ActivityNames.RecoverabilityActivityName, activityKind, parentContext: default, tags: null, links: links);
+            }
+            else
+            {
+                // no new trace was requested, so start a child trace
+                ActivityContext.TryParse(sendSpanId, null, true, out var remoteParentActivityContext);
+                activity = ActivitySources.Main.CreateActivity(name: ActivityNames.RecoverabilityActivityName, activityKind, remoteParentActivityContext);
+            }
+        }
+        else // otherwise start new trace
+        {
+            // This will set Activity.Current as parent if available
+            activity = ActivitySources.Main.CreateActivity(name: ActivityNames.RecoverabilityActivityName, activityKind);
+        }
+
+        if (activity is null)
+        {
+            return activity;
+        }
+
+        ContextPropagation.PropagateContextFromHeaders(activity, context.Headers);
+
+        activity.DisplayName = Options.UseMessageDestinationInSpanNames
+            ? $"{ActivityDisplayNames.ProcessOperation} {context.ReceiveAddress}"
+            : ActivityDisplayNames.ProcessMessage;
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        activity.AddTag(ActivityTags.NativeMessageId, context.NativeMessageId);
+
+        ActivityDecorator.PromoteHeadersToTags(activity, context.Headers);
+
+        activity.Start();
+
+        return activity;
+    }
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
@@ -2,7 +2,9 @@
 
 namespace NServiceBus;
 
+using System.Collections.Generic;
 using System.Diagnostics;
+using Extensibility;
 using Pipeline;
 using Transport;
 
@@ -10,7 +12,7 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
 {
     public InstrumentationOptions Options { get; } = options;
 
-    public Activity? StartIncomingPipelineActivity(MessageContext context)
+    static Activity? CreateActivityFromIncomingMessage(ActivitySource activitySource, string activityName, Dictionary<string, string> headers, ContextBag extensions)
     {
         // CreateActivity is a no-op if there are no listeners but we are doing a fast path check
         // here nonetheless to avoid having to parse headers, access the extension bag, etc.
@@ -20,10 +22,10 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
         }
 
         Activity? activity;
-        var incomingTraceParentExists = context.Headers.TryGetValue(Headers.DiagnosticsTraceParent, out var sendSpanId);
+        var incomingTraceParentExists = headers.TryGetValue(Headers.DiagnosticsTraceParent, out var sendSpanId);
         var activityContextCreatedFromIncomingTraceParent = ActivityContext.TryParse(sendSpanId, null, out var sendSpanContext);
 
-        if (context.Extensions.TryGet<Activity>(out var transportActivity)) // attach to transport span but link receive pipeline span to send pipeline span
+        if (extensions.TryGet<Activity>(out var transportActivity)) // attach to transport span but link receive pipeline span to send pipeline span
         {
             ActivityLink[]? links = null;
             if (incomingTraceParentExists && sendSpanId != transportActivity.Id)
@@ -34,31 +36,31 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
                 }
             }
 
-            activity = ActivitySources.Main.CreateActivity(name: ActivityNames.IncomingMessageActivityName,
+            activity = activitySource.CreateActivity(name: activityName,
                 ActivityKind.Consumer, transportActivity.Context, links: links, idFormat: ActivityIdFormat.W3C);
         }
         else if (incomingTraceParentExists && activityContextCreatedFromIncomingTraceParent) // otherwise directly create child from logical send
         {
-            var isStartNewTraceHeaderAvailable = context.Headers.TryGetValue(Headers.StartNewTrace, out var shouldStartNewTrace);
+            var isStartNewTraceHeaderAvailable = headers.TryGetValue(Headers.StartNewTrace, out var shouldStartNewTrace);
             if (isStartNewTraceHeaderAvailable && shouldStartNewTrace?.Equals(bool.TrueString) is true)
             {
                 // create a new trace or root activity
-                ActivityLink[] links = [new ActivityLink(sendSpanContext)];
+                ActivityLink[] links = [new(sendSpanContext)];
                 //null the current activity so that the new one is created as root https://github.com/dotnet/runtime/issues/65528#issuecomment-2613486896
                 Activity.Current = null;
-                activity = ActivitySources.Main.StartActivity(name: ActivityNames.IncomingMessageActivityName, ActivityKind.Consumer, parentContext: default, tags: null, links: links);
+                activity = activitySource.StartActivity(name: activityName, ActivityKind.Consumer, parentContext: default, tags: null, links: links);
             }
             else
             {
                 // no new trace was requested, so start a child trace
                 ActivityContext.TryParse(sendSpanId, null, true, out var remoteParentActivityContext);
-                activity = ActivitySources.Main.CreateActivity(name: ActivityNames.IncomingMessageActivityName, ActivityKind.Consumer, remoteParentActivityContext);
+                activity = activitySource.CreateActivity(name: activityName, ActivityKind.Consumer, remoteParentActivityContext);
             }
         }
-        else // otherwise start new trace
+        else // otherwise start a new trace
         {
             // This will set Activity.Current as parent if available
-            activity = ActivitySources.Main.CreateActivity(name: ActivityNames.IncomingMessageActivityName, ActivityKind.Consumer);
+            activity = activitySource.CreateActivity(name: activityName, ActivityKind.Consumer);
         }
 
         if (activity is null)
@@ -66,7 +68,18 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
             return activity;
         }
 
-        ContextPropagation.PropagateContextFromHeaders(activity, context.Headers);
+        ContextPropagation.PropagateContextFromHeaders(activity, headers);
+
+        return activity;
+    }
+
+    public Activity? StartIncomingPipelineActivity(MessageContext context)
+    {
+        var activity = CreateActivityFromIncomingMessage(ActivitySources.Main, ActivityNames.IncomingMessageActivityName, context.Headers, context.Extensions);
+        if (activity is null)
+        {
+            return activity;
+        }
 
         activity.DisplayName = Options.UseMessageDestinationInSpanNames
             ? $"{ActivityDisplayNames.ProcessOperation} {context.ReceiveAddress}"
@@ -126,70 +139,13 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
 
     public Activity? StartRecoverabilityActivity(ErrorContext context)
     {
-        // CreateActivity is a no-op if there are no listeners but we are doing a fast path check
-        // here nonetheless to avoid having to parse headers, access the extension bag, etc.
-        if (!ActivitySources.Main.HasListeners())
-        {
-            return null;
-        }
-
-        Activity? activity;
-        var incomingTraceParentExists = context.Headers.TryGetValue(Headers.DiagnosticsTraceParent, out var sendSpanId);
-        var activityContextCreatedFromIncomingTraceParent = ActivityContext.TryParse(sendSpanId, null, out var sendSpanContext);
-
-        ActivityKind activityKind = ActivityKind.Consumer;
-
-        if (context.Extensions.TryGet<Activity>(out var transportActivity)) // attach to transport span but link receive pipeline span to send pipeline span
-        {
-            ActivityLink[]? links = null;
-            if (incomingTraceParentExists && sendSpanId != transportActivity.Id)
-            {
-                if (activityContextCreatedFromIncomingTraceParent)
-                {
-                    links = [new ActivityLink(sendSpanContext)];
-                }
-            }
-
-            activity = ActivitySources.Main.CreateActivity(
-                name: ActivityNames.RecoverabilityActivityName,
-                activityKind,
-                transportActivity.Context,
-                links: links,
-                idFormat: ActivityIdFormat.W3C
-                );
-        }
-        else if (incomingTraceParentExists && activityContextCreatedFromIncomingTraceParent) // otherwise directly create child from logical send
-        {
-            var isStartNewTraceHeaderAvailable = context.Headers.TryGetValue(Headers.StartNewTrace, out var shouldStartNewTrace);
-            if (isStartNewTraceHeaderAvailable && shouldStartNewTrace?.Equals(bool.TrueString) is true)
-            {
-                // create a new trace or root activity
-                ActivityLink[] links = [new ActivityLink(sendSpanContext)];
-                //null the current activity so that the new one is created as root https://github.com/dotnet/runtime/issues/65528#issuecomment-2613486896
-                Activity.Current = null;
-                activity = ActivitySources.Main.StartActivity(name: ActivityNames.RecoverabilityActivityName, activityKind, parentContext: default, tags: null, links: links);
-            }
-            else
-            {
-                // no new trace was requested, so start a child trace
-                ActivityContext.TryParse(sendSpanId, null, true, out var remoteParentActivityContext);
-                activity = ActivitySources.Main.CreateActivity(name: ActivityNames.RecoverabilityActivityName, activityKind, remoteParentActivityContext);
-            }
-        }
-        else // otherwise start new trace
-        {
-            // This will set Activity.Current as parent if available
-            activity = ActivitySources.Main.CreateActivity(name: ActivityNames.RecoverabilityActivityName, activityKind);
-        }
-
+        var activity = CreateActivityFromIncomingMessage(ActivitySources.Recoverability, ActivityNames.RecoverabilityActivityName, context.Headers, context.Extensions);
         if (activity is null)
         {
             return activity;
         }
 
-        ContextPropagation.PropagateContextFromHeaders(activity, context.Headers);
-
-        activity.DisplayName = $"{ActivityDisplayNames.Recoverability} {context.ReceiveAddress}";
+        activity.DisplayName = ActivityDisplayNames.Recoverability;
         activity.SetIdFormat(ActivityIdFormat.W3C);
         activity.AddTag(ActivityTags.NativeMessageId, context.NativeMessageId);
 
@@ -198,5 +154,42 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
         activity.Start();
 
         return activity;
+    }
+
+    public void UpdateActivityFromRecoverabilityAction(Activity activity, RecoverabilityAction recoverabilityAction, string receiveAddress)
+    {
+        if (recoverabilityAction is ImmediateRetry)
+        {
+            activity.AddTag(ActivityTags.RecoverabilityAction, "immediate_retry");
+            activity.DisplayName = ActivityDisplayNames.ImmediateRetryOperation;
+
+            if (Options.UseMessageDestinationInSpanNames)
+            {
+                activity.DisplayName += $" {receiveAddress}";
+            }
+        }
+        else if (recoverabilityAction is DelayedRetry)
+        {
+            activity.AddTag(ActivityTags.RecoverabilityAction, "delayed_retry");
+            activity.DisplayName = ActivityDisplayNames.DelayedRetryOperation;
+
+            if (Options.UseMessageDestinationInSpanNames)
+            {
+                activity.DisplayName += $" {receiveAddress}";
+            }
+        }
+        else if (recoverabilityAction is MoveToError moveToError)
+        {
+            activity.AddTag(ActivityTags.RecoverabilityAction, "move_to_error");
+
+            activity.DisplayName = Options.UseMessageDestinationInSpanNames
+                ? $"{ActivityDisplayNames.MoveToErrorOperation} {moveToError.ErrorQueue}"
+                : $"{ActivityDisplayNames.MoveToErrorOperation} error";
+        }
+        else if (recoverabilityAction is Discard)
+        {
+            activity.AddTag(ActivityTags.RecoverabilityAction, "discard");
+            activity.DisplayName = ActivityDisplayNames.DiscardOperation;
+        }
     }
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
@@ -16,7 +16,7 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
     {
         // CreateActivity is a no-op if there are no listeners but we are doing a fast path check
         // here nonetheless to avoid having to parse headers, access the extension bag, etc.
-        if (!ActivitySources.Main.HasListeners())
+        if (!activitySource.HasListeners())
         {
             return null;
         }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
@@ -12,7 +12,7 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
 {
     public InstrumentationOptions Options { get; } = options;
 
-    static Activity? CreateActivityFromIncomingMessage(ActivitySource activitySource, string activityName, Dictionary<string, string> headers, ContextBag extensions)
+    static Activity? CreateActivityFromIncomingMessage(ActivitySource activitySource, string activityName, Dictionary<string, string> headers, string nativeMessageId, ContextBag extensions)
     {
         // CreateActivity is a no-op if there are no listeners but we are doing a fast path check
         // here nonetheless to avoid having to parse headers, access the extension bag, etc.
@@ -70,12 +70,23 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
 
         ContextPropagation.PropagateContextFromHeaders(activity, headers);
 
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        activity.AddTag(ActivityTags.NativeMessageId, nativeMessageId);
+
+        ActivityDecorator.PromoteHeadersToTags(activity, headers);
+
         return activity;
     }
 
     public Activity? StartIncomingPipelineActivity(MessageContext context)
     {
-        var activity = CreateActivityFromIncomingMessage(ActivitySources.Main, ActivityNames.IncomingMessageActivityName, context.Headers, context.Extensions);
+        var activity = CreateActivityFromIncomingMessage(
+            ActivitySources.Main,
+            ActivityNames.IncomingMessageActivityName,
+            context.Headers,
+            context.NativeMessageId,
+            context.Extensions);
+
         if (activity is null)
         {
             return activity;
@@ -84,10 +95,6 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
         activity.DisplayName = Options.UseMessageDestinationInSpanNames
             ? $"{ActivityDisplayNames.ProcessOperation} {context.ReceiveAddress}"
             : ActivityDisplayNames.ProcessMessage;
-        activity.SetIdFormat(ActivityIdFormat.W3C);
-        activity.AddTag(ActivityTags.NativeMessageId, context.NativeMessageId);
-
-        ActivityDecorator.PromoteHeadersToTags(activity, context.Headers);
 
         activity.Start();
 
@@ -139,17 +146,19 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
 
     public Activity? StartRecoverabilityActivity(ErrorContext context)
     {
-        var activity = CreateActivityFromIncomingMessage(ActivitySources.Recoverability, ActivityNames.RecoverabilityActivityName, context.Headers, context.Extensions);
+        var activity = CreateActivityFromIncomingMessage(
+            ActivitySources.Recoverability,
+            ActivityNames.RecoverabilityActivityName,
+            context.Headers,
+            context.NativeMessageId,
+            context.Extensions);
+
         if (activity is null)
         {
             return activity;
         }
 
         activity.DisplayName = ActivityDisplayNames.Recoverability;
-        activity.SetIdFormat(ActivityIdFormat.W3C);
-        activity.AddTag(ActivityTags.NativeMessageId, context.NativeMessageId);
-
-        ActivityDecorator.PromoteHeadersToTags(activity, context.Headers);
 
         activity.Start();
 

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityNames.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityNames.cs
@@ -10,4 +10,5 @@ static class ActivityNames
     public const string SubscribeActivityName = "NServiceBus.Diagnostics.Subscribe";
     public const string UnsubscribeActivityName = "NServiceBus.Diagnostics.Unsubscribe";
     public const string InvokeHandlerActivityName = "NServiceBus.Diagnostics.InvokeHandler";
+    public const string RecoverabilityActivityName = "NServiceBus.Diagnostics.Recoverability";
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivitySources.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivitySources.cs
@@ -8,7 +8,7 @@ static class ActivitySources
 {
     public static readonly ActivitySource Main =
         new("NServiceBus.Core",
-            "0.1.0");
+            "0.2.0");
 
     public static readonly ActivitySource Handler =
         new("NServiceBus.Core.Handler",

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivitySources.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivitySources.cs
@@ -13,4 +13,8 @@ static class ActivitySources
     public static readonly ActivitySource Handler =
         new("NServiceBus.Core.Handler",
             "0.1.0");
+
+    public static readonly ActivitySource Recoverability =
+        new("NServiceBus.Core.Recoverability",
+            "0.1.0");
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivitySources.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivitySources.cs
@@ -8,7 +8,7 @@ static class ActivitySources
 {
     public static readonly ActivitySource Main =
         new("NServiceBus.Core",
-            "0.2.0");
+            "0.1.0");
 
     public static readonly ActivitySource Handler =
         new("NServiceBus.Core.Handler",

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityTags.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityTags.cs
@@ -42,4 +42,5 @@ static class ActivityTags
     public const string EventTypes = "nservicebus.event_types";
     public const string CancelledTask = "nservicebus.cancelled";
     public const string ErrorType = "error.type";
+    public const string RecoverabilityAction = "nservicebus.recoverability_action";
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/IActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/IActivityFactory.cs
@@ -12,4 +12,5 @@ interface IActivityFactory
     Activity? StartIncomingPipelineActivity(MessageContext context);
     Activity? StartOutgoingPipelineActivity(string activityName, string displayName, IBehaviorContext outgoingContext);
     Activity? StartHandlerActivity(MessageHandler messageHandler);
+    Activity? StartRecoverabilityActivity(ErrorContext context);
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/IActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/IActivityFactory.cs
@@ -13,4 +13,5 @@ interface IActivityFactory
     Activity? StartOutgoingPipelineActivity(string activityName, string displayName, IBehaviorContext outgoingContext);
     Activity? StartHandlerActivity(MessageHandler messageHandler);
     Activity? StartRecoverabilityActivity(ErrorContext context);
+    void UpdateActivityFromRecoverabilityAction(Activity activity, RecoverabilityAction recoverabilityAction, string receiveAddress);
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/NoOpActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/NoOpActivityFactory.cs
@@ -8,11 +8,13 @@ using Transport;
 
 sealed class NoOpActivityFactory : IActivityFactory
 {
-    public InstrumentationOptions Options { get; } = new InstrumentationOptions();
+    public static NoOpActivityFactory Instance = new();
+    public InstrumentationOptions Options { get; } = new();
 
     public Activity? StartIncomingPipelineActivity(MessageContext context) => null;
 
     public Activity? StartOutgoingPipelineActivity(string activityName, string displayName, IBehaviorContext outgoingContext) => null;
 
     public Activity? StartHandlerActivity(MessageHandler messageHandler) => null;
+    public Activity? StartRecoverabilityActivity(ErrorContext context) => null;
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/NoOpActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/NoOpActivityFactory.cs
@@ -8,7 +8,8 @@ using Transport;
 
 sealed class NoOpActivityFactory : IActivityFactory
 {
-    public static NoOpActivityFactory Instance = new();
+    NoOpActivityFactory() { }
+    public static readonly NoOpActivityFactory Instance = new();
     public InstrumentationOptions Options { get; } = new();
 
     public Activity? StartIncomingPipelineActivity(MessageContext context) => null;

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/NoOpActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/NoOpActivityFactory.cs
@@ -18,4 +18,7 @@ sealed class NoOpActivityFactory : IActivityFactory
 
     public Activity? StartHandlerActivity(MessageHandler messageHandler) => null;
     public Activity? StartRecoverabilityActivity(ErrorContext context) => null;
+    public void UpdateActivityFromRecoverabilityAction(Activity activity, RecoverabilityAction recoverabilityAction, string receiveAddress)
+    {
+    }
 }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -180,7 +180,9 @@ partial class ReceiveComponent
             builder,
             pipelineCache,
             pipelineComponent,
-            messageOperations);
+            messageOperations,
+            activityFactory
+            );
 
         await mainPump.Initialize(
             configuration.PushRuntimeSettings,

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
@@ -74,7 +74,8 @@ class RecoverabilityComponent
         IServiceProvider serviceProvider,
         IPipelineCache pipelineCache,
         PipelineComponent pipeline,
-        MessageOperations messageOperations)
+        MessageOperations messageOperations,
+        IActivityFactory activityFactory)
     {
         ArgumentNullException.ThrowIfNull(recoverabilityConfig);
         ArgumentNullException.ThrowIfNull(faultMetadataExtractor);
@@ -103,7 +104,9 @@ class RecoverabilityComponent
             },
             recoverabilityPipeline,
             faultMetadataExtractor,
-            (this, policy));
+            (this, policy),
+            activityFactory
+            );
     }
 
     public IRecoverabilityPipelineExecutor CreateSatelliteRecoverabilityExecutor(

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityPipelineExecutor.cs
@@ -9,30 +9,21 @@ using Microsoft.Extensions.DependencyInjection;
 using NServiceBus.Pipeline;
 using Transport;
 
-class RecoverabilityPipelineExecutor<TState> : IRecoverabilityPipelineExecutor
+class RecoverabilityPipelineExecutor<TState>(
+    IServiceProvider serviceProvider,
+    IPipelineCache pipelineCache,
+    MessageOperations messageOperations,
+    RecoverabilityConfig recoverabilityConfig,
+    Func<ErrorContext, TState, RecoverabilityAction> recoverabilityPolicy,
+    IPipeline<IRecoverabilityContext> recoverabilityPipeline,
+    FaultMetadataExtractor faultMetadataExtractor,
+    TState state,
+    IActivityFactory activityFactory) : IRecoverabilityPipelineExecutor
 {
-    public RecoverabilityPipelineExecutor(
-        IServiceProvider serviceProvider,
-        IPipelineCache pipelineCache,
-        MessageOperations messageOperations,
-        RecoverabilityConfig recoverabilityConfig,
-        Func<ErrorContext, TState, RecoverabilityAction> recoverabilityPolicy,
-        IPipeline<IRecoverabilityContext> recoverabilityPipeline,
-        FaultMetadataExtractor faultMetadataExtractor,
-        TState state)
-    {
-        this.state = state;
-        this.serviceProvider = serviceProvider;
-        this.pipelineCache = pipelineCache;
-        this.messageOperations = messageOperations;
-        this.recoverabilityConfig = recoverabilityConfig;
-        this.recoverabilityPolicy = recoverabilityPolicy;
-        this.recoverabilityPipeline = recoverabilityPipeline;
-        this.faultMetadataExtractor = faultMetadataExtractor;
-    }
-
     public async Task<ErrorHandleResult> Invoke(ErrorContext errorContext, CancellationToken cancellationToken = default)
     {
+        using var activity = activityFactory.StartRecoverabilityActivity(errorContext);
+
         var childScope = serviceProvider.CreateAsyncScope();
         await using (childScope.ConfigureAwait(false))
         {
@@ -56,13 +47,4 @@ class RecoverabilityPipelineExecutor<TState> : IRecoverabilityPipelineExecutor
             return recoverabilityContext.RecoverabilityAction.ErrorHandleResult;
         }
     }
-
-    readonly IServiceProvider serviceProvider;
-    readonly IPipelineCache pipelineCache;
-    readonly MessageOperations messageOperations;
-    readonly RecoverabilityConfig recoverabilityConfig;
-    readonly Func<ErrorContext, TState, RecoverabilityAction> recoverabilityPolicy;
-    readonly IPipeline<IRecoverabilityContext> recoverabilityPipeline;
-    readonly FaultMetadataExtractor faultMetadataExtractor;
-    readonly TState state;
 }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityPipelineExecutor.cs
@@ -22,25 +22,49 @@ class RecoverabilityPipelineExecutor<TState>(
 {
     public async Task<ErrorHandleResult> Invoke(ErrorContext errorContext, CancellationToken cancellationToken = default)
     {
-        using var activity = activityFactory.StartRecoverabilityActivity(errorContext);
-
         var childScope = serviceProvider.CreateAsyncScope();
         await using (childScope.ConfigureAwait(false))
         {
-            var recoverabilityAction = recoverabilityPolicy(errorContext, state);
+            RecoverabilityAction? recoverabilityAction;
+
+            using (var activity = activityFactory.StartRecoverabilityActivity(errorContext))
+            {
+                recoverabilityAction = recoverabilityPolicy(errorContext, state);
+
+                if (recoverabilityAction is ImmediateRetry)
+                {
+                    activity?.AddTag(ActivityTags.RecoverabilityAction, "immediate_retry");
+                    activity?.DisplayName += " immediate retry";
+                }
+                else if (recoverabilityAction is DelayedRetry)
+                {
+                    activity?.AddTag(ActivityTags.RecoverabilityAction, "delayed_retry");
+                    activity?.DisplayName += " delayed retry";
+                }
+                else if (recoverabilityAction is MoveToError)
+                {
+                    activity?.AddTag(ActivityTags.RecoverabilityAction, "move_to_error");
+                    activity?.DisplayName += " move to error queue";
+                }
+                else if (recoverabilityAction is Discard)
+                {
+                    activity?.AddTag(ActivityTags.RecoverabilityAction, "discard");
+                    activity?.DisplayName += " discard";
+                }
+            }
 
             var metadata = faultMetadataExtractor.Extract(errorContext);
 
             var recoverabilityContext = new RecoverabilityContext(
-                childScope.ServiceProvider,
-                messageOperations,
-                pipelineCache,
-                errorContext,
-                recoverabilityConfig,
-                metadata,
-                recoverabilityAction,
-                errorContext.Extensions,
-                cancellationToken);
+                    childScope.ServiceProvider,
+                    messageOperations,
+                    pipelineCache,
+                    errorContext,
+                    recoverabilityConfig,
+                    metadata,
+                    recoverabilityAction,
+                    errorContext.Extensions,
+                    cancellationToken);
 
             await recoverabilityPipeline.Invoke(recoverabilityContext).ConfigureAwait(false);
 

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityPipelineExecutor.cs
@@ -31,25 +31,9 @@ class RecoverabilityPipelineExecutor<TState>(
             {
                 recoverabilityAction = recoverabilityPolicy(errorContext, state);
 
-                if (recoverabilityAction is ImmediateRetry)
+                if (activity is not null)
                 {
-                    activity?.AddTag(ActivityTags.RecoverabilityAction, "immediate_retry");
-                    activity?.DisplayName += " immediate retry";
-                }
-                else if (recoverabilityAction is DelayedRetry)
-                {
-                    activity?.AddTag(ActivityTags.RecoverabilityAction, "delayed_retry");
-                    activity?.DisplayName += " delayed retry";
-                }
-                else if (recoverabilityAction is MoveToError)
-                {
-                    activity?.AddTag(ActivityTags.RecoverabilityAction, "move_to_error");
-                    activity?.DisplayName += " move to error queue";
-                }
-                else if (recoverabilityAction is Discard)
-                {
-                    activity?.AddTag(ActivityTags.RecoverabilityAction, "discard");
-                    activity?.DisplayName += " discard";
+                    activityFactory.UpdateActivityFromRecoverabilityAction(activity, recoverabilityAction, errorContext.ReceiveAddress);
                 }
             }
 

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityRoutingConnector.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityRoutingConnector.cs
@@ -3,6 +3,7 @@
 namespace NServiceBus;
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Pipeline;
 
@@ -36,14 +37,21 @@ class RecoverabilityRoutingConnector : StageConnector<IRecoverabilityContext, IR
         if (context.RecoverabilityAction is ImmediateRetry)
         {
             incomingPipelineMetrics.RecordImmediateRetry(context);
+            Activity.Current?.AddTag("NServiceBus.RecoverabilityAction", "ImmediateRetry");
         }
         else if (context.RecoverabilityAction is DelayedRetry)
         {
             incomingPipelineMetrics.RecordDelayedRetry(context);
+            Activity.Current?.AddTag("NServiceBus.RecoverabilityAction", "DelayedRetry`");
         }
         else if (context.RecoverabilityAction is MoveToError)
         {
             incomingPipelineMetrics.RecordSendToErrorQueue(context);
+            Activity.Current?.AddTag("NServiceBus.RecoverabilityAction", "MoveToError");
+        }
+        else if (context.RecoverabilityAction is Discard)
+        {
+            Activity.Current?.AddTag("NServiceBus.RecoverabilityAction", "Discard");
         }
 
         if (context is IRecoverabilityActionContextNotifications events)

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityRoutingConnector.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityRoutingConnector.cs
@@ -34,28 +34,31 @@ class RecoverabilityRoutingConnector : StageConnector<IRecoverabilityContext, IR
             await stage(routingContext).ConfigureAwait(false);
         }
 
-        var activity = context.Extensions.TryGet<Activity>(out var transportActivity)
-            ? transportActivity
-            : Activity.Current;
+        var activity = Activity.Current;
 
         if (context.RecoverabilityAction is ImmediateRetry)
         {
             incomingPipelineMetrics.RecordImmediateRetry(context);
-            activity?.AddTag("NServiceBus.RecoverabilityAction", "ImmediateRetry");
+            activity?.AddTag("NServiceBus.RecoverabilityAction", "immediate_retry");
+            activity?.DisplayName += " immediate retry";
+
         }
         else if (context.RecoverabilityAction is DelayedRetry)
         {
             incomingPipelineMetrics.RecordDelayedRetry(context);
-            activity?.AddTag("NServiceBus.RecoverabilityAction", "DelayedRetry`");
+            activity?.AddTag("NServiceBus.RecoverabilityAction", "delayed_retry");
+            activity?.DisplayName += " delayed retry";
         }
         else if (context.RecoverabilityAction is MoveToError)
         {
             incomingPipelineMetrics.RecordSendToErrorQueue(context);
-            activity?.AddTag("NServiceBus.RecoverabilityAction", "MoveToError");
+            activity?.AddTag("NServiceBus.RecoverabilityAction", "move_to_error");
+            activity?.DisplayName += " move to error queue";
         }
         else if (context.RecoverabilityAction is Discard)
         {
-            activity?.AddTag("NServiceBus.RecoverabilityAction", "Discard");
+            activity?.AddTag("NServiceBus.RecoverabilityAction", "discard");
+            activity?.DisplayName += " discard";
         }
 
         if (context is IRecoverabilityActionContextNotifications events)

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityRoutingConnector.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityRoutingConnector.cs
@@ -34,24 +34,28 @@ class RecoverabilityRoutingConnector : StageConnector<IRecoverabilityContext, IR
             await stage(routingContext).ConfigureAwait(false);
         }
 
+        var activity = context.Extensions.TryGet<Activity>(out var transportActivity)
+            ? transportActivity
+            : Activity.Current;
+
         if (context.RecoverabilityAction is ImmediateRetry)
         {
             incomingPipelineMetrics.RecordImmediateRetry(context);
-            Activity.Current?.AddTag("NServiceBus.RecoverabilityAction", "ImmediateRetry");
+            activity?.AddTag("NServiceBus.RecoverabilityAction", "ImmediateRetry");
         }
         else if (context.RecoverabilityAction is DelayedRetry)
         {
             incomingPipelineMetrics.RecordDelayedRetry(context);
-            Activity.Current?.AddTag("NServiceBus.RecoverabilityAction", "DelayedRetry`");
+            activity?.AddTag("NServiceBus.RecoverabilityAction", "DelayedRetry`");
         }
         else if (context.RecoverabilityAction is MoveToError)
         {
             incomingPipelineMetrics.RecordSendToErrorQueue(context);
-            Activity.Current?.AddTag("NServiceBus.RecoverabilityAction", "MoveToError");
+            activity?.AddTag("NServiceBus.RecoverabilityAction", "MoveToError");
         }
         else if (context.RecoverabilityAction is Discard)
         {
-            Activity.Current?.AddTag("NServiceBus.RecoverabilityAction", "Discard");
+            activity?.AddTag("NServiceBus.RecoverabilityAction", "Discard");
         }
 
         if (context is IRecoverabilityActionContextNotifications events)

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityRoutingConnector.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityRoutingConnector.cs
@@ -39,25 +39,25 @@ class RecoverabilityRoutingConnector : StageConnector<IRecoverabilityContext, IR
         if (context.RecoverabilityAction is ImmediateRetry)
         {
             incomingPipelineMetrics.RecordImmediateRetry(context);
-            activity?.AddTag("NServiceBus.RecoverabilityAction", "immediate_retry");
+            activity?.AddTag(ActivityTags.RecoverabilityAction, "immediate_retry");
             activity?.DisplayName += " immediate retry";
 
         }
         else if (context.RecoverabilityAction is DelayedRetry)
         {
             incomingPipelineMetrics.RecordDelayedRetry(context);
-            activity?.AddTag("NServiceBus.RecoverabilityAction", "delayed_retry");
+            activity?.AddTag(ActivityTags.RecoverabilityAction, "delayed_retry");
             activity?.DisplayName += " delayed retry";
         }
         else if (context.RecoverabilityAction is MoveToError)
         {
             incomingPipelineMetrics.RecordSendToErrorQueue(context);
-            activity?.AddTag("NServiceBus.RecoverabilityAction", "move_to_error");
+            activity?.AddTag(ActivityTags.RecoverabilityAction, "move_to_error");
             activity?.DisplayName += " move to error queue";
         }
         else if (context.RecoverabilityAction is Discard)
         {
-            activity?.AddTag("NServiceBus.RecoverabilityAction", "discard");
+            activity?.AddTag(ActivityTags.RecoverabilityAction, "discard");
             activity?.DisplayName += " discard";
         }
 

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityRoutingConnector.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityRoutingConnector.cs
@@ -3,7 +3,6 @@
 namespace NServiceBus;
 
 using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Pipeline;
 
@@ -34,31 +33,17 @@ class RecoverabilityRoutingConnector : StageConnector<IRecoverabilityContext, IR
             await stage(routingContext).ConfigureAwait(false);
         }
 
-        var activity = Activity.Current;
-
         if (context.RecoverabilityAction is ImmediateRetry)
         {
             incomingPipelineMetrics.RecordImmediateRetry(context);
-            activity?.AddTag(ActivityTags.RecoverabilityAction, "immediate_retry");
-            activity?.DisplayName += " immediate retry";
-
         }
         else if (context.RecoverabilityAction is DelayedRetry)
         {
             incomingPipelineMetrics.RecordDelayedRetry(context);
-            activity?.AddTag(ActivityTags.RecoverabilityAction, "delayed_retry");
-            activity?.DisplayName += " delayed retry";
         }
         else if (context.RecoverabilityAction is MoveToError)
         {
             incomingPipelineMetrics.RecordSendToErrorQueue(context);
-            activity?.AddTag(ActivityTags.RecoverabilityAction, "move_to_error");
-            activity?.DisplayName += " move to error queue";
-        }
-        else if (context.RecoverabilityAction is Discard)
-        {
-            activity?.AddTag(ActivityTags.RecoverabilityAction, "discard");
-            activity?.DisplayName += " discard";
         }
 
         if (context is IRecoverabilityActionContextNotifications events)


### PR DESCRIPTION
Resolves:
 - https://github.com/Particular/NServiceBus/issues/7088

Adds a dedicated OpenTelemetry span representing each recoverability outcome (immediate retry, delayed retry, move to error, discard). New spans are created under a new `NServiceBus.Core.Recoverability` `ActivitySource`. 