### PR TITLE
Started perf optimizations

### DIFF
--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityFactoryTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityFactoryTests.cs
@@ -258,6 +258,80 @@ public class ActivityFactoryTests
         }
     }
 
+    class PropagationDataSampling
+    {
+        readonly ActivityFactory activityFactory = new(new InstrumentationOptions());
+
+        TestingActivityListener nsbActivityListener;
+
+        [OneTimeSetUp]
+        public void Setup() => nsbActivityListener = TestingActivityListener.SetupNServiceBusDiagnosticListener(ActivitySamplingResult.PropagationData);
+
+        [OneTimeTearDown]
+        public void TearDown() => nsbActivityListener.Dispose();
+
+        [Test]
+        public void Should_create_activity_but_skip_header_tag_promotion()
+        {
+            var messageHeaders = new Dictionary<string, string> { { Headers.SagaId, Guid.NewGuid().ToString() } };
+            var messageContext = CreateMessageContext(messageHeaders);
+
+            var activity = activityFactory.StartIncomingPipelineActivity(messageContext);
+
+            Assert.That(activity, Is.Not.Null, "PropagationData should still create an activity");
+            var tags = activity.Tags.ToImmutableDictionary();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(activity.IsAllDataRequested, Is.False);
+                Assert.That(tags.ContainsKey(ActivityTags.SagaId), Is.False, "should not promote headers to tags when not all data requested");
+                Assert.That(tags[ActivityTags.NativeMessageId], Is.EqualTo(messageContext.NativeMessageId), "native message id tag should always be set");
+            }
+        }
+
+        [Test]
+        public void Should_not_add_exception_event_or_legacy_tags_on_error()
+        {
+            var activity = activityFactory.StartIncomingPipelineActivity(CreateMessageContext());
+            Assert.That(activity, Is.Not.Null);
+
+            activityFactory.RecordError(activity, new Exception("boom"), new ContextBag());
+
+            var tags = activity.Tags.ToImmutableDictionary();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Error), "status should always be set");
+                Assert.That(tags.ContainsKey(ActivityTags.ErrorType), Is.True, "error type tag should always be set");
+                Assert.That(tags.ContainsKey("otel.status_code"), Is.False, "legacy tags should be skipped when not all data requested");
+                Assert.That(activity.Events, Is.Empty, "no exception event should be recorded when not all data requested");
+            }
+        }
+
+        [Test]
+        public void Should_not_update_activity_from_recoverability_action()
+        {
+            var activity = activityFactory.StartIncomingPipelineActivity(CreateMessageContext());
+            Assert.That(activity, Is.Not.Null);
+            var originalDisplayName = activity.DisplayName;
+
+            activityFactory.UpdateActivityFromRecoverabilityAction(activity, new ImmediateRetry(), "receiveAddress");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(activity.DisplayName, Is.EqualTo(originalDisplayName), "display name should not change when not all data requested");
+                Assert.That(activity.Tags.ToImmutableDictionary().ContainsKey(ActivityTags.RecoverabilityAction), Is.False);
+            }
+        }
+
+        static MessageContext CreateMessageContext(Dictionary<string, string>? messageHeaders = null) =>
+            new(
+                Guid.NewGuid().ToString(),
+                messageHeaders ?? [],
+                Array.Empty<byte>(),
+                new TransportTransaction(),
+                "receiver",
+                new ContextBag());
+    }
+
     class StartHandlerActivity : ActivityFactoryTests
     {
         [Test]

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityFactoryTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityFactoryTests.cs
@@ -371,4 +371,32 @@ public class ActivityFactoryTests
             Assert.That(activity, Is.Not.Null);
         }
     }
+
+    class RecordError : ActivityFactoryTests
+    {
+        [Test]
+        public void Should_set_legacy_tags_on_every_activity_even_after_exception_already_recorded()
+        {
+            // Simulates an exception unwinding through the pipeline: the handler activity records it first,
+            // then the same exception instance reaches RecordError again on the enclosing pipeline activity.
+            using var pipelineActivity = ActivitySources.Main.StartActivity("pipeline activity");
+            Assert.That(pipelineActivity, Is.Not.Null);
+            using var handlerActivity = ActivitySources.Main.StartActivity("handler activity");
+            Assert.That(handlerActivity, Is.Not.Null);
+            var exception = new Exception("boom");
+
+            activityFactory.RecordError(handlerActivity!, exception, new ContextBag());
+            activityFactory.RecordError(pipelineActivity!, exception, new ContextBag());
+
+            var pipelineTags = pipelineActivity!.Tags.ToImmutableDictionary();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(pipelineActivity.Status, Is.EqualTo(ActivityStatusCode.Error), "status should be set on every activity");
+                Assert.That(pipelineTags.ContainsKey("otel.status_code"), Is.True, "legacy tags should be set on every activity, not deduped via ExceptionRecordedFlag");
+                Assert.That(pipelineTags.ContainsKey("otel.status_description"), Is.True, "legacy tags should be set on every activity, not deduped via ExceptionRecordedFlag");
+                Assert.That(handlerActivity!.Events.Count(), Is.EqualTo(1), "the first activity to see the exception records the event");
+                Assert.That(pipelineActivity.Events, Is.Empty, "the exception event itself should still only be recorded once");
+            }
+        }
+    }
 }

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/Helpers/TestingActivityListener.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/Helpers/TestingActivityListener.cs
@@ -7,24 +7,25 @@ class TestingActivityListener : IDisposable
 {
     readonly ActivityListener activityListener;
 
-    public static TestingActivityListener SetupNServiceBusDiagnosticListener() => SetupDiagnosticListener(ActivitySources.Main.Name);
+    public static TestingActivityListener SetupNServiceBusDiagnosticListener(ActivitySamplingResult samplingResult = ActivitySamplingResult.AllData) =>
+        SetupDiagnosticListener(ActivitySources.Main.Name, samplingResult);
 
-    public static TestingActivityListener SetupDiagnosticListener(string sourceName)
+    public static TestingActivityListener SetupDiagnosticListener(string sourceName, ActivitySamplingResult samplingResult = ActivitySamplingResult.AllData)
     {
-        var testingListener = new TestingActivityListener(sourceName);
+        var testingListener = new TestingActivityListener(sourceName, samplingResult);
 
         ActivitySource.AddActivityListener(testingListener.activityListener);
         return testingListener;
     }
 
-    TestingActivityListener(string sourceName = null)
+    TestingActivityListener(string sourceName = null, ActivitySamplingResult samplingResult = ActivitySamplingResult.AllData)
     {
         // do not rely on activities from the notifications as tests are run in parallel
         activityListener = new ActivityListener
         {
             ShouldListenTo = source => string.IsNullOrEmpty(sourceName) || source.Name == sourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
-            SampleUsingParentId = (ref ActivityCreationOptions<string> options) => ActivitySamplingResult.AllData
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => samplingResult,
+            SampleUsingParentId = (ref ActivityCreationOptions<string> options) => samplingResult
         };
     }
     public void Dispose() => activityListener?.Dispose();

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityExtensions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityExtensions.cs
@@ -21,7 +21,7 @@ static class ActivityExtensions
     {
         if (Activity.Current is not null // Cheaper to check than searching the pipeline context to start with. If there is no ambient activity, there can't be an activity in the context.
             && pipelineContext.TryGet(activityKey, out activity)  // Search activity in context bag
-            && activity is { IsAllDataRequested: true }) // do not apply "expensive" work on non-recording activities
+            && activity is { IsAllDataRequested: true }) // skip expensive work when no listener asked for full data (IsAllDataRequested, not Recorded/sampled)
         {
             return true;
         }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
@@ -71,12 +71,18 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
             return activity;
         }
 
+        // Baggage/tracestate propagation is correctness, not enrichment, so it must run regardless of sampling.
         ContextPropagation.PropagateContextFromHeaders(activity, headers);
 
         activity.SetIdFormat(ActivityIdFormat.W3C);
         activity.AddTag(ActivityTags.NativeMessageId, nativeMessageId);
 
-        ActivityDecorator.PromoteHeadersToTags(activity, headers);
+        // IsAllDataRequested is false when a listener sampled this as PropagationData-only: it wants the
+        // activity to exist for context propagation but won't read anything beyond that, so skip the tag work.
+        if (activity.IsAllDataRequested)
+        {
+            ActivityDecorator.PromoteHeadersToTags(activity, headers);
+        }
 
         return activity;
     }
@@ -170,6 +176,13 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
 
     public void UpdateActivityFromRecoverabilityAction(Activity activity, RecoverabilityAction recoverabilityAction, string receiveAddress)
     {
+        // Nothing below is read unless a listener asked for full data (IsAllDataRequested), so bail out early
+        // rather than building tags and DisplayName strings for an activity nobody will inspect.
+        if (!activity.IsAllDataRequested)
+        {
+            return;
+        }
+
         if (recoverabilityAction is ImmediateRetry)
         {
             activity.AddTag(ActivityTags.RecoverabilityAction, "immediate_retry");
@@ -210,16 +223,18 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
         activity.SetStatus(ActivityStatusCode.Error, exception.Message);
         activity.SetTag(ActivityTags.ErrorType, exception.GetType().FullName);
 
-        LegacyExceptionTags.SetLegacyStatusTags(activity, exception);
-
         if (!exception.Data.Contains(ExceptionRecordedFlag))
         {
             if (Options.ExceptionRecordingMode == ExceptionRecordingMode.Logs)
             {
                 Logger.Error($"An exception occurred while executing '{activity.DisplayName}'.", exception);
             }
-            else
+            else if (activity.IsAllDataRequested)
             {
+                // Recording the exception on the activity (stack trace event + legacy tags) only matters
+                // if a listener asked for full data; skip it otherwise. The Logs branch above is a separate
+                // capture path and stays unconditional regardless of IsAllDataRequested.
+                LegacyExceptionTags.SetLegacyStatusTags(activity, exception);
                 activity.AddException(exception, LegacyExceptionTags.EscapedTagList);
             }
 

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
@@ -223,6 +223,14 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
         activity.SetStatus(ActivityStatusCode.Error, exception.Message);
         activity.SetTag(ActivityTags.ErrorType, exception.GetType().FullName);
 
+        // Legacy tags apply per-activity (each activity on the way up the pipeline gets its own),
+        // unlike the exception event below which is deduped once per exception via ExceptionRecordedFlag.
+        // Only the "is this worth computing" part is guarded by IsAllDataRequested.
+        if (activity.IsAllDataRequested)
+        {
+            LegacyExceptionTags.SetLegacyStatusTags(activity, exception);
+        }
+
         if (!exception.Data.Contains(ExceptionRecordedFlag))
         {
             if (Options.ExceptionRecordingMode == ExceptionRecordingMode.Logs)
@@ -231,10 +239,7 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
             }
             else if (activity.IsAllDataRequested)
             {
-                // Recording the exception on the activity (stack trace event + legacy tags) only matters
-                // if a listener asked for full data; skip it otherwise. The Logs branch above is a separate
-                // capture path and stays unconditional regardless of IsAllDataRequested.
-                LegacyExceptionTags.SetLegacyStatusTags(activity, exception);
+                // Building the exception event (stack trace) is wasted work when nothing downstream will read it.
                 activity.AddException(exception, LegacyExceptionTags.EscapedTagList);
             }
 


### PR DESCRIPTION
## Skip OTel enrichment work when `IsAllDataRequested` is false

IsAllDataRequested, is represented by https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#isrecording


https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md#:~:text=a%20null%20check.-,Populate,-activity%20with%20tags



`ActivityFactory` was only null-checking activities before doing enrichment work (promoting
headers to tags, recording exceptions, updating recoverability tags/`DisplayName`), even when a
listener sampled the activity as `PropagationData`-only (`IsAllDataRequested == false`). In that
case the work is wasted: nothing reads it.

This guards the expensive paths behind `IsAllDataRequested`, matching the pattern already used
by `TryGetRecordingOutgoingPipelineActivity`/`TryGetRecordingIncomingPipelineActivity`:

- `PromoteHeadersToTags` (header -> tag mapping on incoming messages) - skipped when not
  requested. Context propagation (baggage/tracestate) stays unconditional since it's
  correctness, not enrichment.
- `RecordError` - the exception event (stack trace) and legacy
  `otel.status_code`/`otel.status_description` tags are now guarded. `SetStatus`, the
  `ErrorType` tag, and the `Logs`-mode logging fallback stay unconditional.
- `UpdateActivityFromRecoverabilityAction` - now a no-op when not requested.

No behavior change for fully-sampled or no-listener cases. Added a `PropagationDataSampling`
test class in `ActivityFactoryTests.cs` (and a sampling-result parameter on the shared
`TestingActivityListener`, default unchanged) to cover the previously untested `PropagationData`
path.
