### PR TITLE
Receive properties are lost on delayed retries

### DIFF
--- a/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
@@ -42,6 +42,7 @@ sealed class RecoverabilityContext : PipelineRootContext, IRecoverabilityContext
         RecoverabilityAction = recoverabilityAction;
 
         Extensions.Set(errorContext.TransportTransaction);
+        Extensions.Set(new IncomingMessage(NativeMessageId, Headers, Body, ReceiveProperties));
     }
 
     [ObsoleteMetadata(Message = "For access to the message body, headers, native message ID, or the receive properties use the corresponding properties directly exposed on the context", TreatAsErrorFromVersion = "11", RemoveInVersion = "12")]

--- a/src/NServiceBus.Learning.AcceptanceTests/When_message_sent_with_LearningTransport.cs
+++ b/src/NServiceBus.Learning.AcceptanceTests/When_message_sent_with_LearningTransport.cs
@@ -124,7 +124,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         }
     }
 
-    class Context : ScenarioContext
+    public class Context : ScenarioContext
     {
         public bool MessageReceived { get; set; }
         public bool MessageAudited { get; set; }
@@ -136,7 +136,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         public string SendFileCreatedAt { get; set; }
     }
 
-    class EndPointThatReceivesFromAnotherAndAuditsEndpoint : EndpointConfigurationBuilder
+    public class EndPointThatReceivesFromAnotherAndAuditsEndpoint : EndpointConfigurationBuilder
     {
         public EndPointThatReceivesFromAnotherAndAuditsEndpoint() => EndpointSetup<DefaultServer>(endpointConfiguration =>
         {
@@ -144,7 +144,8 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
             endpointConfiguration.Pipeline.Register(behavior: new AuditHeaderOverrideBehavior(), description: "Override headers on audit messages");
         });
 
-        class OutgoingTestMessageHandler(Context testContext) : IHandleMessages<OutgoingTestMessage>
+        [Handler]
+        public class OutgoingTestMessageHandler(Context testContext) : IHandleMessages<OutgoingTestMessage>
         {
             public Task Handle(OutgoingTestMessage message, IMessageHandlerContext context)
             {
@@ -174,11 +175,12 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         }
     }
 
-    class AuditSpyForEndPointThatReceivesFromAnotherAndAuditsEndpoint : EndpointConfigurationBuilder
+    public class AuditSpyForEndPointThatReceivesFromAnotherAndAuditsEndpoint : EndpointConfigurationBuilder
     {
         public AuditSpyForEndPointThatReceivesFromAnotherAndAuditsEndpoint() =>
             EndpointSetup<DefaultServer>();
 
+        [Handler]
         public class AuditMessageHandler(Context testContext) : IHandleMessages<OutgoingTestMessage>
         {
             public Task Handle(OutgoingTestMessage message, IMessageHandlerContext context)
@@ -204,11 +206,12 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         }
     }
 
-    class SendingEndpoint : EndpointConfigurationBuilder
+    public class SendingEndpoint : EndpointConfigurationBuilder
     {
         public SendingEndpoint() => EndpointSetup<DefaultServer>();
 
-        class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
+        [Handler]
+        public class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
         {
             public async Task Handle(TestMessage message, IMessageHandlerContext context)
             {
@@ -227,7 +230,8 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         }
 
         //handler for the outgoing message to verify that receive properties are not propagated to outgoing messages
-        class OutgoingTestMessageHandler(Context testContext) : IHandleMessages<OutgoingTestMessage>
+        [Handler]
+        public class OutgoingTestMessageHandler(Context testContext) : IHandleMessages<OutgoingTestMessage>
         {
             public Task Handle(OutgoingTestMessage message, IMessageHandlerContext context)
             {
@@ -251,14 +255,15 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         }
     }
 
-    class Endpoint : EndpointConfigurationBuilder
+    public class Endpoint : EndpointConfigurationBuilder
     {
         public Endpoint() => EndpointSetup<DefaultServer>(endpointConfiguration =>
         {
             endpointConfiguration.AuditProcessedMessagesTo(Conventions.EndpointNamingConvention(typeof(AuditSpy)));
         });
 
-        class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
+        [Handler]
+        public class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
         {
             public Task Handle(TestMessage message, IMessageHandlerContext context)
             {
@@ -280,7 +285,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         }
     }
 
-    class FailingEndpoint : EndpointConfigurationBuilder
+    public class FailingEndpoint : EndpointConfigurationBuilder
     {
         public FailingEndpoint() => EndpointSetup<DefaultServer>(endpointConfiguration =>
         {
@@ -288,7 +293,8 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
             endpointConfiguration.Recoverability().Immediate(settings => settings.NumberOfRetries(0));
         });
 
-        class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
+        [Handler]
+        public class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
         {
             public Task Handle(TestMessage message, IMessageHandlerContext context)
             {
@@ -314,14 +320,15 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         }
     }
 
-    class EndpointWithAuditOn : EndpointConfigurationBuilder
+    public class EndpointWithAuditOn : EndpointConfigurationBuilder
     {
         public EndpointWithAuditOn() => EndpointSetup<DefaultServer>(endpointConfiguration =>
         {
             endpointConfiguration.AuditProcessedMessagesTo(Conventions.EndpointNamingConvention(typeof(AuditSpy)));
         });
 
-        class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
+        [Handler]
+        public class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
         {
             public Task Handle(TestMessage message, IMessageHandlerContext context)
             {
@@ -337,11 +344,12 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         }
     }
 
-    class AuditSpy : EndpointConfigurationBuilder
+    public class AuditSpy : EndpointConfigurationBuilder
     {
         public AuditSpy() =>
             EndpointSetup<DefaultServer>();
 
+        [Handler]
         public class AuditMessageHandler(Context testContext) : IHandleMessages<TestMessage>
         {
             public Task Handle(TestMessage message, IMessageHandlerContext context)
@@ -367,7 +375,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         }
     }
 
-    class EndpointWithFailingHandler : EndpointConfigurationBuilder
+    public class EndpointWithFailingHandler : EndpointConfigurationBuilder
     {
         public EndpointWithFailingHandler() => EndpointSetup<DefaultServer>(endpointConfiguration =>
         {
@@ -375,7 +383,8 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
             endpointConfiguration.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(ErrorSpy)));
         });
 
-        class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
+        [Handler]
+        public class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
         {
             public Task Handle(TestMessage message, IMessageHandlerContext context)
             {
@@ -391,7 +400,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         }
     }
 
-    class EndpointWithFailingHandlerAndDispatchOverride : EndpointConfigurationBuilder
+    public class EndpointWithFailingHandlerAndDispatchOverride : EndpointConfigurationBuilder
     {
         public EndpointWithFailingHandlerAndDispatchOverride() => EndpointSetup<DefaultServer>(endpointConfiguration =>
         {
@@ -400,7 +409,8 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
             endpointConfiguration.Pipeline.Register(behavior: new ErrorQueueDispatchPropertyOverrideBehavior(), description: "Override FileCreatedAt dispatch property on error queue messages");
         });
 
-        class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
+        [Handler]
+        public class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
         {
             public Task Handle(TestMessage message, IMessageHandlerContext context)
             {
@@ -444,10 +454,11 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         }
     }
 
-    class ErrorSpy : EndpointConfigurationBuilder
+    public class ErrorSpy : EndpointConfigurationBuilder
     {
         public ErrorSpy() => EndpointSetup<DefaultServer>();
 
+        [Handler]
         public class ErrorMessageHandler(Context testContext) : IHandleMessages<TestMessage>
         {
             public Task Handle(TestMessage message, IMessageHandlerContext context)
@@ -469,10 +480,11 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         }
     }
 
-    class ErrorSpyWithDispatchPropertyVerification : EndpointConfigurationBuilder
+    public class ErrorSpyWithDispatchPropertyVerification : EndpointConfigurationBuilder
     {
         public ErrorSpyWithDispatchPropertyVerification() => EndpointSetup<DefaultServer>();
 
+        [Handler]
         public class ErrorMessageHandler(Context testContext) : IHandleMessages<TestMessage>
         {
             public Task Handle(TestMessage message, IMessageHandlerContext context)

--- a/src/NServiceBus.Learning.AcceptanceTests/When_message_sent_with_LearningTransport.cs
+++ b/src/NServiceBus.Learning.AcceptanceTests/When_message_sent_with_LearningTransport.cs
@@ -39,6 +39,18 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
     }
 
     [Test]
+    public async Task Should_preserve_file_created_time_property_on_delayed_retry()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<FailingEndpoint>(b => b
+                .When(session => session.SendLocal(new TestMessage()))
+                .DoNotFailOnErrorMessages())
+            .Run();
+
+        Assert.That(context.NumberOfRetries, Is.EqualTo(2), "Message was not retried");
+    }
+
+    [Test]
     public async Task Should_not_preserve_receive_properties_on_outgoing_messages()
     {
         var context = await Scenario.Define<Context>()
@@ -104,6 +116,8 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         public bool MessageAudited { get; set; }
         public bool MessageMovedToErrorQueue { get; set; }
         public bool ErrorQueueFileCreatedAtDiffersFromOriginal { get; set; }
+        public int NumberOfRetries { get; set; }
+        public string RetryFileCreatedAt { get; set; }
     }
 
     class EndPointThatReceivesFromAnotherAndAuditsEndpoint : EndpointConfigurationBuilder
@@ -245,6 +259,40 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
                 testContext.MarkAsCompleted(testContext.MessageReceived, testContext.FileCreatedAt != null);
 
                 return Task.CompletedTask;
+            }
+        }
+    }
+
+    class FailingEndpoint : EndpointConfigurationBuilder
+    {
+        public FailingEndpoint() => EndpointSetup<DefaultServer>(endpointConfiguration =>
+        {
+            endpointConfiguration.Recoverability().Delayed(settings => settings.NumberOfRetries(1));
+            endpointConfiguration.Recoverability().Immediate(settings => settings.NumberOfRetries(0));
+        });
+
+        class TestMessageHandler(Context testContext) : IHandleMessages<TestMessage>
+        {
+            public Task Handle(TestMessage message, IMessageHandlerContext context)
+            {
+                if (testContext.NumberOfRetries == 0)
+                {
+                    if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
+                    {
+                        testContext.FileCreatedAt = fileCreatedAt;
+                    }
+                }
+                else
+                {
+                    if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
+                    {
+                        testContext.RetryFileCreatedAt = fileCreatedAt;
+                        testContext.MarkAsCompleted(testContext.FileCreatedAt == testContext.RetryFileCreatedAt);
+                    }
+                }
+                testContext.NumberOfRetries++;
+
+                throw new SimulatedException("Simulating an exception to see if it preserves receive properties on retries");
             }
         }
     }

--- a/src/NServiceBus.Learning.AcceptanceTests/When_message_sent_with_LearningTransport.cs
+++ b/src/NServiceBus.Learning.AcceptanceTests/When_message_sent_with_LearningTransport.cs
@@ -22,8 +22,8 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageReceived, Is.True, "Message was not received");
-            Assert.That(context.FileCreatedAt, Is.Not.Null, "FileCreatedAt property should be present");
-            Assert.That(DateTime.TryParse(context.FileCreatedAt, out _), Is.True, "FileCreatedAt should be a valid datetime");
+            Assert.That(context.ReceiveFileCreatedAt, Is.Not.Null, "FileCreatedAt property should be present");
+            Assert.That(DateTime.TryParse(context.ReceiveFileCreatedAt, out _), Is.True, "FileCreatedAt should be a valid datetime");
         }
     }
 
@@ -35,7 +35,12 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
             .WithEndpoint<AuditSpy>()
             .Run();
 
-        Assert.That(context.MessageAudited, Is.True, "Message was not audited");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(context.MessageAudited, Is.True, "Message was not audited");
+            Assert.That(context.ReceiveFileCreatedAt, Is.Not.Null, "FileCreatedAt property should be present");
+            Assert.That(DateTime.TryParse(context.ReceiveFileCreatedAt, out _), Is.True, "FileCreatedAt should be a valid datetime");
+        }
     }
 
     [Test]
@@ -47,7 +52,12 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
                 .DoNotFailOnErrorMessages())
             .Run();
 
-        Assert.That(context.NumberOfRetries, Is.EqualTo(2), "Message was not retried");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(context.NumberOfRetries, Is.EqualTo(2), "Message was not retried");
+            Assert.That(context.ReceiveFileCreatedAt, Is.Not.Null, "FileCreatedAt property should be present");
+            Assert.That(DateTime.TryParse(context.ReceiveFileCreatedAt, out _), Is.True, "FileCreatedAt should be a valid datetime");
+        }
     }
 
     [Test]
@@ -57,7 +67,12 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
             .WithEndpoint<SendingEndpoint>(b => b.When(session => session.SendLocal(new TestMessage())))
             .Run();
 
-        Assert.That(context.MessageReceived, Is.True, "Message was received");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(context.MessageReceived, Is.True, "Message was received");
+            Assert.That(DateTime.TryParse(context.ReceiveFileCreatedAt, out _), Is.True, "FileCreatedAt should be a valid datetime");
+            Assert.That(DateTime.TryParse(context.SendFileCreatedAt, out _), Is.True, "SendFileCreatedAt should be a valid datetime");
+        }
     }
 
     [Test]
@@ -85,8 +100,8 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageMovedToErrorQueue, Is.True, "Message was not moved to error queue");
-            Assert.That(context.FileCreatedAt, Is.Not.Null, "FileCreatedAt property should be present on message in error queue");
-            Assert.That(DateTime.TryParse(context.FileCreatedAt, out _), Is.True, "FileCreatedAt should be a valid datetime");
+            Assert.That(context.ReceiveFileCreatedAt, Is.Not.Null, "FileCreatedAt property should be present on message in error queue");
+            Assert.That(DateTime.TryParse(context.ReceiveFileCreatedAt, out _), Is.True, "FileCreatedAt should be a valid datetime");
         }
     }
 
@@ -104,7 +119,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
         using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageMovedToErrorQueue, Is.True, "Message was not moved to error queue");
-            Assert.That(context.FileCreatedAt, Is.Not.Null, "FileCreatedAt property should be captured from original message");
+            Assert.That(context.ReceiveFileCreatedAt, Is.Not.Null, "FileCreatedAt property should be captured from original message");
             Assert.That(context.ErrorQueueFileCreatedAtDiffersFromOriginal, Is.True, "Error queue message should have FileCreatedAt from dispatch properties, not receive properties");
         }
     }
@@ -112,12 +127,13 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
     class Context : ScenarioContext
     {
         public bool MessageReceived { get; set; }
-        public string FileCreatedAt { get; set; }
         public bool MessageAudited { get; set; }
         public bool MessageMovedToErrorQueue { get; set; }
         public bool ErrorQueueFileCreatedAtDiffersFromOriginal { get; set; }
         public int NumberOfRetries { get; set; }
+        public string ReceiveFileCreatedAt { get; set; }
         public string RetryFileCreatedAt { get; set; }
+        public string SendFileCreatedAt { get; set; }
     }
 
     class EndPointThatReceivesFromAnotherAndAuditsEndpoint : EndpointConfigurationBuilder
@@ -136,7 +152,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
 
                 if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                 {
-                    testContext.FileCreatedAt = fileCreatedAt;
+                    testContext.ReceiveFileCreatedAt = fileCreatedAt;
                 }
                 else
                 {
@@ -171,12 +187,12 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
 
                 if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                 {
-                    if (fileCreatedAt == testContext.FileCreatedAt)
+                    if (fileCreatedAt == testContext.ReceiveFileCreatedAt)
                     {
                         testContext.MarkAsFailed(new Exception("Receive properties from the original message is propagated to audit messages."));
                     }
 
-                    testContext.MarkAsCompleted(testContext.MessageAudited, testContext.FileCreatedAt != fileCreatedAt);
+                    testContext.MarkAsCompleted(testContext.MessageAudited, testContext.ReceiveFileCreatedAt != fileCreatedAt);
                 }
                 else
                 {
@@ -199,7 +215,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
                 testContext.MessageReceived = true;
                 if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                 {
-                    testContext.FileCreatedAt = fileCreatedAt;
+                    testContext.ReceiveFileCreatedAt = fileCreatedAt;
 
                     await context.SendLocal(new OutgoingTestMessage());
                 }
@@ -218,12 +234,13 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
                 testContext.MessageReceived = true;
                 if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                 {
-                    if (fileCreatedAt == testContext.FileCreatedAt)
+                    testContext.SendFileCreatedAt = fileCreatedAt;
+                    if (fileCreatedAt == testContext.ReceiveFileCreatedAt)
                     {
                         testContext.MarkAsFailed(new Exception("Receive properties from the original message is propagated to outgoing messages."));
                     }
 
-                    testContext.MarkAsCompleted(testContext.MessageReceived, testContext.FileCreatedAt != fileCreatedAt);
+                    testContext.MarkAsCompleted(testContext.MessageReceived, testContext.ReceiveFileCreatedAt != fileCreatedAt);
                 }
                 else
                 {
@@ -249,14 +266,14 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
 
                 if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                 {
-                    testContext.FileCreatedAt = fileCreatedAt;
+                    testContext.ReceiveFileCreatedAt = fileCreatedAt;
                 }
                 else
                 {
                     testContext.MarkAsFailed(new Exception("Failed to retrieve receive properties from the message context."));
                 }
 
-                testContext.MarkAsCompleted(testContext.MessageReceived, testContext.FileCreatedAt != null);
+                testContext.MarkAsCompleted(testContext.MessageReceived, testContext.ReceiveFileCreatedAt != null);
 
                 return Task.CompletedTask;
             }
@@ -279,7 +296,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
                 {
                     if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                     {
-                        testContext.FileCreatedAt = fileCreatedAt;
+                        testContext.ReceiveFileCreatedAt = fileCreatedAt;
                     }
                 }
                 else
@@ -287,7 +304,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
                     if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                     {
                         testContext.RetryFileCreatedAt = fileCreatedAt;
-                        testContext.MarkAsCompleted(testContext.FileCreatedAt == testContext.RetryFileCreatedAt);
+                        testContext.MarkAsCompleted(testContext.ReceiveFileCreatedAt == testContext.RetryFileCreatedAt);
                     }
                 }
                 testContext.NumberOfRetries++;
@@ -312,7 +329,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
 
                 if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                 {
-                    testContext.FileCreatedAt = fileCreatedAt;
+                    testContext.ReceiveFileCreatedAt = fileCreatedAt;
                 }
 
                 return Task.CompletedTask;
@@ -333,12 +350,12 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
 
                 if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                 {
-                    if (fileCreatedAt != testContext.FileCreatedAt)
+                    if (fileCreatedAt != testContext.ReceiveFileCreatedAt)
                     {
                         testContext.MarkAsFailed(new Exception("Receive properties from the original message is not propagated to audit messages."));
                     }
 
-                    testContext.MarkAsCompleted(testContext.MessageAudited, testContext.FileCreatedAt == fileCreatedAt);
+                    testContext.MarkAsCompleted(testContext.MessageAudited, testContext.ReceiveFileCreatedAt == fileCreatedAt);
                 }
                 else
                 {
@@ -366,7 +383,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
 
                 if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                 {
-                    testContext.FileCreatedAt = fileCreatedAt;
+                    testContext.ReceiveFileCreatedAt = fileCreatedAt;
                 }
 
                 throw new SimulatedException("Message should be moved to error queue");
@@ -391,7 +408,7 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
 
                 if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                 {
-                    testContext.FileCreatedAt = fileCreatedAt;
+                    testContext.ReceiveFileCreatedAt = fileCreatedAt;
                 }
 
                 throw new SimulatedException("Message should be moved to error queue");
@@ -439,8 +456,8 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
 
                 if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                 {
-                    testContext.FileCreatedAt = fileCreatedAt;
-                    testContext.MarkAsCompleted(testContext.MessageMovedToErrorQueue, testContext.FileCreatedAt != null);
+                    testContext.ReceiveFileCreatedAt = fileCreatedAt;
+                    testContext.MarkAsCompleted(testContext.MessageMovedToErrorQueue, testContext.ReceiveFileCreatedAt != null);
                 }
                 else
                 {
@@ -464,12 +481,12 @@ public class When_message_sent_with_LearningTransport : NServiceBusAcceptanceTes
 
                 if (context.Extensions.TryGet<IncomingMessage>(out var incomingMessage) && incomingMessage.ReceiveProperties.TryGetValue("LearningTransport.FileCreatedAt", out var fileCreatedAt))
                 {
-                    if (fileCreatedAt == testContext.FileCreatedAt)
+                    if (fileCreatedAt == testContext.ReceiveFileCreatedAt)
                     {
                         testContext.MarkAsFailed(new Exception("Receive properties from the original message were propagated to error queue message instead of dispatch properties."));
                     }
 
-                    testContext.ErrorQueueFileCreatedAtDiffersFromOriginal = testContext.FileCreatedAt != fileCreatedAt;
+                    testContext.ErrorQueueFileCreatedAtDiffersFromOriginal = testContext.ReceiveFileCreatedAt != fileCreatedAt;
                     testContext.MarkAsCompleted(testContext.MessageMovedToErrorQueue, testContext.ErrorQueueFileCreatedAtDiffersFromOriginal);
                 }
                 else


### PR DESCRIPTION
### Symptoms

When a message that carries native transport metadata via `ReceiveProperties` fails processing and is retried using delayed retries, the native receive properties are stripped. The metadata is present on the initial delivery but missing from the message once it is redelivered after the retry delay.

For example, a transport that relies on native metadata such as a message group id or deduplication id would see those values on the first delivery and then lose them on every subsequent delayed-retry delivery.

### Who's affected

Only transport authors who adopt the new `ReceiveProperties` API (introduced in NServiceBus 10.2.0 via [#7662](https://github.com/Particular/NServiceBus/pull/7662)) to carry native message metadata through the pipeline are affected.

End users of the Particular-supported transports are not affected, as no Particular transport currently uses the `ReceiveProperties` feature.

### Root cause

Receive properties are propagated onto outgoing dispatch operations by `RoutingToDispatchConnector`, but **only** when it can locate an `IncomingMessage` with a matching message ID in the current context extensions.

During a delayed retry, the recoverability pipeline creates an `OutgoingMessage` with the original message ID and dispatches it back to the input queue through the routing/dispatch pipeline. The `RecoverabilityContext` already held the `ReceiveProperties` as a direct property, but it **never published an `IncomingMessage` into its context extensions**. Consequently, when `RoutingToDispatchConnector` looked one up during the delayed-retry dispatch, the lookup failed, the receive properties resolved to empty, and the redelivered message shipped without its native metadata.

The fix publishes the `IncomingMessage` (carrying the receive properties) into the recoverability context extensions, so the metadata flows through the routing context into the dispatch stage and survives the delayed retry ([#7900](https://github.com/Particular/NServiceBus/pull/7900)).