### PR TITLE
Endpoint shutdown throws FileNotFoundException when a rolling log file is deleted concurrently (#7921)

### DIFF
--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
@@ -97,6 +97,108 @@ public class RollingLoggerTests
     }
 
     [Test]
+    public void When_file_is_deleted_underneath_immediately_before_size_lookup()
+    {
+        using var tempPath = new TempPath("RollingLoggerTests");
+        var logger = new RollingLoggerThatDeletesBeforeSizeLookup(tempPath.TempDirectory, maxFileSize: 2)
+        {
+            GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+        logger.WriteLine("Foo");
+
+        // Second write exceeds maxFileSize, so the synchronization enumerates today's file;
+        // the override removes it between enumeration and the metadata read
+        logger.WriteLine("Bar");
+
+        // The name proves the sequence number was reused (vanished file counts as empty)
+        // instead of rolling to a new sequence
+        var file = tempPath.GetSingle();
+        Assert.That(Path.GetFileName(file), Is.EqualTo("nsb_log_2010-10-01_0.txt"));
+    }
+
+    class RollingLoggerThatDeletesBeforeSizeLookup(string targetDirectory, long maxFileSize) :
+        RollingLogger(targetDirectory, maxFileSize: maxFileSize)
+    {
+        protected override long GetFileSizeOrZero(string path)
+        {
+            File.Delete(path);
+            return base.GetFileSizeOrZero(path);
+        }
+    }
+
+    [Test]
+    public void When_size_lookup_fails_with_io_error_sync_is_aborted_and_retried()
+    {
+        using var tempPath = new TempPath("RollingLoggerTests");
+        var logger = new RollingLoggerThatFailsSizeLookup(tempPath.TempDirectory, maxFileSize: 10)
+        {
+            GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+        logger.WriteLine("Foo");
+        logger.WriteLine("Bar");
+        logger.WriteLine("Baz");
+
+        // The metadata read fails with a transient I/O error, which must abort the synchronization
+        // instead of treating the file as empty and reusing it
+        logger.FailSizeLookup = true;
+        logger.WriteLine("Qux");
+        logger.FailSizeLookup = false;
+
+        // The next write retries the synchronization and rolls to a new sequence
+        logger.WriteLine("Foo2");
+
+        var files = tempPath.GetFiles();
+        Assert.That(files, Has.Count.EqualTo(2));
+        Assert.That(Path.GetFileName(files[1]), Is.EqualTo("nsb_log_2010-10-01_1.txt"));
+    }
+
+    [Test]
+    public void When_sync_fails_during_filename_calculation_state_is_not_committed_and_next_write_retries()
+    {
+        using var tempPath = new TempPath("RollingLoggerTests");
+        var logger = new RollingLoggerThatFailsSizeLookup(tempPath.TempDirectory, maxFileSize: 20)
+        {
+            GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+        logger.WriteLine("LongMessage");
+        logger.WriteLine("LongMessage");
+
+        logger.GetDate = () => new DateTimeOffset(2010, 10, 2, 0, 0, 0, TimeSpan.Zero);
+        logger.WriteLine("Baz");
+
+        // The clock moves back to a date that already has an oversized file while the stale current file
+        // remains below the size limit. The metadata read fails, so the synchronization must abort without
+        // committing the new date; otherwise the next write would stay on the stale file and not retry.
+        logger.GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero);
+        logger.FailSizeLookup = true;
+        logger.WriteLine("Qux");
+        logger.FailSizeLookup = false;
+
+        // The next write retries the synchronization and rolls the oversized day one file
+        logger.WriteLine("Foo2");
+
+        var files = tempPath.GetFiles();
+        Assert.That(files, Has.Count.EqualTo(3));
+        Assert.That(Path.GetFileName(files[1]), Is.EqualTo("nsb_log_2010-10-01_1.txt"));
+    }
+
+    class RollingLoggerThatFailsSizeLookup(string targetDirectory, long maxFileSize) :
+        RollingLogger(targetDirectory, maxFileSize: maxFileSize)
+    {
+        public bool FailSizeLookup { get; set; }
+
+        protected override long GetFileSizeOrZero(string path)
+        {
+            if (FailSizeLookup)
+            {
+                // An overlong path component makes the metadata read throw a PathTooLongException
+                return base.GetFileSizeOrZero(Path.Combine(Path.GetDirectoryName(path)!, new string('x', 300)));
+            }
+            return base.GetFileSizeOrZero(path);
+        }
+    }
+
+    [Test]
     public void When_file_already_exists_and_is_too_large_a_new_sequence_file_is_written()
     {
         using var tempPath = new TempPath("RollingLoggerTests");
@@ -395,5 +497,30 @@ public class RollingLoggerTests
         logger.WriteLine("Foo");
         var singleFile = tempPath.GetSingle();
         Assert.That(Path.GetFileName(singleFile), Is.EqualTo("nsb_log_2010-10-01_0.txt"));
+    }
+
+    [Test]
+    public void When_log_directory_is_deleted_underneath_write_does_not_throw_and_recovers()
+    {
+        using var tempPath = new TempPath("RollingLoggerTests");
+        var logger = new RollingLogger(tempPath.TempDirectory)
+        {
+            GetDate = () => new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+        logger.WriteLine("Foo");
+
+        Directory.Delete(tempPath.TempDirectory, true);
+        logger.GetDate = () => new DateTimeOffset(2010, 10, 2, 0, 0, 0, TimeSpan.Zero);
+
+        // Simulates e.g. a deployment or slot swap removing the whole log directory: the synchronization
+        // and the write must degrade to tracing instead of throwing out of WriteLine
+        Assert.That(() => logger.WriteLine("Bar"), Throws.Nothing);
+
+        Directory.CreateDirectory(tempPath.TempDirectory);
+        logger.WriteLine("Baz");
+
+        // GetSingle also verifies the day one file is not resurrected after the directory came back
+        var singleFile = tempPath.GetSingle();
+        Assert.That(Path.GetFileName(singleFile), Is.EqualTo("nsb_log_2010-10-02_0.txt"));
     }
 }

--- a/src/NServiceBus.Core/Logging/RollingLogger.cs
+++ b/src/NServiceBus.Core/Logging/RollingLogger.cs
@@ -44,15 +44,27 @@ class RollingLogger(
 
     void SyncFileSystem()
     {
-        if (!HasCurrentDateChanged() && !IsCurrentFileTooLarge())
+        try
         {
-            return;
+            if (!HasCurrentDateChanged() && !IsCurrentFileTooLarge())
+            {
+                return;
+            }
+            var today = GetDate();
+            var nsbLogFiles = GetNsbLogFiles(targetDirectory).ToList();
+            CalculateNewFileName(nsbLogFiles, today);
+            lastWriteDate = today;
+            PurgeOldFiles(nsbLogFiles);
         }
-        var today = GetDate();
-        lastWriteDate = today;
-        var nsbLogFiles = GetNsbLogFiles(targetDirectory).ToList();
-        CalculateNewFileName(nsbLogFiles, today);
-        PurgeOldFiles(nsbLogFiles);
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // Tolerate environmental file system failures like the log directory or its files being removed
+            // by overlapping processes, deployments, slot swaps or cleanups. Anything else is a bug and propagates.
+            // The synchronization state is only committed once the filename calculation succeeded so a failed
+            // attempt is retried on the next write.
+            var errorMessage = $"NServiceBus.RollingLogger Could not synchronize log files in directory '{targetDirectory}'. Exception: {exception}";
+            Trace.WriteLine(errorMessage);
+        }
     }
 
     bool HasCurrentDateChanged() => GetDate() != lastWriteDate;
@@ -126,6 +138,23 @@ class RollingLogger(
 
     static bool TryParseDate(string datePart, out DateTimeOffset dateTime) => DateTimeOffset.TryParseExact(datePart, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out dateTime);
 
+    protected virtual long GetFileSizeOrZero(string path)
+    {
+        try
+        {
+            return new FileInfo(path).Length;
+        }
+        catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)
+        {
+            // The file can vanish between enumerating it and reading its metadata, e.g. removed by
+            // overlapping processes, deployments or external cleanup. Treat it as empty so the
+            // sequence number is reused and the file is recreated by the next append. Any other
+            // failure, like a transient I/O error or an ACL that denies metadata reads, aborts the
+            // synchronization instead of resetting the tracked size and reusing the oversized file.
+            return 0;
+        }
+    }
+
     void CalculateNewFileName(List<LogFile> logFiles, DateTimeOffset today)
     {
         var logFile = GetTodaysNewest(logFiles, today);
@@ -137,7 +166,7 @@ class RollingLogger(
         }
         else
         {
-            var existingFileSize = new FileInfo(logFile.Path).Length;
+            var existingFileSize = GetFileSizeOrZero(logFile.Path);
             if (existingFileSize > maxFileSize)
             {
                 sequenceNumber = logFile.SequenceNumber + 1;


### PR DESCRIPTION
Backport of #7921 to `release-10.2`. Addresses the crash reported in #7919.

### Symptoms

On shutdown or an App Service recycle, host disposal can fail with a `FileNotFoundException` from `RollingLogger` when a rolling log file is deleted concurrently. The exception escapes the `Microsoft.Extensions.Logging` pipeline, so the endpoint does not stop cleanly.

### Who's affected

NServiceBus v10 endpoints that log during disposal through a static `LogManager` logger, such as `BlobStorageClaimCheck`, on hosts where rolling log files can change or be deleted underneath the process. This includes Azure App Service recycles, deployments, slot swaps, and external cleanup of `nsb_log_*.txt` files.

### Root cause

`RollingLogger` enumerates rolling files and then reads the newest file's size without confirming it still exists. If another process deletes the file between those operations, `FileInfo.Length` throws and the exception escapes `SyncFileSystem()`. Disposal-time writes can hit the fallback rolling logger because they occur outside the endpoint logging slot.

### Confirmed workarounds

Both options route logging through the application's Microsoft logging providers instead of NServiceBus's rolling defaults:

- Register a real `ILoggerProvider` in the endpoint container, for example with `services.AddLogging` and the Application Insights provider. Telemetry registration alone is not sufficient.
- Bridge NServiceBus logging with `LogManager.UseFactory` and the Extensions.Logging bridge.
