### PR TITLE
Remove binlog generation from nullable and trimming warnings tests

### DIFF
--- a/src/NServiceBus.Core.Tests/API/NullabilityWarnings.cs
+++ b/src/NServiceBus.Core.Tests/API/NullabilityWarnings.cs
@@ -39,24 +39,12 @@ public partial class NullabilityWarnings
             "NServiceBus.Core",
             "NServiceBus.Core.csproj"));
 
-        var binlogPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "nullable.binlog");
+        var warnings = await BuildWithNullableEnabled(projectPath, cancellationToken);
 
-        try
-        {
-            var warnings = await BuildWithNullableEnabled(projectPath, binlogPath, cancellationToken);
-
-            Approver.Verify(warnings);
-        }
-        finally
-        {
-            if (File.Exists(binlogPath))
-            {
-                File.Delete(binlogPath);
-            }
-        }
+        Approver.Verify(warnings);
     }
 
-    static async Task<string> BuildWithNullableEnabled(string projectPath, string binlogPath, CancellationToken cancellationToken = default)
+    static async Task<string> BuildWithNullableEnabled(string projectPath, CancellationToken cancellationToken = default)
     {
         var startInfo = new ProcessStartInfo
         {
@@ -76,7 +64,6 @@ public partial class NullabilityWarnings
         startInfo.ArgumentList.Add("-p:Nullable=enable");
         startInfo.ArgumentList.Add("-p:TreatWarningsAsErrors=false");
         startInfo.ArgumentList.Add("-p:IsPackable=false");
-        startInfo.ArgumentList.Add($"-bl:{binlogPath}");
 
         using var process = Process.Start(startInfo)!;
 

--- a/src/NServiceBus.Core.Tests/API/TrimmabilityWarnings.cs
+++ b/src/NServiceBus.Core.Tests/API/TrimmabilityWarnings.cs
@@ -39,24 +39,12 @@ public partial class TrimmabilityWarnings
             "NServiceBus.Core",
             "NServiceBus.Core.csproj"));
 
-        var binlogPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "trimming.binlog");
+        var warnings = await BuildWithTrimmingAnalyzerEnabled(projectPath, cancellationToken);
 
-        try
-        {
-            var warnings = await BuildWithTrimmingAnalyzerEnabled(projectPath, binlogPath, cancellationToken);
-
-            Approver.Verify(warnings);
-        }
-        finally
-        {
-            if (File.Exists(binlogPath))
-            {
-                File.Delete(binlogPath);
-            }
-        }
+        Approver.Verify(warnings);
     }
 
-    static async Task<string> BuildWithTrimmingAnalyzerEnabled(string projectPath, string binlogPath, CancellationToken cancellationToken = default)
+    static async Task<string> BuildWithTrimmingAnalyzerEnabled(string projectPath, CancellationToken cancellationToken = default)
     {
         var startInfo = new ProcessStartInfo
         {
@@ -73,7 +61,6 @@ public partial class TrimmabilityWarnings
         startInfo.ArgumentList.Add("-p:EnableTrimAnalyzer=true");
         startInfo.ArgumentList.Add("-p:TreatWarningsAsErrors=false");
         startInfo.ArgumentList.Add("-p:IsPackable=false");
-        startInfo.ArgumentList.Add($"-bl:{binlogPath}");
 
         using var process = Process.Start(startInfo)!;
 


### PR DESCRIPTION
Originally the binlog was added in case someone wants to get detailed information about the build but so far we never needed it so I'm removing it