### PR TITLE
Prepare Core for unsafe context changes in v11

### DIFF
--- a/src/NServiceBus.Core.Analyzer/Utility/NonCryptographicHash.cs
+++ b/src/NServiceBus.Core.Analyzer/Utility/NonCryptographicHash.cs
@@ -1,8 +1,6 @@
 namespace NServiceBus.Core.Analyzer.Utility;
 
 using System;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 /// <summary>
 /// 64-bit FNV-1a over chars, https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
@@ -21,34 +19,28 @@ public static class NonCryptographicHash
         {
             string part = parts[index];
             ReadOnlySpan<char> span = part.AsSpan();
-            ref char first = ref MemoryMarshal.GetReference(span);
             int length = span.Length;
             int i = 0;
             // Process 4 chars at a time
             for (; i + 3 < length; i += 4)
             {
-                char c0 = Unsafe.Add(ref first, i);
-                hash ^= c0;
+                hash ^= span[i];
                 hash *= prime;
 
-                char c1 = Unsafe.Add(ref first, i + 1);
-                hash ^= c1;
+                hash ^= span[i + 1];
                 hash *= prime;
 
-                char c2 = Unsafe.Add(ref first, i + 2);
-                hash ^= c2;
+                hash ^= span[i + 2];
                 hash *= prime;
 
-                char c3 = Unsafe.Add(ref first, i + 3);
-                hash ^= c3;
+                hash ^= span[i + 3];
                 hash *= prime;
             }
 
             // Handle remainder (0–3 chars)
             for (; i < length; i++)
             {
-                char c = Unsafe.Add(ref first, i);
-                hash ^= c;
+                hash ^= span[i];
                 hash *= prime;
             }
         }

--- a/src/NServiceBus.Core.Analyzer/Utility/SourceWriter.cs
+++ b/src/NServiceBus.Core.Analyzer/Utility/SourceWriter.cs
@@ -110,12 +110,16 @@ public sealed class SourceWriter
         return next;
     }
 
-    static unsafe void AppendSpan(StringBuilder builder, ReadOnlySpan<char> span)
+    static void AppendSpan(StringBuilder builder, ReadOnlySpan<char> span)
     {
         // There is no StringBuilder.Append(ReadOnlySpan<char>) overload in the NS2.0
-        fixed (char* ptr = span)
+        // SAFETY: fixed pins the span for the synchronous Append call; length is explicit, no null terminator assumed.
+        unsafe
         {
-            builder.Append(ptr, span.Length);
+            fixed (char* ptr = span)
+            {
+                builder.Append(ptr, span.Length);
+            }
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/IBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/IBehavior.cs
@@ -32,6 +32,7 @@ public interface IBehavior<in TInContext, out TOutContext> : IBehavior
         else
         {
             Func<IBehaviorContext, Task> fn = next.Invoke;
+            // SAFETY: Pipeline wiring guarantees next is invoked only with TOutContext (a reference type); the delegate retype is representation-preserving.
             nextFunc = Unsafe.As<Func<IBehaviorContext, Task>, Func<TOutContext, Task>>(ref fn);
         }
 

--- a/src/NServiceBus.Core/Pipeline/InvokerNode.cs
+++ b/src/NServiceBus.Core/Pipeline/InvokerNode.cs
@@ -30,6 +30,7 @@ sealed class InvokerNode<TInContext, TOutContext>(IBehavior<TInContext, TOutCont
     public override Task Invoke(IBehaviorContext context)
     {
         object obj = context;
+        // SAFETY: Pipeline routing guarantees context is a TInContext (reference type); retype skips a redundant castclass.
         return behavior.Invoke(Unsafe.As<object, TInContext>(ref obj), next);
     }
 }

--- a/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
@@ -248,6 +248,7 @@ public class MessageHandlerRegistry
         static readonly ObjectFactory<THandler> factory = ActivatorUtilities.CreateFactory<THandler>([]);
 
         static readonly ObjectFactory<IHandleTimeouts<TMessage>> handlerFactory =
+            // SAFETY: Registration validated THandler implements IHandleTimeouts<TMessage>; retype skips the interface cast.
             static (sp, args) => Unsafe.As<IHandleTimeouts<TMessage>>(factory(sp, args));
     }
 
@@ -274,6 +275,7 @@ public class MessageHandlerRegistry
         static readonly ObjectFactory<THandler> factory = ActivatorUtilities.CreateFactory<THandler>([]);
 
         static readonly ObjectFactory<IHandleMessages<TMessage>> handlerFactory =
+            // SAFETY: Registration validated THandler implements IHandleMessages<TMessage>; retype skips the interface cast.
             static (sp, args) => Unsafe.As<IHandleMessages<TMessage>>(factory(sp, args));
     }
 }

--- a/src/NServiceBus.Core/Utils/ArrayPoolBufferWriter.cs
+++ b/src/NServiceBus.Core/Utils/ArrayPoolBufferWriter.cs
@@ -5,7 +5,6 @@ namespace NServiceBus;
 using System;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 
 sealed class ArrayPoolBufferWriter<T>(
     ArrayPool<T> pool,
@@ -126,7 +125,20 @@ sealed class ArrayPoolBufferWriter<T>(
     }
 
 
-    Memory<T> IMemoryOwner<T>.Memory => MemoryMarshal.AsMemory(WrittenMemory);
+    Memory<T> IMemoryOwner<T>.Memory
+    {
+        get
+        {
+            T[]? array = buffer;
+
+            if (array is null)
+            {
+                ThrowObjectDisposedException();
+            }
+
+            return array.AsMemory(0, WrittenCount);
+        }
+    }
 
     public void Dispose()
     {

--- a/src/NServiceBus.Core/Utils/LazyArrayPoolBufferWriter.cs
+++ b/src/NServiceBus.Core/Utils/LazyArrayPoolBufferWriter.cs
@@ -5,7 +5,6 @@ namespace NServiceBus;
 using System;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 
 sealed class LazyArrayPoolBufferWriter<T>(int? capacity = null) : IBufferWriter<T>, IMemoryOwner<T>
 {
@@ -56,7 +55,7 @@ sealed class LazyArrayPoolBufferWriter<T>(int? capacity = null) : IBufferWriter<
     public void Clear() => innerWriter?.Clear();
     public void Dispose() => innerWriter?.Dispose();
 
-    Memory<T> IMemoryOwner<T>.Memory => MemoryMarshal.AsMemory(WrittenMemory);
+    Memory<T> IMemoryOwner<T>.Memory => innerWriter is null ? Memory<T>.Empty : ((IMemoryOwner<T>)innerWriter).Memory;
 
     [MemberNotNull(nameof(innerWriter))]
     void EnsureInnerWriter() => innerWriter ??= capacity is null ? new ArrayPoolBufferWriter<T>() : new ArrayPoolBufferWriter<T>(capacity.Value);


### PR DESCRIPTION
AllowUnsafeBlocks still has to be set because we use `SkipLocalsInit`

Additional blocker is https://github.com/dadhi/FastExpressionCompiler/issues/552