### PR TITLE
Report a cancelled token instead of printing the infinite time limit as -0.001s

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -119,7 +119,9 @@ public class ScenarioRunner(
     internal static string GenerateTestTimedOutMessage(TimeSpan maxTime)
     {
         var sb = new StringBuilder();
-        sb.AppendLine($"The maximum time limit for this test({maxTime.TotalSeconds}s) has been reached");
+        sb.AppendLine(maxTime == Timeout.InfiniteTimeSpan
+            ? "The cancellation token passed to the test was cancelled before the test completed"
+            : $"The maximum time limit for this test({maxTime.TotalSeconds}s) has been reached");
         sb.AppendLine("----------------------------------------------------------------------------");
         return sb.ToString();
     }


### PR DESCRIPTION
When `Run` is handed a cancellable token the `Done` limit is `Timeout.InfiniteTimeSpan`, and the timeout message rendered that as `The maximum time limit for this test(-0.001s) has been reached`. It now says the cancellation token was cancelled.