### PR TITLE
Saga correlation id loading falls back to expression compilation instead of using the source-generated correlation accessor

### DIFF
--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.BasicSagas.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.BasicSagas.approved.txt
@@ -39,7 +39,7 @@ namespace NServiceBus
                             OrderBilledOrderIdAccessor_f7dc3394c771851e.Instance,
                             OrderPlacedOrderIdAccessor_ae6ad694572b9fcb.Instance,
                         ];
-                        var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Billing.OrderBillingPolicy, global::Orders.Billing.OrderBillingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                        var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Billing.OrderBillingPolicy, global::Orders.Billing.OrderBillingPolicyData>(associatedMessages, OrderIdAsStringAccessor_5b84242b5a03d625.Instance, propertyAccessors);
                         sagaMetadataCollection.Add(metadata);
 
                         var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -77,7 +77,7 @@ namespace NServiceBus
                             OrderBilledOrderIdAccessor_08b7b00354e1d041.Instance,
                             OrderPlacedOrderIdAccessor_13dea9c2dc628538.Instance,
                         ];
-                        var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.OrderShippingPolicy, global::Orders.Shipping.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                        var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.OrderShippingPolicy, global::Orders.Shipping.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_1073497622a938fb.Instance, propertyAccessors);
                         sagaMetadataCollection.Add(metadata);
 
                         var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -115,7 +115,7 @@ namespace NServiceBus
                         OrderBilledOrderIdAccessor_2fd27f5436ef20b9.Instance,
                         OrderPlacedOrderIdAccessor_c561311f0fcc5cf0.Instance,
                     ];
-                    var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Payments.PaymentsPolicy, global::Payments.PaymentsPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                    var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Payments.PaymentsPolicy, global::Payments.PaymentsPolicyData>(associatedMessages, OrderIdAsStringAccessor_6d931b1825e0c4ca.Instance, propertyAccessors);
                     sagaMetadataCollection.Add(metadata);
 
                     var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -216,21 +216,59 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_5b84242b5a03d625 : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_5b84242b5a03d625() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.Billing.OrderBillingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::Orders.Billing.OrderBillingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.Billing.OrderBillingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::Orders.Billing.OrderBillingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_5b84242b5a03d625();
+    }
+
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
+    file sealed class OrderIdAsStringAccessor_1073497622a938fb : NServiceBus.Sagas.CorrelationPropertyAccessor
+    {
+        OrderIdAsStringAccessor_1073497622a938fb() { }
+
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.Shipping.OrderShippingPolicyData)sagaData);
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
+        static extern string AccessFrom_Property(global::Orders.Shipping.OrderShippingPolicyData sagaData);
+
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.Shipping.OrderShippingPolicyData)sagaData, ((string)value));
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
+        static extern void WriteTo_Property(global::Orders.Shipping.OrderShippingPolicyData sagaData, string value);
+
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_1073497622a938fb();
+    }
+
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
+    file sealed class OrderIdAsStringAccessor_6d931b1825e0c4ca : NServiceBus.Sagas.CorrelationPropertyAccessor
+    {
+        OrderIdAsStringAccessor_6d931b1825e0c4ca() { }
+
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Payments.PaymentsPolicyData)sagaData);
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
+        static extern string AccessFrom_Property(global::Payments.PaymentsPolicyData sagaData);
+
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Payments.PaymentsPolicyData)sagaData, ((string)value));
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
+        static extern void WriteTo_Property(global::Payments.PaymentsPolicyData sagaData, string value);
+
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_6d931b1825e0c4ca();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.CastSyntaxWrappers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.CastSyntaxWrappers.approved.txt
@@ -32,7 +32,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -60,21 +60,21 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.DuplicatePropertyDefinitionsWithCompilationErrors.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.DuplicatePropertyDefinitionsWithCompilationErrors.approved.txt
@@ -36,7 +36,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -64,21 +64,21 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.ExpressionBodiedConfigureHowToFindSaga.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.ExpressionBodiedConfigureHowToFindSaga.approved.txt
@@ -32,7 +32,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -60,21 +60,21 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.InheritedMessageProperty.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.InheritedMessageProperty.approved.txt
@@ -34,7 +34,7 @@ namespace NServiceBus
                     OrderBilledOrderIdAccessor_b1eaacebc632acfc.Instance,
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -78,21 +78,21 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.InvalidMappingWithCompilationErrors.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.InvalidMappingWithCompilationErrors.approved.txt
@@ -37,7 +37,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -67,21 +67,21 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.NestedSagas.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.NestedSagas.approved.txt
@@ -40,7 +40,7 @@ namespace NServiceBus
                             OrderBilledOrderIdAccessor_b1eaacebc632acfc.Instance,
                             OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                         ];
-                        var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicy, global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                        var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicy, global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_f53ba98a08e6a113.Instance, propertyAccessors);
                         sagaMetadataCollection.Add(metadata);
 
                         var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -71,7 +71,7 @@ namespace NServiceBus
                             OrderBilledOrderIdAccessor_b1eaacebc632acfc.Instance,
                             OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                         ];
-                        var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.OuterClass.OrderShippingPolicy, global::Orders.Shipping.OuterClass.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                        var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.OuterClass.OrderShippingPolicy, global::Orders.Shipping.OuterClass.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_14af697526a7e650.Instance, propertyAccessors);
                         sagaMetadataCollection.Add(metadata);
 
                         var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -119,21 +119,40 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_f53ba98a08e6a113 : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_f53ba98a08e6a113() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_f53ba98a08e6a113();
+    }
+
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
+    file sealed class OrderIdAsStringAccessor_14af697526a7e650 : NServiceBus.Sagas.CorrelationPropertyAccessor
+    {
+        OrderIdAsStringAccessor_14af697526a7e650() { }
+
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.Shipping.OuterClass.OrderShippingPolicyData)sagaData);
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
+        static extern string AccessFrom_Property(global::Orders.Shipping.OuterClass.OrderShippingPolicyData sagaData);
+
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.Shipping.OuterClass.OrderShippingPolicyData)sagaData, ((string)value));
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
+        static extern void WriteTo_Property(global::Orders.Shipping.OuterClass.OrderShippingPolicyData sagaData, string value);
+
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_14af697526a7e650();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.NullableReferenceTypeMappings.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.NullableReferenceTypeMappings.approved.txt
@@ -32,7 +32,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -60,21 +60,21 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.NullableReferenceTypeMixedMappings.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.NullableReferenceTypeMixedMappings.approved.txt
@@ -33,7 +33,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     NullableMessageOrderIdAccessor_9894122651576960.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::NonNullableSaga, global::NonNullableSagaData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::NonNullableSaga, global::NonNullableSagaData>(associatedMessages, OrderIdAsStringAccessor_5e4ee6a1b6193efa.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -57,7 +57,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     NonNullableMessageOrderIdAccessor_e023774f080a36b1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::NullableSaga, global::NullableSagaData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::NullableSaga, global::NullableSagaData>(associatedMessages, OrderIdAsStringAccessor_acfa87ac0bc7f48b.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -99,21 +99,40 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_5e4ee6a1b6193efa : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_5e4ee6a1b6193efa() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::NonNullableSagaData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::NonNullableSagaData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::NonNullableSagaData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::NonNullableSagaData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_5e4ee6a1b6193efa();
+    }
+
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
+    file sealed class OrderIdAsStringAccessor_acfa87ac0bc7f48b : NServiceBus.Sagas.CorrelationPropertyAccessor
+    {
+        OrderIdAsStringAccessor_acfa87ac0bc7f48b() { }
+
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::NullableSagaData)sagaData);
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
+        static extern string AccessFrom_Property(global::NullableSagaData sagaData);
+
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::NullableSagaData)sagaData, ((string)value));
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
+        static extern void WriteTo_Property(global::NullableSagaData sagaData, string value);
+
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_acfa87ac0bc7f48b();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.PrimaryConstructorAndSyntaxWrappers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.PrimaryConstructorAndSyntaxWrappers.approved.txt
@@ -36,7 +36,7 @@ namespace NServiceBus
                         NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                             StartPartitionSagaCommandCorrelationIdAccessor_64596642731407e6.Instance,
                         ];
-                        var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.PartitionedEndpointSaga, global::Orders.Shipping.PartitionedEndpointSagaData>(associatedMessages, CorrelationIdAsStringAccessor_566e8fad769818c2.Instance, propertyAccessors);
+                        var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.PartitionedEndpointSaga, global::Orders.Shipping.PartitionedEndpointSagaData>(associatedMessages, CorrelationIdAsStringAccessor_90ab90feac5d44a9.Instance, propertyAccessors);
                         sagaMetadataCollection.Add(metadata);
 
                         var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -66,21 +66,21 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class CorrelationIdAsStringAccessor_566e8fad769818c2 : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class CorrelationIdAsStringAccessor_90ab90feac5d44a9 : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        CorrelationIdAsStringAccessor_566e8fad769818c2() { }
+        CorrelationIdAsStringAccessor_90ab90feac5d44a9() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.Shipping.PartitionedEndpointSagaData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_CorrelationId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::Orders.Shipping.PartitionedEndpointSagaData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.Shipping.PartitionedEndpointSagaData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_CorrelationId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::Orders.Shipping.PartitionedEndpointSagaData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new CorrelationIdAsStringAccessor_566e8fad769818c2();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new CorrelationIdAsStringAccessor_90ab90feac5d44a9();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.RegistrationMethodNamePatterns.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.RegistrationMethodNamePatterns.approved.txt
@@ -37,7 +37,7 @@ namespace CustomRegistrations
                         OrderBilledOrderIdAccessor_6b40737e550b4237.Instance,
                         OrderPlacedOrderIdAccessor_92819afdda929c86.Instance,
                     ];
-                    var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.OrderShippingPolicy, global::Orders.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                    var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.OrderShippingPolicy, global::Orders.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_828f31182d7d1121.Instance, propertyAccessors);
                     sagaMetadataCollection.Add(metadata);
 
                     var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -84,21 +84,21 @@ namespace CustomRegistrations
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_828f31182d7d1121 : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_828f31182d7d1121() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::Orders.OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::Orders.OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_828f31182d7d1121();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.RootClassEntryPointName.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.RootClassEntryPointName.approved.txt
@@ -37,7 +37,7 @@ namespace CustomRegistrations
                         OrderBilledOrderIdAccessor_6b40737e550b4237.Instance,
                         OrderPlacedOrderIdAccessor_92819afdda929c86.Instance,
                     ];
-                    var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.OrderShippingPolicy, global::Orders.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                    var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.OrderShippingPolicy, global::Orders.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_828f31182d7d1121.Instance, propertyAccessors);
                     sagaMetadataCollection.Add(metadata);
 
                     var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -84,21 +84,21 @@ namespace CustomRegistrations
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_828f31182d7d1121 : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_828f31182d7d1121() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::Orders.OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::Orders.OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_828f31182d7d1121();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.RootClassVisibilityAndNamespace.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.RootClassVisibilityAndNamespace.approved.txt
@@ -37,7 +37,7 @@ namespace CustomRegistrations
                         OrderBilledOrderIdAccessor_6b40737e550b4237.Instance,
                         OrderPlacedOrderIdAccessor_92819afdda929c86.Instance,
                     ];
-                    var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.OrderShippingPolicy, global::Orders.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                    var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.OrderShippingPolicy, global::Orders.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_828f31182d7d1121.Instance, propertyAccessors);
                     sagaMetadataCollection.Add(metadata);
 
                     var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -84,21 +84,21 @@ namespace CustomRegistrations
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_828f31182d7d1121 : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_828f31182d7d1121() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::Orders.OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::Orders.OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_828f31182d7d1121();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.UnrelatedCompilationError.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.UnrelatedCompilationError.approved.txt
@@ -40,7 +40,7 @@ namespace NServiceBus
                         NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                             OrderPlacedOrderIdAccessor_13dea9c2dc628538.Instance,
                         ];
-                        var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.OrderShippingPolicy, global::Orders.Shipping.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                        var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.OrderShippingPolicy, global::Orders.Shipping.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_1073497622a938fb.Instance, propertyAccessors);
                         sagaMetadataCollection.Add(metadata);
 
                         var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -70,21 +70,21 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_1073497622a938fb : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_1073497622a938fb() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.Shipping.OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::Orders.Shipping.OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.Shipping.OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::Orders.Shipping.OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_1073497622a938fb();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.UnrelatedCompilationErrorInDifferentFile.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaGeneratorTests.UnrelatedCompilationErrorInDifferentFile.approved.txt
@@ -35,7 +35,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(_configuration);
@@ -63,21 +63,21 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.BasicSagas.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.BasicSagas.approved.txt
@@ -43,7 +43,7 @@ namespace NServiceBus
                     OrderBilledOrderIdAccessor_f7dc3394c771851e.Instance,
                     OrderPlacedOrderIdAccessor_ae6ad694572b9fcb.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Billing.OrderBillingPolicy, global::Orders.Billing.OrderBillingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Billing.OrderBillingPolicy, global::Orders.Billing.OrderBillingPolicyData>(associatedMessages, OrderIdAsStringAccessor_5b84242b5a03d625.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -70,7 +70,7 @@ namespace NServiceBus
                     OrderBilledOrderIdAccessor_08b7b00354e1d041.Instance,
                     OrderPlacedOrderIdAccessor_13dea9c2dc628538.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.OrderShippingPolicy, global::Orders.Shipping.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.OrderShippingPolicy, global::Orders.Shipping.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_1073497622a938fb.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -98,7 +98,7 @@ namespace NServiceBus
                     OrderBilledOrderIdAccessor_2fd27f5436ef20b9.Instance,
                     OrderPlacedOrderIdAccessor_c561311f0fcc5cf0.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Payments.PaymentsPolicy, global::Payments.PaymentsPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Payments.PaymentsPolicy, global::Payments.PaymentsPolicyData>(associatedMessages, OrderIdAsStringAccessor_6d931b1825e0c4ca.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -198,20 +198,58 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_5b84242b5a03d625 : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_5b84242b5a03d625() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.Billing.OrderBillingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::Orders.Billing.OrderBillingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.Billing.OrderBillingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::Orders.Billing.OrderBillingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_5b84242b5a03d625();
+    }
+
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
+    file sealed class OrderIdAsStringAccessor_1073497622a938fb : NServiceBus.Sagas.CorrelationPropertyAccessor
+    {
+        OrderIdAsStringAccessor_1073497622a938fb() { }
+
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.Shipping.OrderShippingPolicyData)sagaData);
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
+        static extern string AccessFrom_Property(global::Orders.Shipping.OrderShippingPolicyData sagaData);
+
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.Shipping.OrderShippingPolicyData)sagaData, ((string)value));
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
+        static extern void WriteTo_Property(global::Orders.Shipping.OrderShippingPolicyData sagaData, string value);
+
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_1073497622a938fb();
+    }
+
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
+    file sealed class OrderIdAsStringAccessor_6d931b1825e0c4ca : NServiceBus.Sagas.CorrelationPropertyAccessor
+    {
+        OrderIdAsStringAccessor_6d931b1825e0c4ca() { }
+
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Payments.PaymentsPolicyData)sagaData);
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
+        static extern string AccessFrom_Property(global::Payments.PaymentsPolicyData sagaData);
+
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Payments.PaymentsPolicyData)sagaData, ((string)value));
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
+        static extern void WriteTo_Property(global::Payments.PaymentsPolicyData sagaData, string value);
+
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_6d931b1825e0c4ca();
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.CastSyntaxWrappers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.CastSyntaxWrappers.approved.txt
@@ -41,7 +41,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -69,20 +69,20 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.DuplicatePropertyDefinitionsWithCompilationErrors.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.DuplicatePropertyDefinitionsWithCompilationErrors.approved.txt
@@ -45,7 +45,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -73,20 +73,20 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.ExpressionBodiedConfigureHowToFindSaga.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.ExpressionBodiedConfigureHowToFindSaga.approved.txt
@@ -41,7 +41,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -69,20 +69,20 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.InheritedMessageProperty.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.InheritedMessageProperty.approved.txt
@@ -43,7 +43,7 @@ namespace NServiceBus
                     OrderBilledOrderIdAccessor_b1eaacebc632acfc.Instance,
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -87,20 +87,20 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.InvalidMappingWithCompilationErrors.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.InvalidMappingWithCompilationErrors.approved.txt
@@ -46,7 +46,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -76,20 +76,20 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.NestedSagas.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.NestedSagas.approved.txt
@@ -44,7 +44,7 @@ namespace NServiceBus
                     OrderBilledOrderIdAccessor_b1eaacebc632acfc.Instance,
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicy, global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicy, global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_f53ba98a08e6a113.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -71,7 +71,7 @@ namespace NServiceBus
                     OrderBilledOrderIdAccessor_b1eaacebc632acfc.Instance,
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.OuterClass.OrderShippingPolicy, global::Orders.Shipping.OuterClass.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::Orders.Shipping.OuterClass.OrderShippingPolicy, global::Orders.Shipping.OuterClass.OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_14af697526a7e650.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -115,20 +115,39 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_f53ba98a08e6a113 : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_f53ba98a08e6a113() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::Orders.Shipping.AnotherOuterClass.InnerClass.OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_f53ba98a08e6a113();
+    }
+
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
+    file sealed class OrderIdAsStringAccessor_14af697526a7e650 : NServiceBus.Sagas.CorrelationPropertyAccessor
+    {
+        OrderIdAsStringAccessor_14af697526a7e650() { }
+
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::Orders.Shipping.OuterClass.OrderShippingPolicyData)sagaData);
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
+        static extern string AccessFrom_Property(global::Orders.Shipping.OuterClass.OrderShippingPolicyData sagaData);
+
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::Orders.Shipping.OuterClass.OrderShippingPolicyData)sagaData, ((string)value));
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
+        static extern void WriteTo_Property(global::Orders.Shipping.OuterClass.OrderShippingPolicyData sagaData, string value);
+
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_14af697526a7e650();
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.NullableReferenceTypeMappings.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.NullableReferenceTypeMappings.approved.txt
@@ -41,7 +41,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -69,20 +69,20 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.NullableReferenceTypeMixedMappings.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.NullableReferenceTypeMixedMappings.approved.txt
@@ -41,7 +41,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     NullableMessageOrderIdAccessor_9894122651576960.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::NonNullableSaga, global::NonNullableSagaData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::NonNullableSaga, global::NonNullableSagaData>(associatedMessages, OrderIdAsStringAccessor_5e4ee6a1b6193efa.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -64,7 +64,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     NonNullableMessageOrderIdAccessor_e023774f080a36b1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::NullableSaga, global::NullableSagaData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::NullableSaga, global::NullableSagaData>(associatedMessages, OrderIdAsStringAccessor_acfa87ac0bc7f48b.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -106,20 +106,39 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_5e4ee6a1b6193efa : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_5e4ee6a1b6193efa() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::NonNullableSagaData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::NonNullableSagaData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::NonNullableSagaData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::NonNullableSagaData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_5e4ee6a1b6193efa();
+    }
+
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
+    file sealed class OrderIdAsStringAccessor_acfa87ac0bc7f48b : NServiceBus.Sagas.CorrelationPropertyAccessor
+    {
+        OrderIdAsStringAccessor_acfa87ac0bc7f48b() { }
+
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::NullableSagaData)sagaData);
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
+        static extern string AccessFrom_Property(global::NullableSagaData sagaData);
+
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::NullableSagaData)sagaData, ((string)value));
+
+        [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
+        static extern void WriteTo_Property(global::NullableSagaData sagaData, string value);
+
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_acfa87ac0bc7f48b();
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.PrimaryConstructorAndSyntaxWrappers.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.PrimaryConstructorAndSyntaxWrappers.approved.txt
@@ -41,7 +41,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     StartPartitionSagaCommandCorrelationIdAccessor_82483382109e24ab.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::PartitionedEndpointSaga, global::PartitionedEndpointSagaData>(associatedMessages, CorrelationIdAsStringAccessor_566e8fad769818c2.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::PartitionedEndpointSaga, global::PartitionedEndpointSagaData>(associatedMessages, CorrelationIdAsStringAccessor_14cc7db5f4370166.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -69,20 +69,20 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class CorrelationIdAsStringAccessor_566e8fad769818c2 : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class CorrelationIdAsStringAccessor_14cc7db5f4370166 : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        CorrelationIdAsStringAccessor_566e8fad769818c2() { }
+        CorrelationIdAsStringAccessor_14cc7db5f4370166() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::PartitionedEndpointSagaData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_CorrelationId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::PartitionedEndpointSagaData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::PartitionedEndpointSagaData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_CorrelationId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::PartitionedEndpointSagaData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new CorrelationIdAsStringAccessor_566e8fad769818c2();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new CorrelationIdAsStringAccessor_14cc7db5f4370166();
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.UnrelatedCompilationError.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.UnrelatedCompilationError.approved.txt
@@ -44,7 +44,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -72,20 +72,20 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.UnrelatedCompilationErrorInDifferentFile.approved.txt
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/ApprovalFiles/AddSagaInterceptorTests.UnrelatedCompilationErrorInDifferentFile.approved.txt
@@ -44,7 +44,7 @@ namespace NServiceBus
                 NServiceBus.Sagas.MessagePropertyAccessor[] propertyAccessors = [
                     OrderPlacedOrderIdAccessor_5f69124e5a7de2e1.Instance,
                 ];
-                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_4a76700cf8410b3a.Instance, propertyAccessors);
+                var metadata = NServiceBus.Sagas.SagaMetadata.Create<global::OrderShippingPolicy, global::OrderShippingPolicyData>(associatedMessages, OrderIdAsStringAccessor_912ea78b27a6e1ec.Instance, propertyAccessors);
                 sagaMetadataCollection.Add(metadata);
 
                 var settings = NServiceBus.Configuration.AdvancedExtensibility.AdvancedExtensibilityExtensions.GetSettings(endpointConfiguration);
@@ -72,20 +72,20 @@ namespace NServiceBus
 
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("NService.Core.Analyzer.Tests", "1.0.0")]
-    file sealed class OrderIdAsStringAccessor_4a76700cf8410b3a : NServiceBus.Sagas.CorrelationPropertyAccessor
+    file sealed class OrderIdAsStringAccessor_912ea78b27a6e1ec : NServiceBus.Sagas.CorrelationPropertyAccessor
     {
-        OrderIdAsStringAccessor_4a76700cf8410b3a() { }
+        OrderIdAsStringAccessor_912ea78b27a6e1ec() { }
 
-        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);
+        public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property((global::OrderShippingPolicyData)sagaData);
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_OrderId")]
-        static extern string AccessFrom_Property(NServiceBus.IContainSagaData sagaData);
+        static extern string AccessFrom_Property(global::OrderShippingPolicyData sagaData);
 
-        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, ((string)value));
+        public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property((global::OrderShippingPolicyData)sagaData, ((string)value));
 
         [global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "set_OrderId")]
-        static extern string WriteTo_Property(NServiceBus.IContainSagaData sagaData, string value);
+        static extern void WriteTo_Property(global::OrderShippingPolicyData sagaData, string value);
 
-        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_4a76700cf8410b3a();
+        public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new OrderIdAsStringAccessor_912ea78b27a6e1ec();
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Sagas/GeneratedCorrelationAccessorExecutionTests.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Roslyn5/Sagas/GeneratedCorrelationAccessorExecutionTests.cs
@@ -1,0 +1,136 @@
+namespace NServiceBus.Core.Analyzer.Tests.Sagas;
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Analyzer;
+using Analyzer.Sagas;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using NServiceBus.Sagas;
+using NUnit.Framework;
+
+[TestFixture]
+public class GeneratedCorrelationAccessorExecutionTests
+{
+    [Test]
+    public void Generated_correlation_accessors_round_trip_for_colliding_saga_data_properties()
+    {
+        var source = """
+                     using System.Threading.Tasks;
+                     using NServiceBus;
+
+                     public class Test
+                     {
+                         public void Configure(EndpointConfiguration cfg)
+                         {
+                             cfg.Handlers.CollidingAccessorsAssembly.AddAll();
+                         }
+                     }
+
+                     namespace First
+                     {
+                         [Saga]
+                         public class SagaA : Saga<SagaAData>, IAmStartedByMessages<StartMessageA>
+                         {
+                             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaAData> mapper) =>
+                                 mapper.MapSaga(s => s.CorrelationId).ToMessage<StartMessageA>(m => m.CorrelationId);
+
+                             public Task Handle(StartMessageA message, IMessageHandlerContext context) => Task.CompletedTask;
+                         }
+
+                         public class SagaAData : ContainSagaData
+                         {
+                             public string CorrelationId { get; set; }
+                         }
+
+                         public class StartMessageA : ICommand
+                         {
+                             public string CorrelationId { get; set; }
+                         }
+                     }
+
+                     namespace Second
+                     {
+                         [Saga]
+                         public class SagaB : Saga<SagaBData>, IAmStartedByMessages<StartMessageB>
+                         {
+                             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaBData> mapper) =>
+                                 mapper.MapSaga(s => s.CorrelationId).ToMessage<StartMessageB>(m => m.CorrelationId);
+
+                             public Task Handle(StartMessageB message, IMessageHandlerContext context) => Task.CompletedTask;
+                         }
+
+                         public class SagaBData : ContainSagaData
+                         {
+                             public string CorrelationId { get; set; }
+                         }
+
+                         public class StartMessageB : ICommand
+                         {
+                             public string CorrelationId { get; set; }
+                         }
+                     }
+                     """;
+
+        var assembly = CompileAndLoad(source);
+
+        // Two saga-data classes with a colliding property name/type must not share one generated accessor.
+        var accessorTypes = assembly.GetTypes()
+            .Where(t => typeof(CorrelationPropertyAccessor).IsAssignableFrom(t) && !t.IsAbstract)
+            .ToArray();
+
+        Assert.That(accessorTypes, Has.Length.EqualTo(2), "Each saga-data class must get its own generated correlation accessor.");
+
+        foreach (var accessorType in accessorTypes)
+        {
+            var sagaDataType = accessorType
+                .GetMethod("AccessFrom_Property", BindingFlags.Static | BindingFlags.NonPublic)!
+                .GetParameters()[0]
+                .ParameterType;
+            var sagaData = (IContainSagaData)Activator.CreateInstance(sagaDataType);
+            var accessor = (CorrelationPropertyAccessor)accessorType.GetField("Instance")!.GetValue(null)!;
+
+            accessor.WriteTo(sagaData, "correlation-value");
+            var value = accessor.AccessFrom(sagaData);
+
+            Assert.That(value, Is.EqualTo("correlation-value"), $"Accessor for {sagaDataType.Name} did not round-trip the correlation value.");
+        }
+    }
+
+    static Assembly CompileAndLoad(string source)
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+        var sourceTree = CSharpSyntaxTree.ParseText(source, parseOptions);
+
+        var compilation = CSharpCompilation.Create(
+            "CollidingAccessors",
+            [sourceTree],
+            ReferenceAssemblyPaths(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+
+        var driver = CSharpGeneratorDriver.Create(
+            [
+                new AddSagaGenerator().AsSourceGenerator(),
+                new AddHandlerAndSagasRegistrationGenerator().AsSourceGenerator()
+            ],
+            parseOptions: parseOptions);
+
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _);
+
+        using var peStream = new MemoryStream();
+        var emitResult = outputCompilation.Emit(peStream);
+
+        var errors = emitResult.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.That(errors, Is.Empty, string.Join(Environment.NewLine, errors.Select(e => e.ToString())));
+
+        return Assembly.Load(peStream.ToArray());
+    }
+
+    static MetadataReference[] ReferenceAssemblyPaths() =>
+        AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !string.IsNullOrWhiteSpace(a.Location))
+            .Select(a => (MetadataReference)MetadataReference.CreateFromFile(a.Location))
+            .ToArray();
+}

--- a/src/NServiceBus.Core.Analyzer/Sagas/Sagas.Emitter.cs
+++ b/src/NServiceBus.Core.Analyzer/Sagas/Sagas.Emitter.cs
@@ -48,7 +48,7 @@ public static partial class Sagas
                 sourceWriter.WriteLine($"{propertyAccessorClassName}.Instance,");
             }
 
-            var correlationPropertyAccessorClassName = CorrelationPropertyAccessorName(details.CorrelationPropertyMapping);
+            var correlationPropertyAccessorClassName = CorrelationPropertyAccessorName(details.SagaDataFullyQualifiedName, details.CorrelationPropertyMapping);
             var correlationPropertyAccessor = $"{correlationPropertyAccessorClassName}.Instance";
 
             sourceWriter.Indentation--;
@@ -131,14 +131,17 @@ public static partial class Sagas
 
         static void EmitCorrelationPropertyAccessors(SourceWriter sourceWriter, ImmutableEquatableArray<SagaSpec> sagas)
         {
-            var uniqueMappings = new Dictionary<(string PropertyType, string PropertyName), CorrelationPropertyMappingSpec>();
+            // Accessors are keyed by the concrete saga-data type plus property identity: two saga-data classes with
+            // the same correlation property name and type must not share an accessor, because the UnsafeAccessor
+            // receiver is the concrete saga-data type.
+            var uniqueMappings = new Dictionary<(string SagaDataType, string PropertyType, string PropertyName), (CorrelationPropertyMappingSpec Mapping, string SagaDataType)>();
             foreach (var saga in sagas)
             {
                 var mapping = saga.CorrelationPropertyMapping;
-                var key = (mapping.PropertyType, mapping.PropertyName);
+                var key = (saga.SagaDataFullyQualifiedName, mapping.PropertyType, mapping.PropertyName);
                 if (!uniqueMappings.ContainsKey(key))
                 {
-                    uniqueMappings.Add(key, mapping);
+                    uniqueMappings.Add(key, (mapping, saga.SagaDataFullyQualifiedName));
                 }
             }
 
@@ -147,19 +150,25 @@ public static partial class Sagas
                 return;
             }
 
-            var allPropertyMappings = new List<CorrelationPropertyMappingSpec>(uniqueMappings.Values);
+            var allPropertyMappings = new List<(CorrelationPropertyMappingSpec Mapping, string SagaDataType)>(uniqueMappings.Values);
             allPropertyMappings.Sort(static (a, b) =>
             {
-                var typeComparison = string.CompareOrdinal(a.PropertyType, b.PropertyType);
-                return typeComparison != 0 ? typeComparison : string.CompareOrdinal(a.PropertyName, b.PropertyName);
+                var sagaTypeComparison = string.CompareOrdinal(a.SagaDataType, b.SagaDataType);
+                if (sagaTypeComparison != 0)
+                {
+                    return sagaTypeComparison;
+                }
+
+                var typeComparison = string.CompareOrdinal(a.Mapping.PropertyType, b.Mapping.PropertyType);
+                return typeComparison != 0 ? typeComparison : string.CompareOrdinal(a.Mapping.PropertyName, b.Mapping.PropertyName);
             });
 
             sourceWriter.WriteLine();
 
             for (var index = 0; index < allPropertyMappings.Count; index++)
             {
-                var mapping = allPropertyMappings[index];
-                var accessorClassName = CorrelationPropertyAccessorName(mapping);
+                var (mapping, sagaDataType) = allPropertyMappings[index];
+                var accessorClassName = CorrelationPropertyAccessorName(sagaDataType, mapping);
                 _ = sourceWriter.WithCompilerGeneratedAttribute()
                     .WithGeneratedCodeAttribute();
                 sourceWriter.WriteLine($"file sealed class {accessorClassName} : NServiceBus.Sagas.CorrelationPropertyAccessor");
@@ -169,15 +178,15 @@ public static partial class Sagas
 
                 sourceWriter.WriteLine($$"""{{accessorClassName}}() { }""");
                 sourceWriter.WriteLine();
-                sourceWriter.WriteLine("public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(sagaData);");
+                sourceWriter.WriteLine($"public override object? AccessFrom(NServiceBus.IContainSagaData sagaData) => AccessFrom_Property(({sagaDataType})sagaData);");
                 sourceWriter.WriteLine();
                 sourceWriter.WriteLine($"[global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = \"get_{mapping.PropertyName}\")]");
-                sourceWriter.WriteLine($"static extern {mapping.PropertyType} AccessFrom_Property(NServiceBus.IContainSagaData sagaData);");
+                sourceWriter.WriteLine($"static extern {mapping.PropertyType} AccessFrom_Property({sagaDataType} sagaData);");
                 sourceWriter.WriteLine();
-                sourceWriter.WriteLine($"public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(sagaData, (({mapping.PropertyType})value));");
+                sourceWriter.WriteLine($"public override void WriteTo(NServiceBus.IContainSagaData sagaData, object value) => WriteTo_Property(({sagaDataType})sagaData, (({mapping.PropertyType})value));");
                 sourceWriter.WriteLine();
                 sourceWriter.WriteLine($"[global::System.Runtime.CompilerServices.UnsafeAccessor(global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = \"set_{mapping.PropertyName}\")]");
-                sourceWriter.WriteLine($"static extern {mapping.PropertyType} WriteTo_Property(NServiceBus.IContainSagaData sagaData, {mapping.PropertyType} value);");
+                sourceWriter.WriteLine($"static extern void WriteTo_Property({sagaDataType} sagaData, {mapping.PropertyType} value);");
                 sourceWriter.WriteLine();
                 sourceWriter.WriteLine($"public static readonly NServiceBus.Sagas.CorrelationPropertyAccessor Instance = new {accessorClassName}();");
                 sourceWriter.Indentation--;
@@ -190,9 +199,9 @@ public static partial class Sagas
             }
         }
 
-        static string CorrelationPropertyAccessorName(CorrelationPropertyMappingSpec mapping)
+        static string CorrelationPropertyAccessorName(string sagaDataType, CorrelationPropertyMappingSpec mapping)
         {
-            var hash = NonCryptographicHash.GetHash(mapping.PropertyType, "_", mapping.PropertyName);
+            var hash = NonCryptographicHash.GetHash(sagaDataType, "_", mapping.PropertyType, "_", mapping.PropertyName);
             return $"{mapping.PropertyName}As{mapping.PropertyTypeMetadataName}Accessor_{hash:x16}";
         }
     }


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus/commit/c55ef0920860d41818f98163e049b9a6c9b355b4 to `release-10.2`.

### Symptoms

Saga correlation lookup compiles and invokes an expression tree at runtime on first use per saga type instead of using the source-generated accessor. The generated accessor is discarded before `SagaMapper` is built, and the generated code also has issues with the receiver type, duplicate property identities, and setter signatures.

### Who's affected

Endpoints that map saga correlation to a saga-data property (`mapper.MapSaga(...).ToMessage(...)`) and build saga metadata from the source generator, which is the default for saga metadata. The generated path must also distinguish saga-data classes that share a correlation property name and type.

### Root cause

`SagaMetadata.Create` accepts the generated accessor but does not pass it to `SagaMapper`, so every saga uses the expression-compiled fallback. The generator declares `UnsafeAccessor` members against `IContainSagaData` instead of the concrete saga-data type, deduplicates accessors by property name and type alone, and emits setters that return the property type instead of `void`.

### Confirmed workarounds

No runtime workaround is needed. Correlation loading continues through the expression-compiled fallback, so sagas function as before.

### Change

Generate accessors for the concrete saga-data type, key them by saga-data type and property identity, and emit `void` setters. Tests cover two saga-data classes with the same correlation property name and type.
