### PR TITLE
Fix edge case where InstrumentionOptions could not be a shared instance

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_processing_fails_with_exception_logs_opt_in.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_processing_fails_with_exception_logs_opt_in.cs
@@ -1,0 +1,59 @@
+namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry.Traces;
+
+using System.Linq;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using Configuration.AdvancedExtensibility;
+using EndpointTemplates;
+using NServiceBus;
+using NUnit.Framework;
+
+// The OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN override is applied while the OpenTelemetryFeature defaults
+// run, which is AFTER the endpoint's activity factory has already been built from the instrumentation
+// options. The opt-in only takes effect when the activity factory and the settings share a single
+// InstrumentationOptions instance.
+public class When_processing_fails_with_exception_logs_opt_in : OpenTelemetryAcceptanceTest
+{
+    [Test]
+    public async Task Should_record_the_exception_as_a_log_instead_of_a_span_event()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<FailingEndpoint>(e => e
+                .DoNotFailOnErrorMessages()
+                .When(s => s.SendLocal(new FailingMessage())))
+            .Run();
+
+        Assert.That(context.FailedMessages, Has.Count.EqualTo(1), "the message should have failed");
+
+        var handlerActivity = NServiceBusActivityListener.CompletedActivities.GetInvokedHandlerActivities().Single();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(handlerActivity.Events, Is.Empty, "the exception should not be recorded as a span event when the endpoint opted in to exceptions as logs");
+            Assert.That(context.Logs.Any(l => l.LoggerName == "NServiceBus.ActivityFactory" && l.Level == Logging.LogLevel.Error && l.Message.Contains(ErrorMessage)), Is.True, "the exception should be recorded as an error log instead");
+        }
+    }
+
+    public class Context : ScenarioContext;
+
+    public class FailingEndpoint : EndpointConfigurationBuilder
+    {
+        // Does not call endpointConfiguration.Tracing(): the instrumentation options only come into existence while the endpoint is being created.
+        public FailingEndpoint() => EndpointSetup<DefaultServer>(c => c.GetSettings().Set($"ACCEPTANCETEST_ENV:{OptInEnvironmentVariable}", "logs"));
+
+        [Handler]
+        public class FailingMessageHandler(Context testContext) : IHandleMessages<FailingMessage>
+        {
+            public Task Handle(FailingMessage message, IMessageHandlerContext context)
+            {
+                testContext.MarkAsCompleted();
+                throw new SimulatedException(ErrorMessage);
+            }
+        }
+    }
+
+    public class FailingMessage : IMessage;
+
+    const string OptInEnvironmentVariable = "OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN";
+    const string ErrorMessage = "boom!";
+}

--- a/src/NServiceBus.Core/Hosting/HostingComponent.Settings.cs
+++ b/src/NServiceBus.Core/Hosting/HostingComponent.Settings.cs
@@ -95,7 +95,7 @@ partial class HostingComponent
             get; set;
         }
 
-        public InstrumentationOptions InstrumentationOptions => settings.GetOrDefault<InstrumentationOptions>() ?? new InstrumentationOptions();
+        public InstrumentationOptions InstrumentationOptions => settings.GetOrCreate<InstrumentationOptions>();
 
         internal void ConfigureHostLogging(object? endpointIdentifier)
         {


### PR DESCRIPTION
Previously the InstrumentationOptions during initializaion COULD result in not having a singleton/shared instance. The edge case was when initialized based on ennvvars. This was applied on the resolved non shared instance.