### PR TITLE
Add test to track usage of legacy NServiceBus.Logging API

### DIFF
--- a/src/NServiceBus.Core.Tests/API/LogManagerUsage.cs
+++ b/src/NServiceBus.Core.Tests/API/LogManagerUsage.cs
@@ -1,0 +1,73 @@
+namespace NServiceBus.Core.Tests.API;
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using NServiceBus.Core.Tests.API.Infra;
+using NServiceBus.Logging;
+using NUnit.Framework;
+using Particular.Approvals;
+
+// The legacy logging API (NServiceBus.Logging.LogManager.GetLogger and the
+// NServiceBus.Logging.ILog logger fields it produces) is still used throughout
+// NServiceBus.Core. The goal is to migrate this code to the high performance,
+// source-generated loggers provided by Microsoft.Extensions.Logging using the
+// [LoggerMessage] source generator.
+//
+// This test captures the set of types that still hold an NServiceBus.Logging.ILog
+// logger field so that any new usage is immediately visible. When a type is migrated
+// to a source-generated logger its ILog field is removed and it drops off this list,
+// so the list naturally shrinks over time. It is acceptable for the list to grow
+// only when the type affects user-facing code or when DI (dependency injection) is
+// not available to obtain an ILogger<T>.
+//
+// See https://learn.microsoft.com/dotnet/core/extensions/logger-message-generator
+// for more details about the Microsoft.Extensions.Logging source generator.
+[TestFixture]
+public class LogManagerUsage
+{
+    [Test]
+    public void ApproveLogManagerUsage()
+    {
+        var b = new StringBuilder()
+            .AppendLine("The following types hold an NServiceBus.Logging.ILog logger field obtained via LogManager.GetLogger.")
+            .AppendLine("For new code where DI is available, use the high performance source generated loggers from")
+            .AppendLine("Microsoft.Extensions.Logging instead (see https://learn.microsoft.com/dotnet/core/extensions/logger-message-generator).")
+            .AppendLine("Changes that make this list longer should only be approved when the type affects user-facing")
+            .AppendLine("code or when DI is not available. The list should otherwise shrink over time.")
+            .AppendLine("-----");
+
+        foreach (var type in NServiceBusAssembly.Types.OrderBy(t => t.FullName, StringComparer.Ordinal))
+        {
+            if (HasILogField(type))
+            {
+                b.AppendLine(type.FullName);
+            }
+        }
+
+        Console.WriteLine(b.ToString());
+        Approver.Verify(b.ToString());
+    }
+
+    static bool HasILogField(Type type)
+    {
+        // The NServiceBus.Logging namespace contains adapter types that intentionally
+        // implement the legacy API surface and are not candidates for migration.
+        if (type.Namespace == "NServiceBus.Logging")
+        {
+            return false;
+        }
+
+        // Compiler-generated state machines and closures are not meaningful migration
+        // units; the ILog usage they contain belongs to their containing type.
+        if (Attribute.IsDefined(type, typeof(CompilerGeneratedAttribute), false))
+        {
+            return false;
+        }
+
+        return type.GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+            .Any(field => field.FieldType == typeof(ILog));
+    }
+}

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/LogManagerUsage.ApproveLogManagerUsage.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/LogManagerUsage.ApproveLogManagerUsage.approved.txt
@@ -1,0 +1,54 @@
+The following types hold an NServiceBus.Logging.ILog logger field obtained via LogManager.GetLogger.
+For new code where DI is available, use the high performance source generated loggers from
+Microsoft.Extensions.Logging instead (see https://learn.microsoft.com/dotnet/core/extensions/logger-message-generator).
+Changes that make this list longer should only be approved when the type affects user-facing
+code or when DI is not available. The list should otherwise shrink over time.
+-----
+NServiceBus.AsyncFile
+NServiceBus.AuditConfigReader
+NServiceBus.AuditInvalidLicenseBehavior
+NServiceBus.ConsecutiveFailuresCircuitBreaker
+NServiceBus.Conventions
+NServiceBus.DelayedMessagePoller
+NServiceBus.DelayedRetry
+NServiceBus.DeserializeMessageConnector
+NServiceBus.DirectoryBasedTransaction
+NServiceBus.Discard
+NServiceBus.EnvelopeUnwrapper
+NServiceBus.ErrorQueueSettings
+NServiceBus.Features.Audit
+NServiceBus.Features.AutoSubscribe+ApplySubscriptions
+NServiceBus.Features.FeatureStartupTaskController`1
+NServiceBus.Features.LicenseReminder
+NServiceBus.HostStartupDiagnosticsWriter
+NServiceBus.HostStartupDiagnosticsWriterFactory
+NServiceBus.HostingComponent
+NServiceBus.ImmediateRetry
+NServiceBus.LearningTransportMessagePump
+NServiceBus.LicenseManager
+NServiceBus.LoadHandlersConnector
+NServiceBus.LogErrorOnInvalidLicenseBehavior
+NServiceBus.MessageDrivenSubscribeTerminator
+NServiceBus.MessageDrivenUnsubscribeTerminator
+NServiceBus.MigrationSubscribeTerminator
+NServiceBus.MigrationUnsubscribeTerminator
+NServiceBus.MoveToError
+NServiceBus.PersistenceComponent
+NServiceBus.PipelineModelBuilder
+NServiceBus.Pipeline`1
+NServiceBus.ReceiveComponent
+NServiceBus.RecoverabilityComponent
+NServiceBus.RoutingToDispatchConnector
+NServiceBus.RunningEndpointInstance
+NServiceBus.SagaPersistenceBehavior
+NServiceBus.SerializationFeature
+NServiceBus.SerializationSettingsExtensions
+NServiceBus.SerializeMessageConnector
+NServiceBus.SubscriptionReceiverBehavior
+NServiceBus.TransportReceiveToPhysicalMessageConnector
+NServiceBus.Unicast.Messages.MessageMetadataRegistry
+NServiceBus.UnicastPublishRouter
+NServiceBus.Validations
+NServiceBus.WrappedMessageReceiver
+NServiceBus.XmlDeserialization
+NServiceBus.XmlSerializerCache


### PR DESCRIPTION
This adds a simple test that discovers static fields of the legacy logger. This does not capture every usage. For example, we have cases where we resolved a logger dynamically from LogManager without storing it in a field, but the complexity of using body inspection either via method body reader or `System.Reflection.Metadata` seems outrageous compared to the value it provides. 

This is a good enough first start.