### PR TITLE
Add `UseExistingTraceOnReceive` support to trace mode handling

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_messages.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry.Traces;
+namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry.Traces;
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -231,6 +231,56 @@ public class When_sending_messages : OpenTelemetryAcceptanceTest
     {
         public TestEndpointWithSpanLinkConnector() =>
             EndpointSetup<DefaultServer>(b => b.Tracing().SendTraceMode = TraceMode.StartNew);
+
+        [Handler]
+        public class MessageHandler(Context testContext) : IHandleMessages<OutgoingMessage>
+        {
+            public Task Handle(OutgoingMessage message, IMessageHandlerContext context)
+            {
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    [Test]
+    public async Task Should_link_to_send_span_without_continuing_its_trace_when_endpoint_defaults_to_use_existing()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<TestEndpointWithUseExistingConnector>(b => b
+                .When(s => s.SendLocal(new OutgoingMessage())))
+            .Run();
+
+        var sendMessageActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
+        var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(sendMessageActivities, Has.Count.EqualTo(1), "1 message is sent as part of this test");
+            Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
+        }
+
+        var sendRequest = sendMessageActivities[0];
+        var receiveRequest = receiveMessageActivities[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receiveRequest.TraceId, Is.Not.EqualTo(sendRequest.TraceId), "receive does not continue the trace carried in the message headers");
+            Assert.That(receiveRequest.ParentSpanId, Is.Not.EqualTo(sendRequest.SpanId), "receive is not a child of the send span");
+        }
+
+        ActivityLink link = receiveRequest.Links.FirstOrDefault();
+        Assert.That(link, Is.Not.EqualTo(default(ActivityLink)), "Receive has a link");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(link.Context.TraceId, Is.EqualTo(sendRequest.TraceId), "receive is linked to the send trace");
+            Assert.That(link.Context.SpanId, Is.EqualTo(sendRequest.SpanId), "receive is linked to the send span");
+        }
+    }
+
+    public class TestEndpointWithUseExistingConnector : EndpointConfigurationBuilder
+    {
+        public TestEndpointWithUseExistingConnector() =>
+            EndpointSetup<DefaultServer>(b => b.Tracing().SendTraceMode = TraceMode.UseExisting);
 
         [Handler]
         public class MessageHandler(Context testContext) : IHandleMessages<OutgoingMessage>

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -810,6 +810,8 @@ namespace NServiceBus
         public static void StartNewTraceOnReceive(this NServiceBus.PublishOptions publishOptions) { }
         public static void StartNewTraceOnReceive(this NServiceBus.SendOptions sendOptions) { }
         public static NServiceBus.InstrumentationOptions Tracing(this NServiceBus.EndpointConfiguration config) { }
+        public static void UseExistingTraceOnReceive(this NServiceBus.PublishOptions publishOptions) { }
+        public static void UseExistingTraceOnReceive(this NServiceBus.SendOptions sendOptions) { }
     }
     public static class OutboxConfigExtensions
     {
@@ -1214,6 +1216,7 @@ namespace NServiceBus
     {
         ContinueExisting = 0,
         StartNew = 1,
+        UseExisting = 2,
     }
     public static class TransportConfig
     {

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityFactoryTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 namespace NServiceBus.Core.Tests.OpenTelemetry;
 
@@ -198,6 +198,57 @@ public class ActivityFactoryTests
             var activity = activityFactory.StartIncomingPipelineActivity(messageContext);
 
             Assert.That(activity!.Tags.ToImmutableDictionary()["nservicebus.native_message_id"], Is.EqualTo(messageContext.NativeMessageId));
+        }
+
+        [Test]
+        public void Should_attach_to_ambient_activity_and_link_to_send_span_when_use_existing_trace_header()
+        {
+            using var sendActivity = CreateCompletedActivity("send activity");
+            using var ambientActivity = new Activity("ambient activity");
+            ambientActivity.SetIdFormat(ActivityIdFormat.W3C);
+            ambientActivity.Start();
+
+            var messageHeaders = new Dictionary<string, string>
+            {
+                { Headers.DiagnosticsTraceParent, sendActivity.Id! },
+                { Headers.StartNewTrace, "UseExisting" }
+            };
+
+            var activity = activityFactory.StartIncomingPipelineActivity(CreateMessageContext(messageHeaders));
+
+            Assert.That(activity, Is.Not.Null, "should create activity for receive pipeline");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(activity.ParentId, Is.EqualTo(ambientActivity.Id), "should attach to the ambient activity instead of the send span");
+                Assert.That(activity.TraceId, Is.EqualTo(ambientActivity.TraceId), "should stay in the ambient trace");
+                Assert.That(activity.Links.Count(), Is.EqualTo(1), "should link to logical send span");
+                Assert.That(activity.Links.Single().Context.TraceId, Is.EqualTo(sendActivity.TraceId));
+                Assert.That(activity.Links.Single().Context.SpanId, Is.EqualTo(sendActivity.SpanId));
+            }
+        }
+
+        [Test]
+        public void Should_start_new_linked_trace_when_use_existing_trace_header_and_no_ambient_activity()
+        {
+            using var sendActivity = CreateCompletedActivity("send activity");
+            Assert.That(Activity.Current, Is.Null, "test requires no ambient activity");
+
+            var messageHeaders = new Dictionary<string, string>
+            {
+                { Headers.DiagnosticsTraceParent, sendActivity.Id! },
+                { Headers.StartNewTrace, "UseExisting" }
+            };
+
+            var activity = activityFactory.StartIncomingPipelineActivity(CreateMessageContext(messageHeaders));
+
+            Assert.That(activity, Is.Not.Null, "should create activity for receive pipeline");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(activity.ParentId, Is.Null, "should start a new trace when there is no ambient activity");
+                Assert.That(activity.TraceId, Is.Not.EqualTo(sendActivity.TraceId), "should not continue the send trace");
+                Assert.That(activity.Links.Count(), Is.EqualTo(1), "should link to logical send span");
+                Assert.That(activity.Links.Single().Context.SpanId, Is.EqualTo(sendActivity.SpanId));
+            }
         }
 
         static Activity CreateCompletedActivity(string activityName, ActivityIdFormat idFormat = ActivityIdFormat.W3C)

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryExtensionsTests.cs
@@ -30,6 +30,28 @@ public class OpenTelemetryExtensionsTests
     }
 
     [Test]
+    public void UseExistingTraceOnReceive_should_set_use_existing_override_on_send_options()
+    {
+        var options = new SendOptions();
+
+        options.UseExistingTraceOnReceive();
+
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceMode.UseExisting));
+    }
+
+    [Test]
+    public void UseExistingTraceOnReceive_should_set_use_existing_override_on_publish_options()
+    {
+        var options = new PublishOptions();
+
+        options.UseExistingTraceOnReceive();
+
+        Assert.That(options.Context.TryGet(OpenTelemetryExtensions.TraceConnectorOverrideKey, out TraceMode connector), Is.True);
+        Assert.That(connector, Is.EqualTo(TraceMode.UseExisting));
+    }
+
+    [Test]
     public void StartNewTraceOnReceive_should_set_span_link_override_on_publish_options()
     {
         var options = new PublishOptions();

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryPublishBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetryPublishBehaviorTests.cs
@@ -30,6 +30,29 @@ public class OpenTelemetryPublishBehaviorTests
     }
 
     [Test]
+    public async Task Should_use_existing_trace_on_receive_when_endpoint_trace_mode_is_use_existing()
+    {
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishTraceMode = TraceMode.UseExisting });
+        var context = new TestableOutgoingPublishContext();
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo("UseExisting"));
+    }
+
+    [Test]
+    public async Task Should_prefer_use_existing_option_over_endpoint_connector()
+    {
+        var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishTraceMode = TraceMode.StartNew });
+        var context = new TestableOutgoingPublishContext();
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceMode.UseExisting);
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo("UseExisting"));
+    }
+
+    [Test]
     public async Task Should_prefer_child_span_option_over_endpoint_connector()
     {
         var behavior = new OpenTelemetryPublishBehavior(new InstrumentationOptions { PublishTraceMode = TraceMode.StartNew });

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetrySendBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/OpenTelemetrySendBehaviorTests.cs
@@ -1,8 +1,11 @@
 namespace NServiceBus.Core.Tests.OpenTelemetry;
 
+using System;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Testing;
+using DelayedDelivery;
+using Transport;
 
 [TestFixture]
 public class OpenTelemetrySendBehaviorTests
@@ -27,6 +30,58 @@ public class OpenTelemetrySendBehaviorTests
         await behavior.Invoke(context, _ => Task.CompletedTask);
 
         Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public async Task Should_use_existing_trace_on_receive_when_endpoint_trace_mode_is_use_existing()
+    {
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SendTraceMode = TraceMode.UseExisting });
+        var context = new TestableOutgoingSendContext();
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo("UseExisting"));
+    }
+
+    [Test]
+    public async Task Should_prefer_use_existing_option_over_endpoint_connector()
+    {
+        var behavior = new OpenTelemetrySendBehavior(new InstrumentationOptions { SendTraceMode = TraceMode.StartNew });
+        var context = new TestableOutgoingSendContext();
+        context.Extensions.Set(OpenTelemetryExtensions.TraceConnectorOverrideKey, TraceMode.UseExisting);
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo("UseExisting"));
+    }
+
+    [Test]
+    public async Task Should_use_existing_trace_on_receive_for_delayed_message_when_delayed_delivery_trace_mode_is_use_existing()
+    {
+        var options = new InstrumentationOptions();
+        options.DelayedDelivery.SendOperationTraceMode = TraceMode.UseExisting;
+        var behavior = new OpenTelemetrySendBehavior(options);
+        var context = new TestableOutgoingSendContext();
+        context.Extensions.Set(new DispatchProperties { DelayDeliveryWith = new DelayDeliveryWith(TimeSpan.FromSeconds(10)) });
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo("UseExisting"));
+    }
+
+    [Test]
+    public async Task Should_use_existing_trace_on_receive_for_saga_timeout_when_saga_timeout_trace_mode_is_use_existing()
+    {
+        var options = new InstrumentationOptions();
+        options.DelayedDelivery.SagaTimeoutTraceMode = TraceMode.UseExisting;
+        var behavior = new OpenTelemetrySendBehavior(options);
+        var context = new TestableOutgoingSendContext();
+        context.Headers[Headers.IsSagaTimeoutMessage] = bool.TrueString;
+        context.Extensions.Set(new DispatchProperties { DelayDeliveryWith = new DelayDeliveryWith(TimeSpan.FromSeconds(10)) });
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Headers[Headers.StartNewTrace], Is.EqualTo("UseExisting"));
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/PopulateRecoverabilityTraceMetadataBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/PopulateRecoverabilityTraceMetadataBehaviorTests.cs
@@ -100,6 +100,25 @@ public class PopulateRecoverabilityTraceMetadataBehaviorTests
         Assert.That(context.Metadata[Headers.StartNewTrace], Is.EqualTo(bool.FalseString));
     }
 
+    [Test]
+    public async Task Should_use_existing_trace_for_delayed_retry_when_trace_mode_is_use_existing()
+    {
+        var behavior = new PopulateRecoverabilityTraceMetadataBehavior(new InstrumentationOptions
+        {
+            Recoverability = { DelayedRetryTraceMode = TraceMode.UseExisting }
+        });
+
+        var context = new TestableRecoverabilityContext
+        {
+            Headers = { { Headers.DiagnosticsTraceParent, "traceparent" } },
+            RecoverabilityAction = new DelayedRetry(TimeSpan.FromSeconds(10))
+        };
+
+        await behavior.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.That(context.Metadata[Headers.StartNewTrace], Is.EqualTo("UseExisting"));
+    }
+
     static IEnumerable<RecoverabilityAction> ActionsThatWriteMetadata()
     {
         yield return new DelayedRetry(TimeSpan.FromSeconds(10));

--- a/src/NServiceBus.Core/Headers.cs
+++ b/src/NServiceBus.Core/Headers.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus;
+namespace NServiceBus;
 
 /// <summary>
 /// Static class containing headers used by NServiceBus.
@@ -257,8 +257,11 @@ public static partial class Headers
     public const string DataBusConfigContentType = "NServiceBus.DataBusConfig.ContentType"; // NOTE: .DataConfig required for compatibility with the Gateway BLOB matching behavior.
 
     /// <summary>
-    /// This header is set when a new trace should be started when receiving this message.
-    /// This is automatically set when: a saga timeout is requested, a message is set to be delivered at a certain time, a delayed retry is requested or a message is moved to the error queue.
+    /// This header controls how the receiving endpoint relates its processing span to the trace carried in the message headers.
+    /// <c>True</c> starts a new trace linked back to the outgoing span (<see cref="TraceMode.StartNew"/>), <c>False</c> continues the
+    /// trace (<see cref="TraceMode.ContinueExisting"/>), and <c>UseExisting</c> attaches to the ambient activity at receive time
+    /// with a link back to the outgoing span (<see cref="TraceMode.UseExisting"/>).
+    /// The value is derived from <see cref="InstrumentationOptions"/> and the per-message overrides in <see cref="OpenTelemetryExtensions"/>.
     /// </summary>
     public const string StartNewTrace = "NServiceBus.OpenTelemetry.StartNewTrace";
 }

--- a/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/InstrumentationOptions.cs
@@ -27,7 +27,7 @@ public partial class InstrumentationOptions
 
     /// <summary>
     /// Controls instrumentation of explicitly delayed messages (<c>SendOptions.DelayDeliveryWith</c>
-    /// / <c>DoNotDeliverBefore</c> and saga timeouts. 
+    /// / <c>DoNotDeliverBefore</c> and saga timeouts.
     /// Recoverability-driven delayed retries are controlled separately via
     /// <see cref="RecoverabilityInstrumentationOptions.DelayedRetryTraceMode"/>.
     /// </summary>

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryExtensions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryExtensions.cs
@@ -43,6 +43,17 @@ public static class OpenTelemetryExtensions
     }
 
     /// <summary>
+    /// Attach the processing span to the ambient activity on receive of this message (ignoring the trace carried in the headers), linked back to the send span.
+    /// Overrides <see cref="InstrumentationOptions.SendTraceMode"/> for this message.
+    /// </summary>
+    /// <param name="sendOptions">The option being extended.</param>
+    public static void UseExistingTraceOnReceive(this SendOptions sendOptions)
+    {
+        ArgumentNullException.ThrowIfNull(sendOptions);
+        sendOptions.Context.Set(TraceConnectorOverrideKey, TraceMode.UseExisting);
+    }
+
+    /// <summary>
     /// Start a new OpenTelemetry trace on receive of this event, linked back to the publish span.
     /// Overrides <see cref="InstrumentationOptions.PublishTraceMode"/> for this message.
     /// </summary>
@@ -62,6 +73,17 @@ public static class OpenTelemetryExtensions
     {
         ArgumentNullException.ThrowIfNull(publishOptions);
         publishOptions.Context.Set(TraceConnectorOverrideKey, TraceMode.ContinueExisting);
+    }
+
+    /// <summary>
+    /// Attach the processing span to the ambient activity on receive of this event (ignoring the trace carried in the headers), linked back to the publish span.
+    /// Overrides <see cref="InstrumentationOptions.PublishTraceMode"/> for this message.
+    /// </summary>
+    /// <param name="publishOptions">The option being extended.</param>
+    public static void UseExistingTraceOnReceive(this PublishOptions publishOptions)
+    {
+        ArgumentNullException.ThrowIfNull(publishOptions);
+        publishOptions.Context.Set(TraceConnectorOverrideKey, TraceMode.UseExisting);
     }
 
     internal const string TraceConnectorOverrideKey = "NServiceBus.OpenTelemetry.TraceConnectorOverride";

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryPublishBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryPublishBehavior.cs
@@ -15,7 +15,7 @@ class OpenTelemetryPublishBehavior(InstrumentationOptions instrumentationOptions
             ? requestedConnector
             : instrumentationOptions.PublishTraceMode;
 
-        context.Headers[Headers.StartNewTrace] = connector == TraceMode.StartNew ? bool.TrueString : bool.FalseString;
+        context.Headers[Headers.StartNewTrace] = TraceModeHeaderValue.From(connector);
 
         return next(context);
     }

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetrySendBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetrySendBehavior.cs
@@ -16,33 +16,23 @@ class OpenTelemetrySendBehavior(InstrumentationOptions instrumentationOptions) :
             ? requestedConnector
             : instrumentationOptions.SendTraceMode;
 
-        if (operationTraceMode == TraceMode.StartNew)
-        {
-            context.Headers[Headers.StartNewTrace] = bool.TrueString;
-        }
-        else
+        if (operationTraceMode != TraceMode.StartNew)
         {
             // This is needed to ensure the trace continuation behavior is backwards compatible.
-            // If the message is delayed, we always start a new trace unless different behavior is explicitly configured. 
+            // If the message is delayed, we always start a new trace unless different behavior is explicitly configured.
             var isDelayed = context.Extensions.TryGet<DispatchProperties>(out var dispatchProperties) &&
                             (dispatchProperties.DelayDeliveryWith != null || dispatchProperties.DoNotDeliverBefore != null);
 
-            bool startNewTrace;
             if (isDelayed)
             {
                 var isSagaTimeout = context.Headers.ContainsKey(Headers.IsSagaTimeoutMessage);
-                var mode = isSagaTimeout
+                operationTraceMode = isSagaTimeout
                     ? instrumentationOptions.DelayedDelivery.SagaTimeoutTraceMode
                     : instrumentationOptions.DelayedDelivery.SendOperationTraceMode;
-                startNewTrace = mode == TraceMode.StartNew;
             }
-            else
-            {
-                startNewTrace = false;
-            }
-
-            context.Headers[Headers.StartNewTrace] = startNewTrace ? bool.TrueString : bool.FalseString;
         }
+
+        context.Headers[Headers.StartNewTrace] = TraceModeHeaderValue.From(operationTraceMode);
 
         return next(context);
     }

--- a/src/NServiceBus.Core/OpenTelemetry/TraceMode.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/TraceMode.cs
@@ -15,5 +15,12 @@ public enum TraceMode
     /// <summary>
     /// The receiving endpoint starts a new trace: the processing span becomes the root of a new trace with a link back to the outgoing span.
     /// </summary>
-    StartNew
+    StartNew,
+
+    /// <summary>
+    /// The receiving endpoint ignores the trace carried in the message headers: the processing span becomes a child of the ambient
+    /// <c>Activity.Current</c> at receive time (for example a transport or host span), or the root of a new trace when there is none,
+    /// with a link back to the outgoing span.
+    /// </summary>
+    UseExisting,
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 namespace NServiceBus;
 
@@ -24,6 +24,13 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
             return null;
         }
 
+        // TODO: Is this needed??
+
+        // If the native client or transport set a trace with kind consumer, we mark this as internal
+        var activityKind = Activity.Current?.Kind == ActivityKind.Consumer
+            ? ActivityKind.Internal
+            : ActivityKind.Consumer;
+
         Activity? activity;
         var incomingTraceParentExists = headers.TryGetValue(Headers.DiagnosticsTraceParent, out var sendSpanId);
         var activityContextCreatedFromIncomingTraceParent = ActivityContext.TryParse(sendSpanId, null, out var sendSpanContext);
@@ -40,24 +47,35 @@ sealed class ActivityFactory(InstrumentationOptions options) : IActivityFactory
             }
 
             activity = activitySource.CreateActivity(name: activityName,
-                ActivityKind.Consumer, transportActivity.Context, links: links, idFormat: ActivityIdFormat.W3C);
+                activityKind, transportActivity.Context, links: links, idFormat: ActivityIdFormat.W3C);
         }
         else if (incomingTraceParentExists && activityContextCreatedFromIncomingTraceParent) // otherwise directly create child from logical send
         {
-            var isStartNewTraceHeaderAvailable = headers.TryGetValue(Headers.StartNewTrace, out var shouldStartNewTrace);
-            if (isStartNewTraceHeaderAvailable && shouldStartNewTrace?.Equals(bool.TrueString) is true)
+            headers.TryGetValue(Headers.StartNewTrace, out var traceModeHeader);
+            var traceMode = TraceModeHeaderValue.Parse(traceModeHeader);
+
+            if (traceMode == TraceMode.StartNew)
             {
                 // create a new trace or root activity
                 ActivityLink[] links = [new(sendSpanContext)];
                 //null the current activity so that the new one is created as root https://github.com/dotnet/runtime/issues/65528#issuecomment-2613486896
                 Activity.Current = null;
-                activity = activitySource.StartActivity(name: activityName, ActivityKind.Consumer, parentContext: default, tags: null, links: links);
+                activity = activitySource.StartActivity(name: activityName, activityKind, parentContext: default, tags: null, links: links);
+            }
+
+            // TODO: Do we even need a new UseExisting mode? If not, and this is just the new behavior then we need an AppSwitch
+            else if (traceMode == TraceMode.UseExisting && Activity.Current?.Kind == ActivityKind.Consumer)
+            {
+                // ignore the trace carried in the headers: attach to the ambient activity (Activity.Current) when there is one,
+                // otherwise this becomes the root of a new trace. Either way link back to the logical send span.
+                ActivityLink[] links = [new(sendSpanContext)];
+                activity = activitySource.CreateActivity(name: activityName, activityKind, parentContext: default, tags: null, links: links, idFormat: ActivityIdFormat.W3C);
             }
             else
             {
                 // no new trace was requested, so start a child trace
                 ActivityContext.TryParse(sendSpanId, null, true, out var remoteParentActivityContext);
-                activity = activitySource.CreateActivity(name: activityName, ActivityKind.Consumer, remoteParentActivityContext);
+                activity = activitySource.CreateActivity(name: activityName, activityKind, remoteParentActivityContext);
             }
         }
         else // otherwise start a new trace

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/PopulateRecoverabilityTraceMetadataBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/PopulateRecoverabilityTraceMetadataBehavior.cs
@@ -17,9 +17,7 @@ class PopulateRecoverabilityTraceMetadataBehavior(InstrumentationOptions instrum
         {
             // Setting it to the metadata makes sure it is propagated to the headers
             // even in more advanced scenarios like native dead-lettering
-            context.Metadata[Headers.StartNewTrace] = instrumentationOptions.Recoverability.DelayedRetryTraceMode == TraceMode.StartNew
-                ? bool.TrueString
-                : bool.FalseString;
+            context.Metadata[Headers.StartNewTrace] = TraceModeHeaderValue.From(instrumentationOptions.Recoverability.DelayedRetryTraceMode);
         }
         else if (context.RecoverabilityAction is MoveToError)
         {


### PR DESCRIPTION
- Introduced new `TraceMode.UseExisting` to enable attaching to the ambient activity while linking to the previous trace.
- Updated API and behaviors to incorporate `UseExistingTraceOnReceive` logic.
- Enhanced tests and acceptance scenarios to validate the new mode against delayed sends, saga timeouts, and recoverability pipelines.
- Refactored trace mode headers and propagation for better readability and consistency.