### PR TITLE
RollingLogger race condition due to file system failures

### DIFF
--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
@@ -156,18 +156,19 @@ public class RollingLoggerTests
     public void When_sync_fails_during_filename_calculation_state_is_not_committed_and_next_write_retries()
     {
         using var tempPath = new TempPath("RollingLoggerTests");
-        var logger = new RollingLoggerThatFailsSizeLookup(tempPath.TempDirectory, maxFileSize: 4)
+        var logger = new RollingLoggerThatFailsSizeLookup(tempPath.TempDirectory, maxFileSize: 20)
         {
             GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
         };
-        logger.WriteLine("Foo");
-        logger.WriteLine("Bar");
+        logger.WriteLine("LongMessage");
+        logger.WriteLine("LongMessage");
 
         logger.GetDate = () => new DateTimeOffset(2010, 10, 2, 0, 0, 0, TimeSpan.Zero);
         logger.WriteLine("Baz");
 
-        // The clock moves back to a date that already has an oversized file. The metadata read fails,
-        // so the synchronization must abort without committing the new date
+        // The clock moves back to a date that already has an oversized file while the stale current file
+        // remains below the size limit. The metadata read fails, so the synchronization must abort without
+        // committing the new date; otherwise the next write would stay on the stale file and not retry.
         logger.GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero);
         logger.FailSizeLookup = true;
         logger.WriteLine("Qux");

--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
@@ -97,6 +97,36 @@ public class RollingLoggerTests
     }
 
     [Test]
+    public void When_file_is_deleted_underneath_immediately_before_size_lookup()
+    {
+        using var tempPath = new TempPath("RollingLoggerTests");
+        var logger = new RollingLoggerThatDeletesBeforeSizeLookup(tempPath.TempDirectory, maxFileSize: 2)
+        {
+            GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+        logger.WriteLine("Foo");
+
+        // Second write exceeds maxFileSize, so the synchronization enumerates today's file;
+        // the override removes it between enumeration and the metadata read
+        logger.WriteLine("Bar");
+
+        // The name proves the sequence number was reused (vanished file counts as empty)
+        // instead of rolling to a new sequence
+        var file = tempPath.GetSingle();
+        Assert.That(Path.GetFileName(file), Is.EqualTo("nsb_log_2010-10-01_0.txt"));
+    }
+
+    class RollingLoggerThatDeletesBeforeSizeLookup(string targetDirectory, long maxFileSize) :
+        RollingLogger(targetDirectory, maxFileSize: maxFileSize)
+    {
+        protected override long GetFileSizeOrZero(string path)
+        {
+            File.Delete(path);
+            return base.GetFileSizeOrZero(path);
+        }
+    }
+
+    [Test]
     public void When_file_already_exists_and_is_too_large_a_new_sequence_file_is_written()
     {
         using var tempPath = new TempPath("RollingLoggerTests");

--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
@@ -127,6 +127,77 @@ public class RollingLoggerTests
     }
 
     [Test]
+    public void When_size_lookup_fails_with_io_error_sync_is_aborted_and_retried()
+    {
+        using var tempPath = new TempPath("RollingLoggerTests");
+        var logger = new RollingLoggerThatFailsSizeLookup(tempPath.TempDirectory, maxFileSize: 10)
+        {
+            GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+        logger.WriteLine("Foo");
+        logger.WriteLine("Bar");
+        logger.WriteLine("Baz");
+
+        // The metadata read fails with a transient I/O error, which must abort the synchronization
+        // instead of treating the file as empty and reusing it
+        logger.FailSizeLookup = true;
+        logger.WriteLine("Qux");
+        logger.FailSizeLookup = false;
+
+        // The next write retries the synchronization and rolls to a new sequence
+        logger.WriteLine("Foo2");
+
+        var files = tempPath.GetFiles();
+        Assert.That(files, Has.Count.EqualTo(2));
+        Assert.That(Path.GetFileName(files[1]), Is.EqualTo("nsb_log_2010-10-01_1.txt"));
+    }
+
+    [Test]
+    public void When_sync_fails_during_filename_calculation_state_is_not_committed_and_next_write_retries()
+    {
+        using var tempPath = new TempPath("RollingLoggerTests");
+        var logger = new RollingLoggerThatFailsSizeLookup(tempPath.TempDirectory, maxFileSize: 4)
+        {
+            GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+        logger.WriteLine("Foo");
+        logger.WriteLine("Bar");
+
+        logger.GetDate = () => new DateTimeOffset(2010, 10, 2, 0, 0, 0, TimeSpan.Zero);
+        logger.WriteLine("Baz");
+
+        // The clock moves back to a date that already has an oversized file. The metadata read fails,
+        // so the synchronization must abort without committing the new date
+        logger.GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero);
+        logger.FailSizeLookup = true;
+        logger.WriteLine("Qux");
+        logger.FailSizeLookup = false;
+
+        // The next write retries the synchronization and rolls the oversized day one file
+        logger.WriteLine("Foo2");
+
+        var files = tempPath.GetFiles();
+        Assert.That(files, Has.Count.EqualTo(3));
+        Assert.That(Path.GetFileName(files[1]), Is.EqualTo("nsb_log_2010-10-01_1.txt"));
+    }
+
+    class RollingLoggerThatFailsSizeLookup(string targetDirectory, long maxFileSize) :
+        RollingLogger(targetDirectory, maxFileSize: maxFileSize)
+    {
+        public bool FailSizeLookup { get; set; }
+
+        protected override long GetFileSizeOrZero(string path)
+        {
+            if (FailSizeLookup)
+            {
+                // An overlong path component makes the metadata read throw a PathTooLongException
+                return base.GetFileSizeOrZero(Path.Combine(Path.GetDirectoryName(path)!, new string('x', 300)));
+            }
+            return base.GetFileSizeOrZero(path);
+        }
+    }
+
+    [Test]
     public void When_file_already_exists_and_is_too_large_a_new_sequence_file_is_written()
     {
         using var tempPath = new TempPath("RollingLoggerTests");

--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
@@ -396,4 +396,29 @@ public class RollingLoggerTests
         var singleFile = tempPath.GetSingle();
         Assert.That(Path.GetFileName(singleFile), Is.EqualTo("nsb_log_2010-10-01_0.txt"));
     }
+
+    [Test]
+    public void When_log_directory_is_deleted_underneath_write_does_not_throw_and_recovers()
+    {
+        using var tempPath = new TempPath("RollingLoggerTests");
+        var logger = new RollingLogger(tempPath.TempDirectory)
+        {
+            GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+        logger.WriteLine("Foo");
+
+        Directory.Delete(tempPath.TempDirectory, true);
+        logger.GetDate = () => new DateTimeOffset(2010, 10, 2, 0, 0, 0, TimeSpan.Zero);
+
+        // Simulates e.g. a deployment or slot swap removing the whole log directory: the synchronization
+        // and the write must degrade to tracing instead of throwing out of WriteLine
+        Assert.That(() => logger.WriteLine("Bar"), Throws.Nothing);
+
+        Directory.CreateDirectory(tempPath.TempDirectory);
+        logger.WriteLine("Baz");
+
+        // GetSingle also verifies the day one file is not resurrected after the directory came back
+        var singleFile = tempPath.GetSingle();
+        Assert.That(Path.GetFileName(singleFile), Is.EqualTo("nsb_log_2010-10-02_0.txt"));
+    }
 }

--- a/src/NServiceBus.Core/Logging/RollingLogger.cs
+++ b/src/NServiceBus.Core/Logging/RollingLogger.cs
@@ -52,15 +52,16 @@ class RollingLogger(
             }
             var today = GetDate();
             var nsbLogFiles = GetNsbLogFiles(targetDirectory).ToList();
-            lastWriteDate = today;
             CalculateNewFileName(nsbLogFiles, today);
+            lastWriteDate = today;
             PurgeOldFiles(nsbLogFiles);
         }
         catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
         {
             // Tolerate environmental file system failures like the log directory or its files being removed
             // by overlapping processes, deployments, slot swaps or cleanups. Anything else is a bug and propagates.
-            // lastWriteDate is only updated once the synchronization succeeded so a failed attempt is retried on the next write.
+            // The synchronization state is only committed once the filename calculation succeeded so a failed
+            // attempt is retried on the next write.
             var errorMessage = $"NServiceBus.RollingLogger Could not synchronize log files in directory '{targetDirectory}'. Exception: {exception}";
             Trace.WriteLine(errorMessage);
         }
@@ -143,11 +144,13 @@ class RollingLogger(
         {
             return new FileInfo(path).Length;
         }
-        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)
         {
             // The file can vanish between enumerating it and reading its metadata, e.g. removed by
             // overlapping processes, deployments or external cleanup. Treat it as empty so the
-            // sequence number is reused and the file is recreated by the next append
+            // sequence number is reused and the file is recreated by the next append. Any other
+            // failure, like a transient I/O error or an ACL that denies metadata reads, aborts the
+            // synchronization instead of resetting the tracked size and reusing the oversized file.
             return 0;
         }
     }

--- a/src/NServiceBus.Core/Logging/RollingLogger.cs
+++ b/src/NServiceBus.Core/Logging/RollingLogger.cs
@@ -44,15 +44,26 @@ class RollingLogger(
 
     void SyncFileSystem()
     {
-        if (!HasCurrentDateChanged() && !IsCurrentFileTooLarge())
+        try
         {
-            return;
+            if (!HasCurrentDateChanged() && !IsCurrentFileTooLarge())
+            {
+                return;
+            }
+            var today = GetDate();
+            var nsbLogFiles = GetNsbLogFiles(targetDirectory).ToList();
+            lastWriteDate = today;
+            CalculateNewFileName(nsbLogFiles, today);
+            PurgeOldFiles(nsbLogFiles);
         }
-        var today = GetDate();
-        lastWriteDate = today;
-        var nsbLogFiles = GetNsbLogFiles(targetDirectory).ToList();
-        CalculateNewFileName(nsbLogFiles, today);
-        PurgeOldFiles(nsbLogFiles);
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // Tolerate environmental file system failures like the log directory or its files being removed
+            // by overlapping processes, deployments, slot swaps or cleanups. Anything else is a bug and propagates.
+            // lastWriteDate is only updated once the synchronization succeeded so a failed attempt is retried on the next write.
+            var errorMessage = $"NServiceBus.RollingLogger Could not synchronize log files in directory '{targetDirectory}'. Exception: {exception}";
+            Trace.WriteLine(errorMessage);
+        }
     }
 
     bool HasCurrentDateChanged() => GetDate() != lastWriteDate;
@@ -126,6 +137,21 @@ class RollingLogger(
 
     static bool TryParseDate(string datePart, out DateTimeOffset dateTime) => DateTimeOffset.TryParseExact(datePart, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out dateTime);
 
+    static long GetFileSizeOrZero(string path)
+    {
+        try
+        {
+            return new FileInfo(path).Length;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // The file can vanish between enumerating it and reading its metadata, e.g. removed by
+            // overlapping processes, deployments or external cleanup. Treat it as empty so the
+            // sequence number is reused and the file is recreated by the next append
+            return 0;
+        }
+    }
+
     void CalculateNewFileName(List<LogFile> logFiles, DateTimeOffset today)
     {
         var logFile = GetTodaysNewest(logFiles, today);
@@ -137,7 +163,7 @@ class RollingLogger(
         }
         else
         {
-            var existingFileSize = new FileInfo(logFile.Path).Length;
+            var existingFileSize = GetFileSizeOrZero(logFile.Path);
             if (existingFileSize > maxFileSize)
             {
                 sequenceNumber = logFile.SequenceNumber + 1;

--- a/src/NServiceBus.Core/Logging/RollingLogger.cs
+++ b/src/NServiceBus.Core/Logging/RollingLogger.cs
@@ -137,7 +137,7 @@ class RollingLogger(
 
     static bool TryParseDate(string datePart, out DateTimeOffset dateTime) => DateTimeOffset.TryParseExact(datePart, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out dateTime);
 
-    static long GetFileSizeOrZero(string path)
+    protected virtual long GetFileSizeOrZero(string path)
     {
         try
         {


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus/issues/7919

This pull request improves the robustness of the `RollingLogger` by handling file system disruptions more gracefully, such as deleted log files or directories, and adds tests to verify these behaviors. The core logic is updated to tolerate and recover from environmental file system failures, ensuring that logging continues without throwing exceptions in these scenarios.

**Resilience improvements to `RollingLogger`:**

* Wrapped the file synchronization logic in `SyncFileSystem()` with a try/catch block to handle `IOException` and `UnauthorizedAccessException`, logging the error and allowing the logger to continue operating instead of throwing. This ensures that transient file system issues (like deleted directories or files) do not crash the logger.
* Added a new protected method `GetFileSizeOrZero(string path)` that safely retrieves the size of a file, returning zero if the file is missing or inaccessible, to handle cases where files may be deleted between enumeration and metadata reading.
* Updated `CalculateNewFileName` to use the new `GetFileSizeOrZero` method, ensuring resilience when determining log file sizes.

**New tests for file system failure scenarios:**

* Added a test to verify that if the log file is deleted just before size lookup, the logger treats it as empty and reuses the sequence number instead of rolling to a new file. Introduced a custom logger subclass for this scenario.
* Added a test to verify that if the log directory is deleted, subsequent writes do not throw exceptions and the logger recovers gracefully once the directory is recreated.