### PR TITLE
Respect [CancelAfter] budgets in the acceptance testing framework

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -21,6 +21,11 @@ public class ScenarioWithContext<TContext>(Action<TContext> initializer) : IScen
 
     public async Task<TContext> Run(RunSettings settings, CancellationToken cancellationToken = default)
     {
+        if (!cancellationToken.CanBeCanceled)
+        {
+            cancellationToken = TestContext.CurrentContext.CancellationToken;
+        }
+
         var scenarioContext = new TContext();
         initializer(scenarioContext);
 
@@ -160,7 +165,7 @@ public class ScenarioWithContext<TContext>(Action<TContext> initializer) : IScen
             }
             catch (OperationCanceledException e) when (combinedDoneTokenSource.Token.IsCancellationRequested)
             {
-                throw new TimeoutException(GenerateTestTimedOutMessage(maxTime), e);
+                throw new TimeoutException(GenerateTestTimedOutMessage(maxTime, cancellationToken), e);
             }
         });
         return this;

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using NServiceBus.Logging;
+using NUnit.Framework.Internal;
 
 public class ScenarioRunner(
     RunDescriptor runDescriptor,
@@ -92,7 +93,7 @@ public class ScenarioRunner(
                 }
                 catch (OperationCanceledException e)
                 {
-                    throw new TimeoutException(GenerateTestTimedOutMessage(maxTime), e);
+                    throw new TimeoutException(GenerateTestTimedOutMessage(maxTime, cancellationToken), e);
                 }
             }
 
@@ -116,12 +117,21 @@ public class ScenarioRunner(
         }
     }
 
-    internal static string GenerateTestTimedOutMessage(TimeSpan maxTime)
+    internal static string GenerateTestTimedOutMessage(TimeSpan maxTime, CancellationToken cancellationToken = default)
     {
         var sb = new StringBuilder();
-        sb.AppendLine(maxTime == Timeout.InfiniteTimeSpan
-            ? "The cancellation token passed to the test was cancelled before the test completed"
-            : $"The maximum time limit for this test({maxTime.TotalSeconds}s) has been reached");
+        if (cancellationToken.CanBeCanceled && cancellationToken.IsCancellationRequested)
+        {
+            var timeoutMs = TestExecutionContext.CurrentContext.TestCaseTimeout;
+            sb.AppendLine(timeoutMs > 0
+                ? $"The scenario did not complete within the test's timeout budget of {timeoutMs} ms"
+                : "The scenario did not complete before the cancellation token was cancelled");
+        }
+        else
+        {
+            sb.AppendLine($"The maximum time limit for this test({maxTime.TotalSeconds}s) has been reached");
+        }
+
         sb.AppendLine("----------------------------------------------------------------------------");
         return sb.ToString();
     }

--- a/src/NServiceBus.AcceptanceTests/Core/ScenarioTimeout/When_an_already_cancelled_token_is_passed_to_run.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/ScenarioTimeout/When_an_already_cancelled_token_is_passed_to_run.cs
@@ -1,0 +1,20 @@
+namespace NServiceBus.AcceptanceTests.Core.ScenarioTimeout;
+
+using System;
+using System.Threading;
+using NServiceBus.AcceptanceTesting;
+using NUnit.Framework;
+
+public class When_an_already_cancelled_token_is_passed_to_run : NServiceBusAcceptanceTest
+{
+    [Test]
+    public void Should_fail_with_a_timeout()
+    {
+        var exception = Assert.ThrowsAsync<TimeoutException>(() => Scenario.Define<Context>()
+            .Run(new CancellationToken(canceled: true)));
+
+        Assert.That(exception.Message, Does.Contain("The scenario did not complete before the cancellation token was cancelled"));
+    }
+
+    public class Context : ScenarioContext;
+}

--- a/src/NServiceBus.AcceptanceTests/Core/ScenarioTimeout/When_scenario_exceeds_the_test_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/ScenarioTimeout/When_scenario_exceeds_the_test_timeout.cs
@@ -1,0 +1,19 @@
+namespace NServiceBus.AcceptanceTests.Core.ScenarioTimeout;
+
+using System;
+using NServiceBus.AcceptanceTesting;
+using NUnit.Framework;
+
+public class When_scenario_exceeds_the_test_timeout : NServiceBusAcceptanceTest
+{
+    [Test, CancelAfter(250)]
+    public void Should_fail_with_the_test_timeout_budget()
+    {
+        var exception = Assert.ThrowsAsync<TimeoutException>(() => Scenario.Define<Context>()
+            .Run());
+
+        Assert.That(exception.Message, Does.Contain("timeout budget of 250 ms"));
+    }
+
+    public class Context : ScenarioContext;
+}

--- a/src/NServiceBus.AcceptanceTests/Core/ScenarioTimeout/When_the_test_cancellation_token_is_passed_to_run.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/ScenarioTimeout/When_the_test_cancellation_token_is_passed_to_run.cs
@@ -1,0 +1,21 @@
+namespace NServiceBus.AcceptanceTests.Core.ScenarioTimeout;
+
+using System;
+using System.Threading;
+using NServiceBus.AcceptanceTesting;
+using NUnit.Framework;
+
+[CancelAfter(5_000)]
+public class When_the_test_cancellation_token_is_passed_to_run : NServiceBusAcceptanceTest
+{
+    [Test, CancelAfter(250)]
+    public void Should_use_the_passed_token(CancellationToken cancellationToken = default)
+    {
+        var exception = Assert.ThrowsAsync<TimeoutException>(() => Scenario.Define<Context>()
+            .Run(cancellationToken));
+
+        Assert.That(exception.Message, Does.Contain("timeout budget of 250 ms"));
+    }
+
+    public class Context : ScenarioContext;
+}


### PR DESCRIPTION
See conversation on:

- https://github.com/Particular/ServiceControl/pull/5871